### PR TITLE
feat(theme): 终端配色跟随 Pier 主题切换

### DIFF
--- a/native/Package.swift
+++ b/native/Package.swift
@@ -22,6 +22,7 @@ let package = Package(
             name: "GhosttyBridge",
             dependencies: [
                 .product(name: "GhosttyTerminal", package: "libghostty-spm"),
+                .product(name: "GhosttyTheme", package: "libghostty-spm"),
             ],
             swiftSettings: [
                 .unsafeFlags(["-Xfrontend", "-enable-objc-interop"]),

--- a/native/Sources/GhosttyBridge/GhosttyBridge.swift
+++ b/native/Sources/GhosttyBridge/GhosttyBridge.swift
@@ -15,6 +15,16 @@
 
 import AppKit
 import GhosttyTerminal
+import GhosttyTheme
+
+// MARK: - Helpers
+
+/// Pier IPC 边界统一传 `#RRGGBB`. GhosttyThemeDefinition 的 background/foreground/
+/// cursorColor/selectionBackground 直接转给 builder, 不带 #; palette[i] 由库内
+/// 拼接 `"#\(value)"`. 这里统一剥前缀, 既符合两类 API.
+private func stripHash(_ s: String) -> String {
+    s.hasPrefix("#") ? String(s.dropFirst()) : s
+}
 
 // MARK: - EventRouterView
 
@@ -522,6 +532,37 @@ final class GhosttyBridgeImpl {
         controllers.removeValue(forKey: windowId)
     }
 
+    // MARK: - Theme apply
+
+    /// 把 Pier 主题派生的终端配色应用到该 window 下的 Ghostty controller. 走库的
+    /// `controller.setTheme(...)` 路径, 内部 reconfigure 并 push 到 ghostty app, shell
+    /// 进程不重启. 一个 controller 服务 window 下所有 terminal panel.
+    ///
+    /// controller(for:) 是 lazy 创建 — 即使 applyTheme 在 createTerminal 之前调
+    /// (主题 hydrate 顺序在前), 也会 cache 主题; 后续 createTerminal 拿到的是已经
+    /// 应用了主题的 controller, terminalView 创建即正确配色.
+    func applyTheme(
+        window: NSWindow,
+        background: String,
+        foreground: String,
+        cursor: String?,
+        selectionBackground: String?,
+        palette: [Int: String]
+    ) {
+        let controller = controller(for: window)
+        let definition = GhosttyThemeDefinition(
+            name: "pier-runtime",
+            background: background,
+            foreground: foreground,
+            cursorColor: cursor,
+            cursorText: nil,
+            selectionBackground: selectionBackground,
+            selectionForeground: nil,
+            palette: palette
+        )
+        controller.setTheme(definition.toTerminalTheme())
+    }
+
     // MARK: - Coordinate conversion
 
     private func computeFrame(in contentView: NSView, viewport: NSRect) -> NSRect {
@@ -663,5 +704,36 @@ public func ghosttyBridgeSetActivePanelKind(
         let kind: GhosttyBridgeImpl.PanelKind = (kindRaw == 0) ? .terminal : .web
         let panelId: String? = panelIdPtr.flatMap { String(cString: $0) }
         GhosttyBridgeImpl.shared.setActivePanelKind(window: window, kind: kind, panelId: panelId)
+    }
+}
+
+/// palette 必须长度 16, 且每槽非空 (Pier renderer derive 阶段保证). cursor /
+/// selectionBackground 可空. 调用同步处理: addon.mm 的 std::string 在本调用栈
+/// 内保持, swift 这里立即 String(cString:) 拷贝, 拷贝完所有指针即可失效.
+@_cdecl("ghostty_bridge_apply_theme")
+public func ghosttyBridgeApplyTheme(
+    _ nsWindowPtr: UnsafeMutableRawPointer,
+    _ backgroundPtr: UnsafePointer<CChar>,
+    _ foregroundPtr: UnsafePointer<CChar>,
+    _ cursorPtr: UnsafePointer<CChar>?,
+    _ selectionBackgroundPtr: UnsafePointer<CChar>?,
+    _ palettePtr: UnsafePointer<UnsafePointer<CChar>?>
+) {
+    MainActor.assumeIsolated {
+        let window = Unmanaged<NSWindow>.fromOpaque(nsWindowPtr).takeUnretainedValue()
+        var palette: [Int: String] = [:]
+        for i in 0..<16 {
+            if let p = palettePtr.advanced(by: i).pointee {
+                palette[i] = stripHash(String(cString: p))
+            }
+        }
+        GhosttyBridgeImpl.shared.applyTheme(
+            window: window,
+            background: stripHash(String(cString: backgroundPtr)),
+            foreground: stripHash(String(cString: foregroundPtr)),
+            cursor: cursorPtr.map { stripHash(String(cString: $0)) },
+            selectionBackground: selectionBackgroundPtr.map { stripHash(String(cString: $0)) },
+            palette: palette
+        )
     }
 }

--- a/native/src/addon.mm
+++ b/native/src/addon.mm
@@ -22,6 +22,18 @@ extern "C" {
     typedef void (*KeyboardForwardFn)(long browserWindowId, unsigned long modifiers, const char* chars);
     void ghostty_bridge_set_keyboard_forward_callback(KeyboardForwardFn cb);
     void ghostty_bridge_set_active_panel_kind(void* nsWindow, long kindRaw, const char* panelId);
+    // 应用 Pier 主题派生的终端配色. cursor / selection 可空 (NULL = 不设置).
+    // palette 是 16 槽 const char* 数组, 每槽 #RRGGBB hex (含 #). 调用同步, swift 同步
+    // 构造 GhosttyThemeDefinition 后立即 setTheme — addon 端的字符串生命周期只需覆盖
+    // 这次调用即可.
+    void ghostty_bridge_apply_theme(
+        void* nsWindow,
+        const char* background,
+        const char* foreground,
+        const char* cursor,            // nullable
+        const char* selectionBackground, // nullable
+        const char** palette           // length 16, non-null entries
+    );
 }
 
 // Electron getNativeWindowHandle() returns Buffer containing NSView**
@@ -163,6 +175,55 @@ static Napi::Value JsSetKeyboardForwardCallback(const Napi::CallbackInfo& info) 
     return env.Undefined();
 }
 
+static Napi::Value JsApplyTerminalTheme(const Napi::CallbackInfo& info) {
+    NSWindow* win = WindowFromHandle(info[0]);
+    if (!win) return info.Env().Undefined();
+    Napi::Object colors = info[1].As<Napi::Object>();
+
+    // 解析必填: background / foreground.
+    std::string bg = colors.Get("background").As<Napi::String>().Utf8Value();
+    std::string fg = colors.Get("foreground").As<Napi::String>().Utf8Value();
+
+    // 解析可选 cursor / selectionBackground. undefined / "" 视为缺失.
+    std::string cursorStr;
+    const char* cursorPtr = nullptr;
+    Napi::Value cursorVal = colors.Get("cursor");
+    if (cursorVal.IsString()) {
+        cursorStr = cursorVal.As<Napi::String>().Utf8Value();
+        if (!cursorStr.empty()) cursorPtr = cursorStr.c_str();
+    }
+
+    std::string selStr;
+    const char* selPtr = nullptr;
+    Napi::Value selVal = colors.Get("selectionBackground");
+    if (selVal.IsString()) {
+        selStr = selVal.As<Napi::String>().Utf8Value();
+        if (!selStr.empty()) selPtr = selStr.c_str();
+    }
+
+    // palette: 长度 16, 每项 string. 不足则 NoOp (renderer 端 derive 保证 16 槽).
+    Napi::Array paletteArr = colors.Get("palette").As<Napi::Array>();
+    if (paletteArr.Length() != 16) {
+        return info.Env().Undefined();
+    }
+    std::string paletteStrs[16];
+    const char* palettePtrs[16];
+    for (uint32_t i = 0; i < 16; ++i) {
+        paletteStrs[i] = paletteArr.Get(i).As<Napi::String>().Utf8Value();
+        palettePtrs[i] = paletteStrs[i].c_str();
+    }
+
+    ghostty_bridge_apply_theme(
+        (__bridge void*)win,
+        bg.c_str(),
+        fg.c_str(),
+        cursorPtr,
+        selPtr,
+        palettePtrs
+    );
+    return info.Env().Undefined();
+}
+
 static Napi::Value JsSetActivePanelKind(const Napi::CallbackInfo& info) {
     NSWindow* win = WindowFromHandle(info[0]);
     if (!win) return info.Env().Undefined();
@@ -190,6 +251,7 @@ static Napi::Object Init(Napi::Env env, Napi::Object exports) {
     exports.Set("detachWindow",    Napi::Function::New(env, JsDetachWindow));
     exports.Set("setKeyboardForwardCallback", Napi::Function::New(env, JsSetKeyboardForwardCallback));
     exports.Set("setActivePanelKind", Napi::Function::New(env, JsSetActivePanelKind));
+    exports.Set("applyTerminalTheme", Napi::Function::New(env, JsApplyTerminalTheme));
     return exports;
 }
 

--- a/src/main/ipc/preferences.ts
+++ b/src/main/ipc/preferences.ts
@@ -1,4 +1,4 @@
-import type { IpcMain } from "electron";
+import { BrowserWindow, type IpcMain } from "electron";
 import {
   type ProjectPreferences,
   readPreferences,
@@ -10,7 +10,23 @@ export function registerPreferencesIpc(ipcMain: IpcMain): void {
 
   ipcMain.handle(
     "pier:preferences:update",
-    async (_event, patch: Partial<ProjectPreferences>) =>
-      updatePreferences(patch)
+    async (event, patch: Partial<ProjectPreferences>) => {
+      const merged = await updatePreferences(patch);
+      // 广播给除 sender 外的所有窗口. 当前 renderer 只有 theme.store 订阅
+      // onChanged, 所以 跨窗口同步仅覆盖 theme + stylePreset; font.store 和
+      // locale.store 暂未接 listener — 跨窗口字体/语言切换需要重启目标窗口才
+      // 生效. sender 自己已在 setTheme/setStylePreset await 后立即应用, 不走
+      // listener 路径避免重复 set.
+      for (const win of BrowserWindow.getAllWindows()) {
+        if (win.webContents.id === event.sender.id) {
+          continue;
+        }
+        if (win.webContents.isDestroyed()) {
+          continue;
+        }
+        win.webContents.send("pier:preferences:changed", merged);
+      }
+      return merged;
+    }
   );
 }

--- a/src/main/ipc/terminal.ts
+++ b/src/main/ipc/terminal.ts
@@ -1,11 +1,19 @@
 import { createRequire } from "node:module";
 import type {
   CreateTerminalArgs,
+  TerminalColors,
   TerminalFrame,
 } from "@shared/contracts/terminal.ts";
 import { BrowserWindow, type IpcMain } from "electron";
 
 interface NativeAddon {
+  /**
+   * 应用 Pier 主题派生的终端配色到指定 window 下的 Ghostty controller.
+   * Ghostty 库 controller.setTheme(...) 内部 reconfigure 并立即生效, shell 进程
+   * 不重启. 每个 BrowserWindow 一个 controller, 该 window 下所有 terminal panel
+   * 共享, 调一次即可.
+   */
+  applyTerminalTheme(parentHandle: Buffer, colors: TerminalColors): void;
   closeAllTerminals(parentHandle: Buffer): void;
   closeTerminal(panelId: string): void;
   createTerminal(
@@ -185,6 +193,21 @@ export function registerTerminalIpc(ipcMain: IpcMain): void {
     // makeFirstResponder(WKWebView) 的脆弱实现 (Electron 42 没真 WKWebView).
     if (active) {
       win.webContents.focus();
+    }
+  });
+
+  ipcMain.on("pier:terminal:apply-theme", (event, colors: TerminalColors) => {
+    if (!addon) {
+      return;
+    }
+    const win = BrowserWindow.fromWebContents(event.sender);
+    if (!win) {
+      return;
+    }
+    try {
+      addon.applyTerminalTheme(win.getNativeWindowHandle(), colors);
+    } catch (err) {
+      console.error("[pier-terminal-apply-theme] failed:", err);
     }
   });
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -6,29 +6,23 @@ export interface WindowInfo {
   id: string;
 }
 
+interface PreferencesSnapshot {
+  language: string;
+  monoFontFamily: string;
+  stylePresetId: string;
+  theme: string;
+  uiFontFamily: string;
+}
+
 export interface PierPreferencesAPI {
-  read: () => Promise<{
-    theme: string;
-    stylePresetId: string;
-    language: string;
-    uiFontFamily: string;
-    monoFontFamily: string;
-  }>;
-  update: (
-    patch: Partial<{
-      theme: string;
-      stylePresetId: string;
-      language: string;
-      uiFontFamily: string;
-      monoFontFamily: string;
-    }>
-  ) => Promise<{
-    theme: string;
-    stylePresetId: string;
-    language: string;
-    uiFontFamily: string;
-    monoFontFamily: string;
-  }>;
+  /**
+   * 订阅其他窗口对 preferences 的修改 — main 端 update 后会广播给除 sender 外
+   * 的所有 BrowserWindow. 调用方在 sender 自己的 setter 里已经 await + 同步
+   * 应用过, 不会收到自己的广播.
+   */
+  onChanged: (cb: (next: PreferencesSnapshot) => void) => () => void;
+  read: () => Promise<PreferencesSnapshot>;
+  update: (patch: Partial<PreferencesSnapshot>) => Promise<PreferencesSnapshot>;
 }
 
 export interface PierThemeAPI {
@@ -69,11 +63,21 @@ export interface PierWindowAPI {
 }
 
 const preferencesApi: PierPreferencesAPI = {
+  onChanged: (cb) => {
+    const listener = (_event: unknown, next: PreferencesSnapshot): void => {
+      cb(next);
+    };
+    ipcRenderer.on("pier:preferences:changed", listener);
+    return () => {
+      ipcRenderer.off("pier:preferences:changed", listener);
+    };
+  },
   read: () => ipcRenderer.invoke("pier:preferences:read"),
   update: (patch) => ipcRenderer.invoke("pier:preferences:update", patch),
 };
 
 const terminalApi: TerminalAPI = {
+  applyTheme: (colors) => ipcRenderer.send("pier:terminal:apply-theme", colors),
   close: (panelId) => ipcRenderer.invoke("pier:terminal:close", panelId),
   create: (args) => ipcRenderer.invoke("pier:terminal:create", args),
   focus: (panelId) => ipcRenderer.send("pier:terminal:focus", panelId),

--- a/src/renderer/lib/theme/derive-terminal-colors.ts
+++ b/src/renderer/lib/theme/derive-terminal-colors.ts
@@ -1,0 +1,150 @@
+// Pier 主题 → Ghostty 终端配色派生
+//
+// Shiki 主题用 VS Code 配色 dict, ANSI 16 色按 `terminal.ansi*` / `terminal.ansiBright*`
+// 命名约定存在 colors map 里. 缺失键 (有些 minimal 主题不定义 ANSI) 回落到 hardcode
+// 默认调色板 (light / dark 各一套, 取自 Ghostty 库 TerminalTheme+Defaults 的 IR_Black
+// 风格), 保证任何主题都拿到 16 槽完整 palette.
+//
+// 输出 hex 经 opaqueOn → 6 字符 (#RRGGBB). 终端不接 alpha, 把 alpha 合成进 bg.
+
+import type {
+  AnsiPalette,
+  TerminalColors,
+} from "@shared/contracts/terminal.ts";
+import { normalizeHex, opaqueOn } from "./oklch.ts";
+import type { ShikiThemeLike } from "./preset-registry.ts";
+
+// 缺 ANSI 键时的兜底 palette. 风格沿 Ghostty 内置 default (TerminalTheme+Defaults.swift).
+// 不依赖任一具体 Shiki preset, 避免主题缺失时退化成无配色的纯文本.
+const FALLBACK_PALETTE_DARK: AnsiPalette = [
+  "#151515",
+  "#ac4142",
+  "#7e8e50",
+  "#e4b567",
+  "#6c99bb",
+  "#9f4e86",
+  "#7dd5cf",
+  "#d0d0d0",
+  "#505050",
+  "#cc6666",
+  "#a1b56c",
+  "#f0c674",
+  "#81a2be",
+  "#b294bb",
+  "#8abeb7",
+  "#f5f5f5",
+];
+
+const FALLBACK_PALETTE_LIGHT: AnsiPalette = [
+  "#000000",
+  "#aa3731",
+  "#448c27",
+  "#cb8800",
+  "#325cc0",
+  "#7a3e9d",
+  "#0083b2",
+  "#a0a0a0",
+  "#777777",
+  "#f03e31",
+  "#60cb00",
+  "#bb8800",
+  "#007acc",
+  "#e64ce6",
+  "#00aacb",
+  "#f5f5f5",
+];
+
+function pickHex(
+  colors: Record<string, string>,
+  key: string,
+  bg: string
+): string | undefined {
+  const raw = colors[key];
+  if (!raw) {
+    return;
+  }
+  const norm = normalizeHex(raw);
+  if (!norm) {
+    return;
+  }
+  // opaqueOn 把 #rrggbbaa 合成进 bg → #rrggbb; 6 字符直接返回.
+  return opaqueOn(norm, bg);
+}
+
+// tuple destructure: tsconfig 启 noUncheckedIndexedAccess 下 array index 都带
+// undefined; 解构成 16 个变量 TS 才能推出 string. 顺序严格对齐 ANSI 0..15.
+function derivePalette(
+  colors: Record<string, string>,
+  background: string,
+  mode: "light" | "dark"
+): AnsiPalette {
+  const [
+    fb0,
+    fb1,
+    fb2,
+    fb3,
+    fb4,
+    fb5,
+    fb6,
+    fb7,
+    fb8,
+    fb9,
+    fb10,
+    fb11,
+    fb12,
+    fb13,
+    fb14,
+    fb15,
+  ] = mode === "dark" ? FALLBACK_PALETTE_DARK : FALLBACK_PALETTE_LIGHT;
+  return [
+    pickHex(colors, "terminal.ansiBlack", background) ?? fb0,
+    pickHex(colors, "terminal.ansiRed", background) ?? fb1,
+    pickHex(colors, "terminal.ansiGreen", background) ?? fb2,
+    pickHex(colors, "terminal.ansiYellow", background) ?? fb3,
+    pickHex(colors, "terminal.ansiBlue", background) ?? fb4,
+    pickHex(colors, "terminal.ansiMagenta", background) ?? fb5,
+    pickHex(colors, "terminal.ansiCyan", background) ?? fb6,
+    pickHex(colors, "terminal.ansiWhite", background) ?? fb7,
+    pickHex(colors, "terminal.ansiBrightBlack", background) ?? fb8,
+    pickHex(colors, "terminal.ansiBrightRed", background) ?? fb9,
+    pickHex(colors, "terminal.ansiBrightGreen", background) ?? fb10,
+    pickHex(colors, "terminal.ansiBrightYellow", background) ?? fb11,
+    pickHex(colors, "terminal.ansiBrightBlue", background) ?? fb12,
+    pickHex(colors, "terminal.ansiBrightMagenta", background) ?? fb13,
+    pickHex(colors, "terminal.ansiBrightCyan", background) ?? fb14,
+    pickHex(colors, "terminal.ansiBrightWhite", background) ?? fb15,
+  ];
+}
+
+export function deriveTerminalColors(
+  theme: ShikiThemeLike,
+  mode: "light" | "dark"
+): TerminalColors {
+  const colors = theme.colors ?? {};
+
+  const bgFallback = mode === "dark" ? "#0a0a0a" : "#ffffff";
+  const background =
+    pickHex(colors, "editor.background", bgFallback) ?? bgFallback;
+
+  const fgFallback = mode === "dark" ? "#fafafa" : "#0a0a0a";
+  const foreground =
+    pickHex(colors, "editor.foreground", background) ??
+    pickHex(colors, "terminal.foreground", background) ??
+    fgFallback;
+
+  const cursor =
+    pickHex(colors, "editorCursor.foreground", background) ??
+    pickHex(colors, "terminalCursor.foreground", background);
+
+  const selectionBackground =
+    pickHex(colors, "terminal.selectionBackground", background) ??
+    pickHex(colors, "editor.selectionBackground", background);
+
+  return {
+    background,
+    cursor,
+    foreground,
+    palette: derivePalette(colors, background, mode),
+    selectionBackground,
+  };
+}

--- a/src/renderer/stores/theme.store.ts
+++ b/src/renderer/stores/theme.store.ts
@@ -6,6 +6,11 @@ import type {
 
 import { create } from "zustand";
 import { applyTokens } from "@/lib/theme/apply-tokens.ts";
+import { deriveTerminalColors } from "@/lib/theme/derive-terminal-colors.ts";
+import {
+  getShikiTheme,
+  STYLE_PRESET_REGISTRY,
+} from "@/lib/theme/preset-registry.ts";
 import { syncThemeHead } from "@/lib/theme/sync-head.ts";
 
 interface ThemeState {
@@ -52,6 +57,60 @@ function applyDocumentTheme(resolved: ResolvedTheme): void {
     ?.catch(() => undefined);
 }
 
+/**
+ * 把当前 preset + 模式派生的终端配色推给 native Ghostty controller.
+ * 在所有主题变化点调一次: _hydrate / setTheme / setStylePreset / system listener
+ * / preferences listener (跨窗口同步) / applyThemeVisual (命令面板 hover 预览).
+ *
+ * 用 requestAnimationFrame coalesce — 同一帧内多次调用合并成一次 IPC, 避免
+ * 命令面板箭头狂按时引起 controller.setTheme 风暴 (每次 setTheme 会写 ghostty
+ * 临时 .conf + 遍历所有 surface reconfigure). 用户连续切预览时, 最多每帧一次
+ * IPC, 视觉跟随且 native 端不被打爆. accept 类 setter 同帧内调一次 applyTokens
+ * + applyTerminalColors, 下一帧 flush 时拿到最终色板; dismiss 时同样调一次
+ * applyThemeVisual(original) 即可还原, rAF 自然合并到一个 IPC.
+ *
+ * 失败 (preload 未 ready / native addon 未装) 时静默 — 终端只是色板没跟上, 不
+ * 影响 DOM 主题应用; 不能让 IPC 错误拖垮整个主题切换.
+ */
+let pendingTerminalApply: {
+  presetId: StylePresetId;
+  resolved: ResolvedTheme;
+} | null = null;
+let scheduledTerminalFrame: number | null = null;
+
+function flushPendingTerminalApply(): void {
+  scheduledTerminalFrame = null;
+  const pending = pendingTerminalApply;
+  pendingTerminalApply = null;
+  if (!pending) {
+    return;
+  }
+  try {
+    const shiki = getShikiTheme(pending.presetId, pending.resolved);
+    const colors = deriveTerminalColors(shiki, pending.resolved);
+    window.pier?.terminal?.applyTheme?.(colors);
+  } catch (err) {
+    console.error("[theme.store] applyTerminalColors failed:", err);
+  }
+}
+
+function applyTerminalColors(
+  presetId: StylePresetId,
+  resolved: ResolvedTheme
+): void {
+  pendingTerminalApply = { presetId, resolved };
+  if (scheduledTerminalFrame !== null) {
+    return;
+  }
+  if (typeof window === "undefined" || !window.requestAnimationFrame) {
+    flushPendingTerminalApply();
+    return;
+  }
+  scheduledTerminalFrame = window.requestAnimationFrame(
+    flushPendingTerminalApply
+  );
+}
+
 export function applyThemeVisual(
   themePreference: ThemePreference,
   presetId: StylePresetId
@@ -59,6 +118,7 @@ export function applyThemeVisual(
   const resolved = resolveTheme(themePreference);
   applyTokens({ presetId, resolved });
   applyDocumentTheme(resolved);
+  applyTerminalColors(presetId, resolved);
 }
 
 export const useThemeStore = create<ThemeState>((set) => ({
@@ -70,6 +130,7 @@ export const useThemeStore = create<ThemeState>((set) => ({
     const resolved = resolveTheme(theme);
     applyTokens({ presetId: stylePresetId, resolved });
     applyDocumentTheme(resolved);
+    applyTerminalColors(stylePresetId, resolved);
     set({ theme, resolvedTheme: resolved, stylePresetId });
   },
 
@@ -80,6 +141,7 @@ export const useThemeStore = create<ThemeState>((set) => ({
       const currentPreset = useThemeStore.getState().stylePresetId;
       applyTokens({ presetId: currentPreset as StylePresetId, resolved });
       applyDocumentTheme(resolved);
+      applyTerminalColors(currentPreset as StylePresetId, resolved);
       set({
         theme: merged.theme as ThemePreference,
         resolvedTheme: resolved,
@@ -90,30 +152,73 @@ export const useThemeStore = create<ThemeState>((set) => ({
   },
 
   async setStylePreset(next) {
+    // 纯校验, 不写 DOM — 防止 stale settings UI 把已删除的 preset id 写到 disk
+    // 引起下次启动 _hydrate 抛错. 与"applyTokens 提前到 update 之前"的旧路径
+    // 不同, 这里 update 失败时 DOM 完全不动, 三态 (DOM / store / disk) 始终一致.
+    if (!(next in STYLE_PRESET_REGISTRY)) {
+      console.error(
+        `[theme.store] setStylePreset: unknown preset id "${next}"`
+      );
+      return;
+    }
     try {
       const merged = await window.pier.preferences.update({
         stylePresetId: next,
       });
+      const nextPreset = merged.stylePresetId as StylePresetId;
       const currentResolved = useThemeStore.getState().resolvedTheme;
-      applyTokens({
-        presetId: merged.stylePresetId as StylePresetId,
-        resolved: currentResolved,
-      });
+      applyTokens({ presetId: nextPreset, resolved: currentResolved });
       syncThemeHead({ resolved: currentResolved });
       window.pier?.theme
         ?.setNativeChrome?.(currentResolved, readChromeColor())
         ?.catch(() => undefined);
+      applyTerminalColors(nextPreset, currentResolved);
       set({
-        stylePresetId: merged.stylePresetId as StylePresetId,
+        stylePresetId: nextPreset,
       });
     } catch (err) {
-      console.error("[theme.store] setStylePreset IPC failed:", err);
+      console.error("[theme.store] setStylePreset failed:", err);
     }
   },
 }));
 
 let systemListenerAttached = false;
 let detachSystemListener: (() => void) | null = null;
+let preferencesListenerAttached = false;
+let detachPreferencesListener: (() => void) | null = null;
+
+/**
+ * 订阅 main 端广播的 preferences 变化 — 其他窗口修改 theme / stylePreset 时,
+ * 本窗口收到后同步 DOM + 终端配色 + store state. main 端已经把 sender 自己排除,
+ * 所以这里不会收到自己窗口刚 await 完的回声.
+ */
+function attachPreferencesListener(): void {
+  if (preferencesListenerAttached || typeof window === "undefined") {
+    return;
+  }
+  const detach = window.pier?.preferences?.onChanged?.((next) => {
+    const nextTheme = next.theme as ThemePreference;
+    const nextPreset = next.stylePresetId as StylePresetId;
+    const current = useThemeStore.getState();
+    if (current.theme === nextTheme && current.stylePresetId === nextPreset) {
+      return;
+    }
+    const resolved = resolveTheme(nextTheme);
+    applyTokens({ presetId: nextPreset, resolved });
+    applyDocumentTheme(resolved);
+    applyTerminalColors(nextPreset, resolved);
+    useThemeStore.setState({
+      resolvedTheme: resolved,
+      stylePresetId: nextPreset,
+      theme: nextTheme,
+    });
+  });
+  if (!detach) {
+    return;
+  }
+  detachPreferencesListener = detach;
+  preferencesListenerAttached = true;
+}
 
 function attachSystemListener(): void {
   if (systemListenerAttached || typeof window === "undefined") {
@@ -131,6 +236,7 @@ function attachSystemListener(): void {
     const { stylePresetId } = useThemeStore.getState();
     applyTokens({ presetId: stylePresetId, resolved });
     applyDocumentTheme(resolved);
+    applyTerminalColors(stylePresetId, resolved);
     useThemeStore.setState({ resolvedTheme: resolved });
   };
   mq.addEventListener("change", onChange);
@@ -142,16 +248,25 @@ export function detachThemeSystemListener(): void {
   detachSystemListener?.();
   detachSystemListener = null;
   systemListenerAttached = false;
+  detachPreferencesListener?.();
+  detachPreferencesListener = null;
+  preferencesListenerAttached = false;
 }
 
 export async function initTheme(): Promise<void> {
+  // 先 attach listener 再 await read — 防止新窗口在 read 进行中错过其它窗口的
+  // pier:preferences:changed 广播 (preload 已收到事件但 JS listener 还没装,
+  // 事件被 dropped, 后续也没有 catch-up 路径). listener 比 read 早 fire 不会
+  // 出问题: broadcast 携带的是最新 disk 内容, 它先应用, 之后 _hydrate 应用
+  // read snapshot 是相同或更旧值; 若旧值, 下次 broadcast 会再覆盖到一致.
+  attachSystemListener();
+  attachPreferencesListener();
   try {
     const snapshot = await window.pier.preferences.read();
     useThemeStore.getState()._hydrate({
       theme: snapshot.theme as ThemePreference,
       stylePresetId: snapshot.stylePresetId as StylePresetId,
     });
-    attachSystemListener();
   } catch (err) {
     console.error(
       "[theme.store] initTheme IPC failed; falling back to defaults:",
@@ -162,6 +277,5 @@ export async function initTheme(): Promise<void> {
       theme: current.theme,
       stylePresetId: current.stylePresetId,
     });
-    attachSystemListener();
   }
 }

--- a/src/shared/contracts/terminal.ts
+++ b/src/shared/contracts/terminal.ts
@@ -15,7 +15,50 @@ export interface CreateTerminalResult {
   ok: boolean;
 }
 
+/**
+ * ANSI 16 色 palette. 索引语义 = xterm-256color 前 16 槽:
+ * 0..7   = black, red, green, yellow, blue, magenta, cyan, white
+ * 8..15  = bright black .. bright white
+ *
+ * 每项是 #RRGGBB (6 字符, 不含 alpha) — Ghostty 库接收 hex 字符串.
+ */
+export type AnsiPalette = readonly [
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+];
+
+/**
+ * 终端配色描述. 由 renderer 侧从当前 Shiki 主题派生, 经 IPC → native addon →
+ * Ghostty controller.setTheme 应用. 所有色值都是 #RRGGBB (含 #, 6 字符).
+ *
+ * cursor / selectionBackground 写成 `| undefined` 而非纯 optional, 是因为项目
+ * tsconfig 启用 exactOptionalPropertyTypes — derive 函数会显式赋 undefined 表示
+ * "主题缺这个键", IPC 边界用 isString 守卫区分缺失 vs 实际值.
+ */
+export interface TerminalColors {
+  background: string;
+  cursor?: string | undefined;
+  foreground: string;
+  palette: AnsiPalette;
+  selectionBackground?: string | undefined;
+}
+
 export interface TerminalAPI {
+  applyTheme(colors: TerminalColors): void;
   close(panelId: string): Promise<void>;
   create(args: CreateTerminalArgs): Promise<CreateTerminalResult>;
   focus(panelId: string): void;


### PR DESCRIPTION
## Summary

- 把 Pier 当前 preset + 模式派生的色板（ANSI 16 + bg/fg/cursor/selection）推给 Ghostty native `controller.setTheme(...)`，主题/风格切换时终端实时跟随，shell 不重启
- 命令面板 hover 预览也跟随：`requestAnimationFrame` coalesce 同帧多次合并为一次 IPC，防止箭头狂按引起 setTheme 风暴
- 主进程 `preferences.update` 后广播 `pier:preferences:changed` 给除 sender 外的所有 BrowserWindow，多窗口 theme/preset 自动同步

## 改动链路

```
Renderer (Shiki theme.colors 派生 16 色 + bg/fg/cursor/sel)
  → window.pier.terminal.applyTheme(colors)
  → ipcRenderer.send "pier:terminal:apply-theme"
  → main: addon.applyTerminalTheme(handle, colors)
  → N-API (addon.mm) 解析 + 转 C ABI
  → Swift GhosttyBridgeImpl.applyTheme(window, ...)
  → GhosttyThemeDefinition.toTerminalTheme()
  → controller.setTheme(...) → ghostty_app_update_config + 全 surface reconfigure
```

## 健壮性细节

- `setStylePreset` 用 `next in STYLE_PRESET_REGISTRY` 早验证；失败时不调 IPC 也不写 DOM，三态（DOM/store/disk）始终一致
- `initTheme` 先 attach preferences listener 再 `await read()`，防止新窗口在 read pending 期间错过其它窗口的广播
- `FALLBACK_PALETTE_DARK` 9-14 修复复制粘贴 typo（bright 段曾 = regular 段）；`FALLBACK_PALETTE_LIGHT[15]` 从 `#000000` 修为 `#f5f5f5`（bright white）

## 已知 follow-up（不在本 PR 内）

- 多窗口 broadcast 当前只 `theme.store` 订阅，`font.store` / `locale.store` 需要单独接 `onChanged` 才能跨窗口同步字体/语言。主进程注释已诚实标注此 scope

## Test plan

- [x] `pnpm install` + `pnpm setup:worktree`（首次会自动 `pnpm build:native`）
- [x] `pnpm dev` 启动 Pier
- [x] 命令面板 Cmd+K → "Select Style" → 上下箭头滚 preset：终端配色应实时跟随预览，Esc 还原，Enter 落盘
- [x] 切 light/dark/system：终端配色同样跟随
- [x] 开两个窗口，在 A 切风格：B 窗口的 DOM 和终端都自动同步
- [x] 已开的 shell 进程在切风格后不重启（PID 不变）
- [x] `pnpm check` 全过；`pnpm test:unit` 14/14 过

🤖 Generated with [Claude Code](https://claude.com/claude-code)