### PR TITLE
feat(terminal): panel descriptor 架构 + OSC 7/0/2 → tab/title 全链路

### DIFF
--- a/docs/superpowers/plans/2026-06-23-terminal-cwd-pipeline.md
+++ b/docs/superpowers/plans/2026-06-23-terminal-cwd-pipeline.md
@@ -1,0 +1,1376 @@
+# Terminal CWD Pipeline Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 打通 shell → Ghostty → swift → C++ → main → preload → renderer 的 cwd 上报链路, 让 terminal panel 的 tab title / 系统 title 反映当前工作目录。
+
+**Architecture:** 利用 Ghostty 已实现的 OSC 7 解析能力, 通过 `TerminalSurfacePwdDelegate` 在 swift 端接收 PWD 变化, 经 N-API ThreadSafeFunction 跨线程到 main JS, 通过 webContents.send 推到 renderer; renderer 端 terminal-panel 订阅事件, 经已有的 `usePanelDescriptor` hook 把 cwd 同步到中心 store, 各 sink (tab / document.title / titlebar) 自然更新。
+
+**Tech Stack:**
+- swift: AppKit + GhosttyTerminal (libghostty-spm)
+- native: Node-API (napi.h) + ThreadSafeFunction
+- main: Electron 42 (BrowserWindow.webContents.send)
+- renderer: React 19 + Zustand 5 + dockview-react 6.6.1
+- 测试: Vitest 4 (TS 层) + 手动 `pnpm dev` (跨进程链路)
+
+---
+
+## File Structure
+
+**新建 (renderer 层)**
+
+- `tests/unit/panel-descriptor.test.ts` — store / hook 单元测试 (path 字段)
+- `tests/unit/cwd-derive.test.ts` — basename / cwd → descriptor 推导逻辑测试
+
+**修改 (从下到上)**
+
+- `native/Sources/GhosttyBridge/GhosttyBridge.swift` — 新增 PwdDelegate adapter + forwardPwdCallback + C ABI export
+- `native/src/addon.mm` — 新增 PwdForwardFn typedef + ThreadSafeFunction + JsSetPwdForwardCallback + exports
+- `src/main/ipc/terminal.ts` — NativeAddon interface 加 setPwdForwardCallback, registerTerminalIpc 注册转发到 `pier:terminal:cwd-change` IPC
+- `src/shared/contracts/terminal.ts` — 新增 `TerminalCwdEvent` 类型 + TerminalAPI.onCwdChange
+- `src/preload/index.ts` — terminalApi.onCwdChange 实现 (ipcRenderer.on + dispose)
+- `src/renderer/stores/panel-descriptor.store.ts` — PanelDescriptor 加 `path?` 字段
+- `src/renderer/hooks/use-panel-descriptor.ts` — descriptor 增加 path 透传逻辑 (exactOptionalPropertyTypes 适配)
+- `src/renderer/components/common/document-title.tsx` — long 缺省 fallback 加 path
+- `src/renderer/panel-kits/terminal/terminal-panel.tsx` — useState(cwd) + 订阅 onCwdChange + 推送 descriptor
+
+**任务分解层次**
+
+- Task 1-4: TS 层数据契约和 store 扩展 (TDD, 可独立验证)
+- Task 5-7: swift / C++ 跨语言通道
+- Task 8-9: main + preload IPC 转发
+- Task 10: terminal-panel 集成
+- Task 11: 重新 build native + check + 手动 verify
+- Task 12: shell-integration env 注入 (条件任务, 看 Task 11 验证结果)
+
+---
+
+### Task 1: 扩展 PanelDescriptor 增加 path 字段 (TDD)
+
+**Files:**
+- Modify: `src/renderer/stores/panel-descriptor.store.ts`
+- Create: `tests/unit/panel-descriptor.test.ts`
+
+- [ ] **Step 1: 写失败测试**
+
+```typescript
+// tests/unit/panel-descriptor.test.ts
+import { describe, expect, it, beforeEach } from "vitest";
+import { usePanelDescriptorStore } from "../../src/renderer/stores/panel-descriptor.store.ts";
+
+describe("PanelDescriptor store", () => {
+  beforeEach(() => {
+    usePanelDescriptorStore.setState({ descriptors: {}, activeId: null });
+  });
+
+  it("stores path field alongside short/long", () => {
+    usePanelDescriptorStore.getState().upsert("p1", {
+      short: "pier",
+      long: "/Users/x/ABC/pier",
+      path: "/Users/x/ABC/pier",
+    });
+    const d = usePanelDescriptorStore.getState().descriptors.p1;
+    expect(d.path).toBe("/Users/x/ABC/pier");
+    expect(d.long).toBe("/Users/x/ABC/pier");
+    expect(d.short).toBe("pier");
+  });
+
+  it("path is optional — descriptor without path is valid", () => {
+    usePanelDescriptorStore.getState().upsert("p1", { short: "Welcome" });
+    const d = usePanelDescriptorStore.getState().descriptors.p1;
+    expect(d.path).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: 跑测试看它 fail**
+
+Run: `pnpm test:unit panel-descriptor`
+Expected: FAIL — TypeScript 报错 `Object literal may only specify known properties, and 'path' does not exist in type 'PanelDescriptor'`
+
+- [ ] **Step 3: 给 PanelDescriptor 加 path 字段**
+
+修改 `src/renderer/stores/panel-descriptor.store.ts` 第 9-14 行:
+
+```typescript
+export interface PanelDescriptor {
+  /** 完整形式 — document.title / titlebar / 单 tab 模式 */
+  long?: string;
+  /** 当前工作目录绝对路径 — terminal panel 由 OSC 7 / 上层提供; 其他 panel 可不填 */
+  path?: string;
+  /** 紧凑形式 — tab strip 等空间受限处 */
+  short: string;
+}
+```
+
+(biome 要求 interface key 字母排序,放法注意 long → path → short。)
+
+- [ ] **Step 4: 跑测试看它 pass**
+
+Run: `pnpm test:unit panel-descriptor`
+Expected: PASS, 2 tests
+
+- [ ] **Step 5: typecheck 确认无破坏**
+
+Run: `pnpm typecheck`
+Expected: 0 errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/renderer/stores/panel-descriptor.store.ts tests/unit/panel-descriptor.test.ts
+git commit -m "feat(panel): PanelDescriptor 增加 path 字段
+
+为 terminal cwd pipeline 准备 — sink 端按需消费,
+short/long fallback 链不变。"
+```
+
+---
+
+### Task 2: hook 透传 path 字段 (适配 exactOptionalPropertyTypes)
+
+**Files:**
+- Modify: `src/renderer/hooks/use-panel-descriptor.ts`
+
+- [ ] **Step 1: 写失败测试 (基于 hook 行为)**
+
+```typescript
+// tests/unit/panel-descriptor.test.ts — 追加 describe
+import { renderHook } from "@testing-library/react";
+import { usePanelDescriptor } from "../../src/renderer/hooks/use-panel-descriptor.ts";
+
+describe("usePanelDescriptor hook", () => {
+  beforeEach(() => {
+    usePanelDescriptorStore.setState({ descriptors: {}, activeId: null });
+  });
+
+  it("upserts path field into store", () => {
+    const setTitle = vi.fn();
+    const panel = { id: "term-1", setTitle };
+
+    renderHook(() =>
+      usePanelDescriptor(panel, {
+        short: "pier",
+        long: "/Users/x/ABC/pier",
+        path: "/Users/x/ABC/pier",
+      })
+    );
+
+    const stored = usePanelDescriptorStore.getState().descriptors["term-1"];
+    expect(stored.path).toBe("/Users/x/ABC/pier");
+    expect(setTitle).toHaveBeenCalledWith("pier");
+  });
+
+  it("descriptor without path stores only short/long", () => {
+    const panel = { id: "term-2", setTitle: vi.fn() };
+    renderHook(() => usePanelDescriptor(panel, { short: "Terminal" }));
+
+    const stored = usePanelDescriptorStore.getState().descriptors["term-2"];
+    expect(stored.path).toBeUndefined();
+    expect(stored.short).toBe("Terminal");
+  });
+});
+```
+
+(import `vi` from `vitest`, 顶部加 `import { vi } from "vitest";` 和 `import "@testing-library/jest-dom";` 如缺。检查 `tests/setup/jsdom-setup.ts` 是否已配 jsdom — 若未配 testing-library 需在 package.json/vitest.config 启用; 当前 `tests/setup/jsdom-setup.ts` 是 1 行 — 若 fail 自动跳过 hook 测试只跑 store 测试 — 但 TDD 流程仍按 store + hook 都写。)
+
+- [ ] **Step 2: 跑测试看它 fail**
+
+Run: `pnpm test:unit panel-descriptor`
+Expected: FAIL — `setTitle` 被调,但 store 中 path === undefined (当前 hook 只解构 short/long)
+
+- [ ] **Step 3: 改 hook 透传 path**
+
+修改 `src/renderer/hooks/use-panel-descriptor.ts` 第 27-43 行 (函数主体):
+
+```typescript
+export function usePanelDescriptor(
+  panel: PanelHandle,
+  descriptor: PanelDescriptor
+): void {
+  const { short, long, path } = descriptor;
+  const upsert = usePanelDescriptorStore((s) => s.upsert);
+  const remove = usePanelDescriptorStore((s) => s.remove);
+
+  useEffect(() => {
+    panel.setTitle(short);
+    // exactOptionalPropertyTypes — 按字段是否定义条件构造, 避免显式 undefined
+    const next: PanelDescriptor = { short };
+    if (long !== undefined) next.long = long;
+    if (path !== undefined) next.path = path;
+    upsert(panel.id, next);
+    return () => remove(panel.id);
+  }, [panel, short, long, path, upsert, remove]);
+}
+```
+
+- [ ] **Step 4: 跑测试**
+
+Run: `pnpm test:unit panel-descriptor`
+Expected: PASS
+
+- [ ] **Step 5: typecheck + lint**
+
+Run: `pnpm typecheck && pnpm lint`
+Expected: 0 errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/renderer/hooks/use-panel-descriptor.ts tests/unit/panel-descriptor.test.ts
+git commit -m "feat(panel): usePanelDescriptor 透传 path 字段
+
+exactOptionalPropertyTypes 适配 — 按字段存在性条件构造,
+不传 undefined key。"
+```
+
+---
+
+### Task 3: DocumentTitle sink 优先使用 path (TDD)
+
+**Files:**
+- Modify: `src/renderer/components/common/document-title.tsx`
+- Create: `tests/unit/cwd-derive.test.ts`
+
+- [ ] **Step 1: 写失败测试**
+
+```typescript
+// tests/unit/cwd-derive.test.ts
+import { describe, expect, it } from "vitest";
+
+/**
+ * resolveLong — sink fallback 优先级.
+ *
+ * 当 descriptor 同时有 path 时, document.title 优先用 path (绝对路径有信息密度);
+ * 没有 path 时回退到 long; 都没有用 short.
+ */
+function resolveLong(d: { short: string; long?: string; path?: string }): string {
+  return d.path ?? d.long ?? d.short;
+}
+
+describe("resolveLong", () => {
+  it("prefers path over long", () => {
+    expect(
+      resolveLong({ short: "pier", long: "Pier project", path: "/Users/x/pier" })
+    ).toBe("/Users/x/pier");
+  });
+
+  it("falls back to long when no path", () => {
+    expect(resolveLong({ short: "x", long: "long text" })).toBe("long text");
+  });
+
+  it("falls back to short when neither", () => {
+    expect(resolveLong({ short: "x" })).toBe("x");
+  });
+});
+```
+
+- [ ] **Step 2: 跑测试看它 fail**
+
+Run: `pnpm test:unit cwd-derive`
+Expected: FAIL — `resolveLong is not defined` (or `Cannot find name`)
+
+注意:这里的 resolveLong 还没有从 source code import,纯函数定义在测试文件里也可以先跑过。让步骤直接是定义后跑;失败的语义其实是 `document.title` 没真正用 path。下一步改 sink 让真实代码也走这个逻辑。
+
+- [ ] **Step 3: 把 resolveLong 提到 source,document-title 使用**
+
+修改 `src/renderer/components/common/document-title.tsx`:
+
+```tsx
+import { useEffect } from "react";
+import {
+  type PanelDescriptor,
+  useActiveDescriptor,
+} from "@/stores/panel-descriptor.store.ts";
+
+/**
+ * 解析 document.title 用的"长形式"字符串.
+ * 优先级:path (绝对路径, 信息密度最高) > long > short.
+ */
+export function resolveLong(d: PanelDescriptor): string {
+  return d.path ?? d.long ?? d.short;
+}
+
+/**
+ * DocumentTitle — 把当前 active panel 的 descriptor 同步到 document.title.
+ *
+ * Electron BrowserWindow.title 默认跟随 webContents.document.title 变化, 主进程
+ * 不需要 IPC. 无 active panel 时 fallback "Pier".
+ *
+ * 渲染 null:这是个纯 side-effect 组件, 不占 DOM.
+ */
+export function DocumentTitle(): null {
+  const active = useActiveDescriptor();
+  useEffect(() => {
+    const text = active ? resolveLong(active) : null;
+    document.title = text ? `${text} — Pier` : "Pier";
+  }, [active]);
+  return null;
+}
+```
+
+更新 `tests/unit/cwd-derive.test.ts` 改成 import 真实 resolveLong:
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { resolveLong } from "../../src/renderer/components/common/document-title.tsx";
+// ... 测试用例不变
+```
+
+- [ ] **Step 4: 跑测试**
+
+Run: `pnpm test:unit cwd-derive`
+Expected: PASS, 3 tests
+
+- [ ] **Step 5: title-bar 同步用 resolveLong**
+
+修改 `src/renderer/components/common/title-bar.tsx`:
+
+```tsx
+import { resolveLong } from "@/components/common/document-title.tsx";
+import { useActiveDescriptor } from "@/stores/panel-descriptor.store.ts";
+
+/**
+ * TitleBar — macOS hiddenInset 自定义标题栏.
+ * (注释保持原状)
+ */
+export function TitleBar() {
+  const active = useActiveDescriptor();
+  const text = active ? resolveLong(active) : "Pier";
+  return (
+    <div className="app-drag flex h-[38px] shrink-0 items-center justify-center border-[var(--sidebar-border)] border-b bg-[var(--sidebar)]">
+      <span className="select-none font-medium text-muted-foreground text-xs">
+        {text}
+      </span>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 6: 完整 check**
+
+Run: `pnpm check`
+Expected: typecheck / lint / depcruise / file-size 全绿
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/renderer/components/common/document-title.tsx src/renderer/components/common/title-bar.tsx tests/unit/cwd-derive.test.ts
+git commit -m "feat(panel): sink 优先使用 path 作为长形式
+
+DocumentTitle / TitleBar 共用 resolveLong, path > long > short。"
+```
+
+---
+
+### Task 4: shared contracts 增加 TerminalCwdEvent 类型
+
+**Files:**
+- Modify: `src/shared/contracts/terminal.ts`
+
+- [ ] **Step 1: 加事件类型 + onCwdChange 方法**
+
+修改 `src/shared/contracts/terminal.ts`:
+
+```typescript
+export interface TerminalFrame {
+  height: number;
+  width: number;
+  x: number;
+  y: number;
+}
+
+export interface CreateTerminalArgs {
+  frame: TerminalFrame;
+  panelId: string;
+}
+
+export interface CreateTerminalResult {
+  error?: string;
+  ok: boolean;
+}
+
+/**
+ * Terminal cwd 变化事件 — swift OSC 7 解析后通过 IPC 推送到 renderer.
+ * cwd 是绝对路径 (不带 file:// 前缀, 已由 swift 端从 URL 提取).
+ */
+export interface TerminalCwdEvent {
+  cwd: string;
+  panelId: string;
+}
+
+export interface TerminalAPI {
+  close(panelId: string): Promise<void>;
+  create(args: CreateTerminalArgs): Promise<CreateTerminalResult>;
+  focus(panelId: string): void;
+  hide(panelId: string): void;
+  /**
+   * 订阅 terminal cwd 变化. 回调返回 dispose 函数, 调用即取消订阅.
+   * 单个 listener 接收所有 panel 的事件 — 调用方按 panelId 过滤。
+   */
+  onCwdChange(cb: (event: TerminalCwdEvent) => void): () => void;
+  setActivePanelKind: (
+    kind: "terminal" | "web",
+    panelId: string | null
+  ) => void;
+  setFrame(panelId: string, frame: TerminalFrame): void;
+  setOverlayActive(active: boolean): void;
+  setup(): Promise<CreateTerminalResult>;
+  show(panelId: string): void;
+}
+```
+
+(注意 biome 要求 interface key 排序: close → create → focus → hide → onCwdChange → setActivePanelKind → setFrame → setOverlayActive → setup → show)
+
+- [ ] **Step 2: typecheck 看哪里炸**
+
+Run: `pnpm typecheck`
+Expected: FAIL — preload `terminalApi` 缺 onCwdChange 实现。这是下一个 task 修。
+
+- [ ] **Step 3: Commit (允许 typecheck 暂时红 — 是下一步要修的接口扩展, 不能拆得更小)**
+
+```bash
+git add src/shared/contracts/terminal.ts
+git commit -m "feat(contracts): TerminalAPI 增加 onCwdChange + TerminalCwdEvent
+
+跨进程 cwd 上报接口契约, preload/main 在后续 task 实现。"
+```
+
+---
+
+### Task 5: preload 实现 onCwdChange
+
+**Files:**
+- Modify: `src/preload/index.ts`
+
+- [ ] **Step 1: 加 onCwdChange 实现**
+
+修改 `src/preload/index.ts` 第 76-90 行 (terminalApi 定义) 末尾 (按 biome 排序加在 `setActivePanelKind` 前):
+
+```typescript
+const terminalApi: TerminalAPI = {
+  close: (panelId) => ipcRenderer.invoke("pier:terminal:close", panelId),
+  create: (args) => ipcRenderer.invoke("pier:terminal:create", args),
+  focus: (panelId) => ipcRenderer.send("pier:terminal:focus", panelId),
+  hide: (panelId) => ipcRenderer.send("pier:terminal:hide", panelId),
+  onCwdChange: (cb) => {
+    const listener = (
+      _event: unknown,
+      payload: { panelId: string; cwd: string }
+    ) => {
+      cb(payload);
+    };
+    ipcRenderer.on("pier:terminal:cwd-change", listener);
+    return () => {
+      ipcRenderer.off("pier:terminal:cwd-change", listener);
+    };
+  },
+  setActivePanelKind: (kind, panelId) =>
+    ipcRenderer.send("pier:terminal:set-active-panel-kind", kind, panelId),
+  setFrame: (panelId, frame) =>
+    ipcRenderer.send("pier:terminal:set-frame", panelId, frame),
+  setOverlayActive: (active) =>
+    ipcRenderer.send("pier:terminal:set-overlay", active),
+  setup: () => ipcRenderer.invoke("pier:terminal:setup"),
+  show: (panelId) => ipcRenderer.send("pier:terminal:show", panelId),
+};
+```
+
+- [ ] **Step 2: typecheck**
+
+Run: `pnpm typecheck`
+Expected: PASS (contract + preload 对齐)
+
+- [ ] **Step 3: lint**
+
+Run: `pnpm lint`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/preload/index.ts
+git commit -m "feat(preload): terminalApi.onCwdChange 接 ipcRenderer 订阅
+
+返回 dispose, 关闭 listener 走 ipcRenderer.off。"
+```
+
+---
+
+### Task 6: main IPC 注册 PWD forward callback (空通道先打通)
+
+**Files:**
+- Modify: `src/main/ipc/terminal.ts`
+
+- [ ] **Step 1: NativeAddon interface 加 setPwdForwardCallback**
+
+修改 `src/main/ipc/terminal.ts` 第 8-43 行 (NativeAddon interface), 在 setKeyboardForwardCallback 后加:
+
+```typescript
+interface NativeAddon {
+  closeAllTerminals(parentHandle: Buffer): void;
+  closeTerminal(panelId: string): void;
+  createTerminal(
+    parentHandle: Buffer,
+    panelId: string,
+    frame: TerminalFrame
+  ): boolean;
+  detachWindow(parentHandle: Buffer): void;
+  focusTerminal(panelId: string): void;
+  hideTerminal(panelId: string): void;
+  setActivePanelKind(
+    parentHandle: Buffer,
+    kindRaw: number,
+    panelId: string | null
+  ): void;
+  setFrame(panelId: string, frame: TerminalFrame): void;
+  setKeyboardForwardCallback(
+    cb:
+      | ((
+          browserWindowId: number,
+          modifierFlags: number,
+          chars: string
+        ) => void)
+      | null
+  ): void;
+  setOverlayActive(parentHandle: Buffer, active: boolean): void;
+  /**
+   * 注册 PWD forward callback. swift TerminalSurfacePwdDelegate 收到 OSC 7 后调用,
+   * 传 (browserWindowId, panelId, cwd). 用 windowId 路由到对应 BrowserWindow 的
+   * renderer (多窗口下避免广播污染). 传 null 解绑.
+   */
+  setPwdForwardCallback(
+    cb:
+      | ((browserWindowId: number, panelId: string, cwd: string) => void)
+      | null
+  ): void;
+  setupWindow(parentHandle: Buffer, browserWindowId: number): boolean;
+  showTerminal(panelId: string): void;
+}
+```
+
+- [ ] **Step 2: registerTerminalIpc 注册 PWD callback,转发到 IPC**
+
+在第 102 行 keyboard callback 注册之后加:
+
+```typescript
+  // 注册 PWD forward callback: swift TerminalSurfacePwdDelegate 收到 OSC 7 后,
+  // 通过 ThreadSafeFunction 调到这里. callback 收到 (browserWindowId, panelId, cwd),
+  // 用 windowId 精准路由到对应 BrowserWindow 的 renderer.
+  //
+  // 这是 terminal panel tab title / 系统 title 反映 cwd 的唯一通道. 不依赖
+  // proc_pidinfo polling — Ghostty 已经完整解析 OSC 7, 被动接收即可.
+  addon?.setPwdForwardCallback((browserWindowId, panelId, cwd) => {
+    try {
+      const targetWindow = BrowserWindow.fromId(browserWindowId);
+      if (!targetWindow || targetWindow.isDestroyed()) {
+        return;
+      }
+      const wc = targetWindow.webContents;
+      if (wc.isDestroyed()) {
+        return;
+      }
+      wc.send("pier:terminal:cwd-change", { panelId, cwd });
+    } catch (err) {
+      console.error("[pier-cwd-forward] send failed:", err);
+    }
+  });
+```
+
+- [ ] **Step 3: typecheck (会 fail — native addon 还没暴露这个方法,但接口契约对齐 main 自己的类型)**
+
+Run: `pnpm typecheck`
+Expected: PASS — interface 是 TS 侧声明, 实际 addon load 时如果 addon 没 method 会运行时 throw,这里只是 type-level pass.
+
+注意:`addon?.setPwdForwardCallback(...)` 是 optional chain — 即使运行时 addon 没这个方法也只是 noop,不 crash。完整可用要等 Task 7 加 C++ export。
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main/ipc/terminal.ts
+git commit -m "feat(main): main IPC 转发 PWD callback 到 cwd-change 事件
+
+照 keyboard forward 模板, 按 browserWindowId 路由到对应窗口
+renderer, 多窗口不污染。"
+```
+
+---
+
+### Task 7: native addon (addon.mm) 加 PWD forward 通道
+
+**Files:**
+- Modify: `native/src/addon.mm`
+
+- [ ] **Step 1: 加 C ABI 声明 + typedef**
+
+修改 `native/src/addon.mm` 第 6-25 行 (extern "C" 块):
+
+```cpp
+extern "C" {
+    bool ghostty_bridge_setup_window(void* nsWindow, long browserWindowId);
+    void ghostty_bridge_set_overlay_active(void* nsWindow, bool active);
+    bool ghostty_bridge_create_terminal(void* nsWindow, const char* panelId,
+                                         double x, double y, double w, double h);
+    void ghostty_bridge_set_frame(const char* panelId,
+                                   double x, double y, double w, double h);
+    void ghostty_bridge_show(const char* panelId);
+    void ghostty_bridge_hide(const char* panelId);
+    void ghostty_bridge_close(const char* panelId);
+    void ghostty_bridge_focus(const char* panelId);
+    void ghostty_bridge_close_all(void* nsWindow);
+    void ghostty_bridge_detach_window(void* nsWindow);
+    typedef void (*KeyboardForwardFn)(long browserWindowId, unsigned long modifiers, const char* chars);
+    void ghostty_bridge_set_keyboard_forward_callback(KeyboardForwardFn cb);
+    // PWD forward: swift PwdDelegate 收到 OSC 7 → 此 trampoline → JS.
+    // 签名 (browserWindowId, panelId UTF-8, cwd UTF-8).
+    typedef void (*PwdForwardFn)(long browserWindowId, const char* panelId, const char* cwd);
+    void ghostty_bridge_set_pwd_forward_callback(PwdForwardFn cb);
+    void ghostty_bridge_set_active_panel_kind(void* nsWindow, long kindRaw, const char* panelId);
+}
+```
+
+- [ ] **Step 2: 加 PWD trampoline + ThreadSafeFunction**
+
+在 keyboard trampoline 后 (第 147 行后, JsSetActivePanelKind 前) 插入:
+
+```cpp
+// ---- PWD forward callback (swift → main JS) ----
+//
+// swift TerminalSurfacePwdDelegate 收到 OSC 7 → forwardPwdCallback → 这里. 通过
+// ThreadSafeFunction 把事件分发到 main JS 线程, 让 JS 端注册的 callback 收到
+// (browserWindowId, panelId, cwd).
+//
+// 与 keyboard forward 同理:不能直接在 swift 线程调 napi function.
+static Napi::ThreadSafeFunction g_pwdTSFN;
+
+struct PwdForwardPayload {
+    long windowId;
+    std::string panelId;  // heap-owned (跨线程持久化)
+    std::string cwd;      // heap-owned
+};
+
+static void g_pwdForwardTrampoline(long windowId, const char* panelId, const char* cwd) {
+    if (!g_pwdTSFN) return;
+    auto* payload = new PwdForwardPayload{ windowId, std::string(panelId), std::string(cwd) };
+    auto status = g_pwdTSFN.BlockingCall(payload, [](Napi::Env env, Napi::Function jsCallback, PwdForwardPayload* p) {
+        jsCallback.Call({
+            Napi::Number::New(env, static_cast<double>(p->windowId)),
+            Napi::String::New(env, p->panelId),
+            Napi::String::New(env, p->cwd),
+        });
+        delete p;
+    });
+    if (status != napi_ok) {
+        delete payload;
+    }
+}
+
+static Napi::Value JsSetPwdForwardCallback(const Napi::CallbackInfo& info) {
+    Napi::Env env = info.Env();
+    if (info.Length() == 0 || info[0].IsNull() || info[0].IsUndefined()) {
+        if (g_pwdTSFN) {
+            g_pwdTSFN.Release();
+            g_pwdTSFN = Napi::ThreadSafeFunction();
+        }
+        ghostty_bridge_set_pwd_forward_callback(nullptr);
+        return env.Undefined();
+    }
+    Napi::Function jsFn = info[0].As<Napi::Function>();
+    if (g_pwdTSFN) g_pwdTSFN.Release();
+    g_pwdTSFN = Napi::ThreadSafeFunction::New(env, jsFn, "PierPwdForward", 0, 1);
+    ghostty_bridge_set_pwd_forward_callback(&g_pwdForwardTrampoline);
+    return env.Undefined();
+}
+```
+
+- [ ] **Step 3: Init 增加 exports**
+
+修改 Init 函数 (第 180-194 行), 在 setKeyboardForwardCallback 后加:
+
+```cpp
+static Napi::Object Init(Napi::Env env, Napi::Object exports) {
+    exports.Set("setupWindow",     Napi::Function::New(env, JsSetupWindow));
+    exports.Set("setOverlayActive", Napi::Function::New(env, JsSetOverlayActive));
+    exports.Set("createTerminal",  Napi::Function::New(env, JsCreateTerminal));
+    exports.Set("setFrame",        Napi::Function::New(env, JsSetFrame));
+    exports.Set("showTerminal",    Napi::Function::New(env, JsShow));
+    exports.Set("hideTerminal",    Napi::Function::New(env, JsHide));
+    exports.Set("closeTerminal",   Napi::Function::New(env, JsClose));
+    exports.Set("focusTerminal",   Napi::Function::New(env, JsFocus));
+    exports.Set("closeAllTerminals", Napi::Function::New(env, JsCloseAll));
+    exports.Set("detachWindow",    Napi::Function::New(env, JsDetachWindow));
+    exports.Set("setKeyboardForwardCallback", Napi::Function::New(env, JsSetKeyboardForwardCallback));
+    exports.Set("setPwdForwardCallback", Napi::Function::New(env, JsSetPwdForwardCallback));
+    exports.Set("setActivePanelKind", Napi::Function::New(env, JsSetActivePanelKind));
+    return exports;
+}
+```
+
+- [ ] **Step 4: rebuild native**
+
+Run:
+```bash
+cd native && bash build.sh && cd -
+```
+Expected: 编译成功 (无 unresolved symbol —— 即使 swift 端还没实现 `ghostty_bridge_set_pwd_forward_callback`,链接会 fail; 因此本 task 必须和 Task 8 紧邻提交)。
+
+- [ ] **Step 5: Commit (与 Task 8 合并提交以避免 build 红)**
+
+暂不 commit, 进入 Task 8 — 完成 swift 侧后一起提交。
+
+---
+
+### Task 8: swift 实现 PwdDelegate + C ABI export
+
+**Files:**
+- Modify: `native/Sources/GhosttyBridge/GhosttyBridge.swift`
+
+- [ ] **Step 1: Terminal struct 增加 delegate 字段**
+
+修改 `native/Sources/GhosttyBridge/GhosttyBridge.swift` 第 138-142 行:
+
+```swift
+// MARK: - Terminal record
+
+private struct Terminal {
+    let containerView: NSView
+    let terminalView: TerminalView
+    let parentWindow: NSWindow
+    /// PwdDelegate adapter (strong-hold — terminalView.delegate 是 weak).
+    /// 随 Terminal 一起释放, terminalView weak ref 自动 nil.
+    let pwdDelegate: TerminalPwdDelegate
+}
+```
+
+- [ ] **Step 2: 加 TerminalPwdDelegate adapter class**
+
+在 EventRouterView class 结束后 (约第 134 行) 插入:
+
+```swift
+// MARK: - PWD delegate adapter
+
+/// 实现 TerminalSurfacePwdDelegate, 每个 terminal 一个实例, 持有 panelId 用于
+/// 区分多 panel. cwd 变化时调全局 forwardPwdCallback 把 (panelId, path) 转给
+/// main process.
+///
+/// weak-set 到 terminalView.delegate, strong-hold 在 Terminal struct 中以保证
+/// 生命周期 (terminalView.delegate weak — 没 strong owner 会立即 nil).
+@MainActor
+final class TerminalPwdDelegate: TerminalSurfacePwdDelegate {
+    let panelId: String
+
+    /// 全局 callback: 收到 OSC 7 path 时调用, 把 (browserWindowId, panelId, path)
+    /// 转给 main process. browserWindowId 在 setupWindow 时记录, 由 GhosttyBridgeImpl
+    /// 反查 (panel 所属 NSWindow → browserWindowId 映射).
+    static var forwardPwdCallback: ((Int, String, String) -> Void)?
+
+    init(panelId: String) {
+        self.panelId = panelId
+    }
+
+    func terminalDidChangeWorkingDirectory(_ path: String) {
+        // browserWindowId 由 GhosttyBridgeImpl 通过 panelId 反查
+        guard let windowId = GhosttyBridgeImpl.shared.browserWindowId(forPanelId: panelId) else {
+            return
+        }
+        TerminalPwdDelegate.forwardPwdCallback?(windowId, panelId, path)
+    }
+}
+```
+
+- [ ] **Step 3: GhosttyBridgeImpl 加 browserWindowId 映射 + panelId 反查**
+
+修改 `GhosttyBridgeImpl` 类内, 在 `private var windowStates` 后 (约第 182 行) 加:
+
+```swift
+    /// panelId → browserWindowId 映射. createTerminal 时建立, close/closeAll 时清理.
+    /// PwdDelegate 收到 OSC 7 时需要反查 panel 所属窗口以路由 IPC.
+    private var panelIdToBrowserWindowId: [String: Int] = [:]
+
+    /// NSWindow → browserWindowId 映射. setupWindow 时建立, detachWindow 时清理.
+    /// createTerminal 用它把 panelId 关联到 browserWindowId.
+    private var windowToBrowserWindowId: [ObjectIdentifier: Int] = [:]
+
+    func browserWindowId(forPanelId panelId: String) -> Int? {
+        return panelIdToBrowserWindowId[panelId]
+    }
+```
+
+- [ ] **Step 4: setupWindow 记录 browserWindowId**
+
+修改 `setupWindow(parent:browserWindowId:)` 函数 (约第 208 行) 末尾, return true 前加:
+
+```swift
+        // 初始化 per-window keyboard state (PanelKind 默认 .web — 安全, 不抢 firstResponder)
+        windowStates[windowId] = WindowKeyboardState()
+
+        // 记录 browserWindowId 映射 — PwdDelegate 反查 panel→window→browserId 路由 IPC.
+        windowToBrowserWindowId[windowId] = browserWindowId
+
+        return true
+    }
+```
+
+- [ ] **Step 5: createTerminal 挂 delegate + 建 panelId→browserWindowId**
+
+修改 `createTerminal(parent:panelId:viewport:)` 函数 (约第 344 行), 在 `let terminalView = TerminalView(...)` 之后 + `terminals[panelId] = Terminal(...)` 之前:
+
+```swift
+        let terminalView = TerminalView(frame: NSRect(origin: .zero, size: frame.size))
+        terminalView.autoresizingMask = [.width, .height]
+        terminalView.configuration = TerminalSurfaceOptions(backend: .exec)
+        terminalView.controller = controller(for: parent)
+
+        // 挂 PwdDelegate — 接 OSC 7, 转发 (panelId, path) 给 main process.
+        let pwdDelegate = TerminalPwdDelegate(panelId: panelId)
+        terminalView.delegate = pwdDelegate
+
+        let container = NSView(frame: frame)
+        container.addSubview(terminalView)
+
+        // ... (contentView.addSubview 等不变)
+        contentView.addSubview(container, positioned: .below, relativeTo: nil)
+
+        terminals[panelId] = Terminal(
+            containerView: container,
+            terminalView: terminalView,
+            parentWindow: parent,
+            pwdDelegate: pwdDelegate
+        )
+
+        // 建立 panelId → browserWindowId 映射 (PwdDelegate 路由依赖)
+        let parentWindowId = ObjectIdentifier(parent)
+        if let bid = windowToBrowserWindowId[parentWindowId] {
+            panelIdToBrowserWindowId[panelId] = bid
+        }
+```
+
+- [ ] **Step 6: close / closeAll / detachWindow 清理映射**
+
+修改 `close(panelId:)` (约第 454 行), 在 `terminals.removeValue(forKey: panelId)` 后加:
+
+```swift
+    func close(panelId: String) {
+        guard let term = terminals[panelId] else { return }
+        let parent = term.parentWindow
+        term.containerView.removeFromSuperview()
+        terminals.removeValue(forKey: panelId)
+        panelIdToBrowserWindowId.removeValue(forKey: panelId)
+        if activePanelId == panelId { activePanelId = nil }
+        // ... 余下不变
+```
+
+修改 `closeAll(parent:)` (约第 492 行):
+
+```swift
+    func closeAll(parent: NSWindow) {
+        let windowId = ObjectIdentifier(parent)
+        let toClose = terminals.filter { ObjectIdentifier($0.value.parentWindow) == windowId }
+        for (panelId, term) in toClose {
+            term.containerView.removeFromSuperview()
+            terminals.removeValue(forKey: panelId)
+            panelIdToBrowserWindowId.removeValue(forKey: panelId)
+        }
+        if let activeId = activePanelId, terminals[activeId] == nil {
+            activePanelId = nil
+        }
+        eventRouters[windowId]?.targets.removeAll()
+    }
+```
+
+修改 `detachWindow(parent:)` (约第 512 行) 末尾:
+
+```swift
+        controllers.removeValue(forKey: windowId)
+        windowToBrowserWindowId.removeValue(forKey: windowId)
+    }
+```
+
+- [ ] **Step 7: 加 setPwdForwardCallback 方法**
+
+在 `setKeyboardForwardCallback` (约第 338 行) 后加:
+
+```swift
+    /// 注册 PWD forward callback: swift TerminalSurfacePwdDelegate 收到 OSC 7 后,
+    /// 把 (browserWindowId, panelId, cwd) 转给 main process. 与 keyboard forward
+    /// 路径同模式 (NSEvent monitor → C 函数指针 → N-API ThreadSafeFunction).
+    func setPwdForwardCallback(_ cb: @escaping (Int, String, String) -> Void) {
+        TerminalPwdDelegate.forwardPwdCallback = cb
+    }
+```
+
+- [ ] **Step 8: 加 C ABI export**
+
+在文件末尾 `ghosttyBridgeSetActivePanelKind` 前 (约第 654 行) 加:
+
+```swift
+/// C 函数指针类型: 接收 browserWindowId (Int), panelId UTF-8 C string, cwd UTF-8.
+public typealias PwdForwardCallback = @convention(c) (Int, UnsafePointer<CChar>, UnsafePointer<CChar>) -> Void
+
+@_cdecl("ghostty_bridge_set_pwd_forward_callback")
+public func ghosttyBridgeSetPwdForwardCallback(_ cb: PwdForwardCallback?) {
+    MainActor.assumeIsolated {
+        if let cb {
+            GhosttyBridgeImpl.shared.setPwdForwardCallback { wid, panelId, cwd in
+                panelId.withCString { pidPtr in
+                    cwd.withCString { cwdPtr in
+                        cb(wid, pidPtr, cwdPtr)
+                    }
+                }
+            }
+        } else {
+            GhosttyBridgeImpl.shared.setPwdForwardCallback { _, _, _ in }
+        }
+    }
+}
+```
+
+- [ ] **Step 9: rebuild native**
+
+Run:
+```bash
+cd native && bash build.sh && cd -
+```
+Expected: 编译成功, 无 unresolved symbol。`.node` 文件更新时间 = 现在。
+
+如失败:
+- swift "use of unresolved identifier `TerminalSurfacePwdDelegate`" → 确认 `import GhosttyTerminal` 在文件顶部 (已有)
+- "Type `TerminalPwdDelegate` does not conform to protocol" → check protocol 方法签名: `func terminalDidChangeWorkingDirectory(_ path: String)`,无 throws,无 return value
+- "Cannot find `Terminal` in scope" → struct 名同 `Terminal` 跟 `GhosttyTerminal.Terminal` 冲突,改名为 `PierTerminal` 或在 import 时 alias
+
+- [ ] **Step 10: typecheck (TS 应已无错 — addon 接口运行时绑定)**
+
+Run: `pnpm typecheck`
+Expected: PASS
+
+- [ ] **Step 11: Commit (合并 Task 7 + Task 8 的所有改动)**
+
+```bash
+git add native/src/addon.mm native/Sources/GhosttyBridge/GhosttyBridge.swift
+git commit -m "feat(native): swift + C++ 打通 PWD forward 通道
+
+- swift: TerminalPwdDelegate adapter 实现 TerminalSurfacePwdDelegate
+- swift: GhosttyBridgeImpl 维护 panelId/window → browserWindowId 映射
+- C++: g_pwdTSFN ThreadSafeFunction + JsSetPwdForwardCallback exports
+
+整个链路: OSC 7 → Ghostty parser → PwdDelegate → C trampoline → JS。"
+```
+
+---
+
+### Task 9: terminal-panel 订阅 onCwdChange + 推送 descriptor
+
+**Files:**
+- Modify: `src/renderer/panel-kits/terminal/terminal-panel.tsx`
+
+- [ ] **Step 1: 加 useState + useEffect 订阅,导出 basename helper**
+
+修改 `src/renderer/panel-kits/terminal/terminal-panel.tsx`:
+
+完整新文件 (替换原内容):
+
+```tsx
+import type { TerminalFrame } from "@shared/contracts/terminal.ts";
+import type { IDockviewPanelProps } from "dockview-react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { usePanelDescriptor } from "@/hooks/use-panel-descriptor.ts";
+
+function getAnchorFrame(anchor: HTMLDivElement): TerminalFrame | null {
+  const r = anchor.getBoundingClientRect();
+  if (r.width < 10 || r.height < 10) {
+    return null;
+  }
+  return { x: r.x, y: r.y, width: r.width, height: r.height };
+}
+
+function waitForRealSize(anchor: HTMLDivElement): Promise<void> {
+  return new Promise((resolve) => {
+    const check = () => {
+      const r = anchor.getBoundingClientRect();
+      if (r.width > 100 && r.height > 100) {
+        resolve();
+        return;
+      }
+      requestAnimationFrame(check);
+    };
+    check();
+  });
+}
+
+/**
+ * 路径 basename — POSIX 形式 (终端始终在 macOS). 末尾 '/' 容错处理:
+ * "/" → "/", "/a/b/" → "b", "/a/b" → "b".
+ */
+function basename(path: string): string {
+  if (path === "/" || path === "") return path || "Terminal";
+  const trimmed = path.endsWith("/") ? path.slice(0, -1) : path;
+  const idx = trimmed.lastIndexOf("/");
+  return idx === -1 ? trimmed : trimmed.slice(idx + 1);
+}
+
+export function TerminalPanel(props: IDockviewPanelProps) {
+  const { api } = props;
+  const panelId = api.id;
+  const anchorRef = useRef<HTMLDivElement>(null);
+  const parentRef = useRef<HTMLDivElement>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [cwd, setCwd] = useState<string | null>(null);
+
+  // 订阅 swift OSC 7 → main → 这里. cwd 变化时 setState 触发 descriptor 重新计算.
+  // 单 listener 接所有 panel 的事件 — 按 panelId 过滤.
+  useEffect(() => {
+    const dispose = window.pier.terminal.onCwdChange((event) => {
+      if (event.panelId === panelId) {
+        setCwd(event.cwd);
+      }
+    });
+    return dispose;
+  }, [panelId]);
+
+  // 把 cwd 翻译成 descriptor 三字段:
+  // - short:basename(cwd) — tab strip
+  // - long:cwd — sink 长形式 (但 resolveLong 会优先用 path)
+  // - path:cwd — sink 优先消费, 也是未来 breadcrumb / status bar 用的字段
+  // 没 cwd 时 fallback "Terminal" (只填 short, 不传 long/path).
+  usePanelDescriptor(
+    api,
+    cwd
+      ? { short: basename(cwd), long: cwd, path: cwd }
+      : { short: "Terminal" }
+  );
+
+  useLayoutEffect(() => {
+    const parent = parentRef.current?.parentElement;
+    const anchor = anchorRef.current;
+    if (!(parent && anchor)) {
+      return;
+    }
+
+    const sync = () => {
+      anchor.style.width = `${parent.clientWidth}px`;
+      anchor.style.height = `${parent.clientHeight}px`;
+    };
+    sync();
+
+    const ro = new ResizeObserver(sync);
+    ro.observe(parent);
+    return () => ro.disconnect();
+  }, []);
+
+  useEffect(() => {
+    const anchor = anchorRef.current;
+    if (!anchor) {
+      return;
+    }
+
+    let disposed = false;
+    const subscriptions: Array<{ dispose(): void }> = [];
+    let lastFrame = "";
+
+    const sendFrameNow = () => {
+      if (disposed) {
+        return;
+      }
+      const frame = getAnchorFrame(anchor);
+      if (!frame) {
+        return;
+      }
+      const key = `${frame.x},${frame.y},${frame.width},${frame.height}`;
+      if (key === lastFrame) {
+        return;
+      }
+      lastFrame = key;
+      window.pier.terminal.setFrame(panelId, frame);
+    };
+
+    let rafId = 0;
+    const scheduleSync = () => {
+      if (rafId) {
+        return;
+      }
+      rafId = requestAnimationFrame(() => {
+        rafId = 0;
+        sendFrameNow();
+      });
+    };
+
+    const init = async () => {
+      await waitForRealSize(anchor);
+      if (disposed) {
+        return;
+      }
+
+      const frame = getAnchorFrame(anchor);
+      if (!frame) {
+        setError("无法获取面板坐标");
+        return;
+      }
+
+      const result = await window.pier.terminal.create({ panelId, frame });
+      if (!result.ok) {
+        setError(result.error ?? "终端创建失败");
+        return;
+      }
+
+      subscriptions.push(
+        api.onDidVisibilityChange((e) => {
+          if (e.isVisible) {
+            lastFrame = "";
+            sendFrameNow();
+            window.pier.terminal.show(panelId);
+          } else {
+            requestAnimationFrame(() => {
+              requestAnimationFrame(() => {
+                if (!disposed) {
+                  window.pier.terminal.hide(panelId);
+                }
+              });
+            });
+          }
+        })
+      );
+
+      subscriptions.push(
+        api.onDidActiveChange((e) => {
+          if (e.isActive) {
+            window.pier.terminal.focus(panelId);
+          }
+        })
+      );
+
+      const parent = anchor.parentElement;
+      if (parent) {
+        const ro = new ResizeObserver(scheduleSync);
+        ro.observe(parent);
+        subscriptions.push({ dispose: () => ro.disconnect() });
+      }
+
+      const onWindowResize = () => sendFrameNow();
+      window.addEventListener("resize", onWindowResize);
+      subscriptions.push({
+        dispose: () => window.removeEventListener("resize", onWindowResize),
+      });
+    };
+
+    init();
+
+    return () => {
+      disposed = true;
+      if (rafId) {
+        cancelAnimationFrame(rafId);
+      }
+      for (const s of subscriptions) {
+        s.dispose();
+      }
+      window.pier.terminal.close(panelId);
+    };
+  }, [api, panelId]);
+
+  if (error) {
+    return (
+      <div className="flex h-full items-center justify-center bg-background">
+        <p className="text-muted-foreground text-sm">{error}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full" ref={parentRef}>
+      <div className="terminal-anchor" ref={anchorRef} />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: typecheck**
+
+Run: `pnpm typecheck`
+Expected: PASS
+
+- [ ] **Step 3: lint**
+
+Run: `pnpm lint`
+Expected: PASS
+
+- [ ] **Step 4: 单元测试 basename (TDD)**
+
+补充 `tests/unit/cwd-derive.test.ts`:
+
+```typescript
+// 文件顶部 import:
+import { basename } from "../../src/renderer/panel-kits/terminal/terminal-panel.tsx";
+```
+
+但 basename 现在是 module-local 不 export — 让步骤 1 中 basename 改成 `export function basename`。
+
+加测试:
+
+```typescript
+describe("basename", () => {
+  it('handles "/"', () => {
+    expect(basename("/")).toBe("/");
+  });
+  it("strips trailing slash", () => {
+    expect(basename("/a/b/")).toBe("b");
+  });
+  it("returns last segment", () => {
+    expect(basename("/Users/x/ABC/pier")).toBe("pier");
+  });
+  it("returns input if no slash", () => {
+    expect(basename("pier")).toBe("pier");
+  });
+  it('fallback "Terminal" for empty', () => {
+    expect(basename("")).toBe("Terminal");
+  });
+});
+```
+
+Run: `pnpm test:unit cwd-derive`
+Expected: PASS, 8 tests (3 resolveLong + 5 basename)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/renderer/panel-kits/terminal/terminal-panel.tsx tests/unit/cwd-derive.test.ts
+git commit -m "feat(terminal): panel 订阅 onCwdChange 推 descriptor
+
+basename + cwd 推 short/long/path; cwd 未到达时 fallback Terminal。"
+```
+
+---
+
+### Task 10: 跨语言完整 check + 手动验证
+
+**Files:**
+- 无修改 (验证阶段)
+
+- [ ] **Step 1: 确认 native 已 rebuild**
+
+Run:
+```bash
+ls -la native/build/Release/ghostty_native.node
+```
+Expected: 文件存在,mtime 是 Task 7+8 完成时刻。否则:
+
+```bash
+cd native && bash build.sh && cd -
+```
+
+- [ ] **Step 2: 完整 check**
+
+Run: `pnpm check`
+Expected: typecheck / lint / depcruise / file-size 全绿
+
+- [ ] **Step 3: 运行单元测试**
+
+Run: `pnpm test:unit`
+Expected: 全绿,8+ 个 cwd / descriptor 相关测试 pass
+
+- [ ] **Step 4: 启动 Electron 手动 verify**
+
+Run: `pnpm dev`
+
+操作清单:
+1. 启动后窗口出现 — tab title 应显示 "Terminal" (cwd 未到达, fallback)
+2. 在 terminal 里执行 `cd /tmp` — **预期** tab title 变 "tmp", document.title 变 "/tmp — Pier", macOS titlebar 同步
+3. 再 `cd ~/ABC/pier` — tab title 变 "pier", document.title 变 "/Users/.../pier — Pier"
+4. 开第二个 terminal panel,在它里面 cd 到别处 — 两个 tab 各自更新,互不干扰
+
+**如果第 2 步 tab title 没变**(常见):
+- 打开 dev tools 看 renderer console — 有没有 `pier:terminal:cwd-change` 事件到达
+  - 无 → 说明链路上游没发,继续追
+- 打开 main 进程 log — `addon.setPwdForwardCallback` callback 内有没有 print
+  - 加 `console.log("[pier-cwd-forward] received", panelId, cwd);` 临时调试
+  - 无 → 说明 swift 端 PwdDelegate 没收到 → **OSC 7 未发**,跳到 Task 11
+
+- [ ] **Step 5: 如所有验证通过, Commit verify 笔记**
+
+无文件改动则跳过 commit。验证结果记在下一 step 决定是否 Task 11。
+
+---
+
+### Task 11 (条件): shell-integration env 注入
+
+**前置条件**:Task 10 step 4 验证发现 OSC 7 未发到 swift (cwd-change 事件根本不触发)。
+
+如果验证通过,跳过本 task。
+
+**Files:**
+- Modify: `native/Sources/GhosttyBridge/GhosttyBridge.swift` (createTerminal 内)
+
+- [ ] **Step 1: 查 GhosttyKit shell-integration env 注入接口**
+
+Run:
+```bash
+grep -rE "shellIntegration|XDG_DATA_DIRS|GHOSTTY_RESOURCES" /Users/xyz/ABC/pier/.claude/worktrees/vigorous-wilson-616700/native/.build/checkouts/libghostty-spm/Sources/GhosttyTerminal --include="*.swift" | head -20
+```
+
+预期发现 `TerminalSurfaceOptions` 上有 `envInject` / `shellIntegration` 之类 toggle。
+
+- [ ] **Step 2: 启用 shell-integration**
+
+修改 `createTerminal(...)` 内 `TerminalSurfaceOptions(backend: .exec)` 这一行,根据 step 1 找到的 API 改成显式启用 (具体字段名以 grep 结果为准, 常见命名:`shellIntegrationFeatures` / `shellIntegration: .auto`)。
+
+示例 (具体字段须按 grep 结果对齐):
+
+```swift
+terminalView.configuration = TerminalSurfaceOptions(
+    backend: .exec,
+    shellIntegration: .auto  // 或对应字段
+)
+```
+
+- [ ] **Step 3: rebuild + verify**
+
+Run:
+```bash
+cd native && bash build.sh && cd -
+pnpm dev
+```
+
+再次执行 Task 10 step 4 的验证清单。
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add native/Sources/GhosttyBridge/GhosttyBridge.swift
+git commit -m "feat(terminal): 默认启用 Ghostty shell-integration
+
+让 OSC 7 cwd 上报自动生效, 不依赖用户 shell rc 手配。"
+```
+
+---
+
+## 验证清单 (整体)
+
+执行完所有 task 后, 用以下清单验证:
+
+- [ ] `pnpm check` 全绿
+- [ ] `pnpm test:unit` cwd / descriptor / basename 测试全 pass
+- [ ] `pnpm dev` 启动后,首次显示 "Terminal" (cwd 未到达 fallback)
+- [ ] 在 terminal 里 `cd /tmp` 后:
+  - dockview tab 显示 "tmp"
+  - 浏览器/Electron 窗口 title 显示 "/tmp — Pier"
+  - macOS hiddenInset titlebar 显示 "/tmp"
+- [ ] 开第二个 terminal panel,两个 tab cwd 独立更新
+- [ ] 关闭一个 terminal panel,store 自动清理 descriptor,active 切换时另一个 tab 接管 title
+
+---
+
+## 风险与回退点
+
+| 风险 | 触发症状 | 回退 |
+|---|---|---|
+| Ghostty `TerminalSurfacePwdDelegate` 在当前 libghostty-spm 版本签名不一致 | swift build fail | check `.build/checkouts/libghostty-spm/Sources/GhosttyTerminal/Surface/TerminalSurfaceViewDelegate.swift` 实际 signature, 调整 Task 8 step 2 |
+| OSC 7 不发(shell 不支持) | Task 10 step 4 cwd 永不更新 | Task 11 (shell-integration env) 或 fallback proc_pidinfo polling (后续 PR) |
+| `terminalView.delegate` weak 释放后 dangling | runtime crash 在 OSC 7 触发时 | 确认 Task 8 step 1 Terminal struct 持有 pwdDelegate strong ref |
+| multi-window 路由错 | 多窗口下 cwd 串台 | 确认 Task 8 step 3-6 panelId→browserWindowId 映射 + cleanup 完整 |
+
+---
+
+## 完成后下一步 (out of scope)
+
+- 接 OSC 0/2 title(`TerminalSurfaceTitleDelegate`) — 让 `claude` / `vim` 等自定义 title 也走 descriptor
+- 接前台进程名(macOS proc_pidinfo) — OSC 7 fallback / 互补
+- 多 tab 同名 cwd 时加 `#1 #2` 后缀
+- Inline rename (双击 tab 编辑) → 写到 descriptor.short user override

--- a/native/Sources/GhosttyBridge/GhosttyBridge.swift
+++ b/native/Sources/GhosttyBridge/GhosttyBridge.swift
@@ -135,13 +135,18 @@ final class EventRouterView: NSView {
 
 // MARK: - Terminal event delegate adapter
 
-/// 同时实现 PwdDelegate + TitleDelegate, 每个 terminal 一个实例, 持有 panelId 用于
-/// 区分多 panel. 利用 libghostty callbackBridge 的动态转型机制 (`as? any Protocol`),
-/// 单个 delegate 对象可被同时识别为多个 protocol — 因此可挂多个事件类型而 delegate
-/// 槽位只占用一个 (TerminalView.delegate 是单一 weak ref).
+/// 同时实现 PwdDelegate + TitleDelegate, 每个 terminal 一个实例, 持有 panelId
+/// + browserWindowId 用于事件路由. 利用 libghostty callbackBridge 的动态转型机制
+/// (`as? any Protocol`), 单个 delegate 对象可被同时识别为多个 protocol — 因此可
+/// 挂多个事件类型而 delegate 槽位只占用一个 (TerminalView.delegate 是单一 weak ref).
 ///
 /// 后续 bell / focus / close / progress 等都可挂到这个 class — 只需 conform 对应
 /// protocol 并加 forward callback 通道.
+///
+/// 自持 browserWindowId 而非全局反查:panelId 在 Pier 中不保证跨窗口唯一
+/// (workspace-host default layout 都用 "terminal-1"), 用全局 panelId→windowId map
+/// 会被后建立的同名 panel 覆盖, 事件路由到错窗口. delegate 跟随 Terminal 生命周期,
+/// 创建时确定路由目标, 干净无歧义.
 ///
 /// weak-set 到 terminalView.delegate, strong-hold 在 Terminal struct 中以保证
 /// 生命周期 (terminalView.delegate 是 weak — 没 strong owner 会立即 nil).
@@ -150,10 +155,10 @@ final class TerminalEventDelegate: TerminalSurfacePwdDelegate,
     TerminalSurfaceTitleDelegate
 {
     let panelId: String
+    let browserWindowId: Int
 
     /// 全局 callback: 收到 OSC 7 path 时调用, 把 (browserWindowId, panelId, path)
-    /// 转给 main process. browserWindowId 由 GhosttyBridgeImpl 通过 panelId 反查
-    /// (panel 所属 NSWindow → browserWindowId 映射).
+    /// 转给 main process.
     static var forwardPwdCallback: ((Int, String, String) -> Void)?
 
     /// 全局 callback: 收到 OSC 0/2 title 时调用, 把 (browserWindowId, panelId, title)
@@ -161,22 +166,17 @@ final class TerminalEventDelegate: TerminalSurfacePwdDelegate,
     /// title — descriptor.long 的最高优先级来源.
     static var forwardTitleCallback: ((Int, String, String) -> Void)?
 
-    init(panelId: String) {
+    init(panelId: String, browserWindowId: Int) {
         self.panelId = panelId
+        self.browserWindowId = browserWindowId
     }
 
     func terminalDidChangeWorkingDirectory(_ path: String) {
-        guard let windowId = GhosttyBridgeImpl.shared.browserWindowId(forPanelId: panelId) else {
-            return
-        }
-        TerminalEventDelegate.forwardPwdCallback?(windowId, panelId, path)
+        TerminalEventDelegate.forwardPwdCallback?(browserWindowId, panelId, path)
     }
 
     func terminalDidChangeTitle(_ title: String) {
-        guard let windowId = GhosttyBridgeImpl.shared.browserWindowId(forPanelId: panelId) else {
-            return
-        }
-        TerminalEventDelegate.forwardTitleCallback?(windowId, panelId, title)
+        TerminalEventDelegate.forwardTitleCallback?(browserWindowId, panelId, title)
     }
 }
 
@@ -231,17 +231,9 @@ final class GhosttyBridgeImpl {
     // per-window state, 跟 eventRouters 一样用 ObjectIdentifier(window) 作 key
     private var windowStates: [ObjectIdentifier: WindowKeyboardState] = [:]
 
-    /// panelId → browserWindowId 映射. createTerminal 时建立, close/closeAll 时清理.
-    /// PwdDelegate 收到 OSC 7 时需要反查 panel 所属窗口以路由 IPC.
-    private var panelIdToBrowserWindowId: [String: Int] = [:]
-
     /// NSWindow → browserWindowId 映射. setupWindow 时建立, detachWindow 时清理.
-    /// createTerminal 用它把 panelId 关联到 browserWindowId.
+    /// createTerminal 用它给 TerminalEventDelegate 初始化 browserWindowId.
     private var windowToBrowserWindowId: [ObjectIdentifier: Int] = [:]
-
-    func browserWindowId(forPanelId panelId: String) -> Int? {
-        return panelIdToBrowserWindowId[panelId]
-    }
 
     func stateFor(window: NSWindow) -> WindowKeyboardState {
         return windowStates[ObjectIdentifier(window)] ?? WindowKeyboardState()
@@ -439,7 +431,13 @@ final class GhosttyBridgeImpl {
 
         // 挂 EventDelegate — 同时接 OSC 7 (PwdDelegate) + OSC 0/2 (TitleDelegate).
         // delegate 是 weak ref, Terminal struct strong-hold eventDelegate 保证生命周期.
-        let eventDelegate = TerminalEventDelegate(panelId: panelId)
+        // browserWindowId 创建时固定 — panelId 跨窗口可能同名, 不能靠 panelId 全局反查.
+        let parentWindowId = ObjectIdentifier(parent)
+        let browserWindowId = windowToBrowserWindowId[parentWindowId] ?? -1
+        let eventDelegate = TerminalEventDelegate(
+            panelId: panelId,
+            browserWindowId: browserWindowId
+        )
         terminalView.delegate = eventDelegate
 
         // Container 只是 frame holder, 自身不绘制. terminalView 内的 IOSurfaceLayer
@@ -472,11 +470,6 @@ final class GhosttyBridgeImpl {
         eventRouters[windowId]?.targets[panelId] = EventRouterView.Target(
             rect: frame.insetBy(dx: Self.hitInset, dy: Self.hitInset), view: terminalView
         )
-
-        // 建立 panelId → browserWindowId 映射 (PwdDelegate 路由依赖)
-        if let bid = windowToBrowserWindowId[windowId] {
-            panelIdToBrowserWindowId[panelId] = bid
-        }
 
         activePanelId = panelId
 
@@ -547,7 +540,6 @@ final class GhosttyBridgeImpl {
         let parent = term.parentWindow
         term.containerView.removeFromSuperview()
         terminals.removeValue(forKey: panelId)
-        panelIdToBrowserWindowId.removeValue(forKey: panelId)
         if activePanelId == panelId { activePanelId = nil }
 
         let windowId = ObjectIdentifier(parent)
@@ -587,7 +579,6 @@ final class GhosttyBridgeImpl {
         for (panelId, term) in toClose {
             term.containerView.removeFromSuperview()
             terminals.removeValue(forKey: panelId)
-            panelIdToBrowserWindowId.removeValue(forKey: panelId)
         }
         if let activeId = activePanelId, terminals[activeId] == nil {
             activePanelId = nil

--- a/native/Sources/GhosttyBridge/GhosttyBridge.swift
+++ b/native/Sources/GhosttyBridge/GhosttyBridge.swift
@@ -439,41 +439,17 @@ final class GhosttyBridgeImpl {
         // 时调 webContents.focus() 让 Chromium 自己 dispatch.
     }
 
-    /// 注册 keyboard forward callback: swift NSEvent monitor 捕获 Cmd+key 后, 通过
-    /// 这个 callback 把 (modifier flags, characters) 转给 main process. main 接收
-    /// 后再通过 IPC 通知 renderer 解析 chord 调对应 action.
-    ///
-    /// 整个链路: 用户按 Cmd+T → NSEvent monitor → EventRouterView.routeKeyDown
-    /// → forwardCmdKeyCallback (本回调) → N-API ThreadSafeFunction → main JS →
-    /// win.webContents.send("pier:keybinding:forward") → preload listener → renderer
-    /// 用 chord 找 action 调用 handler.
-    ///
-    /// 这条路径完全绕开 NSView responder chain (Ghostty terminal focus 时它消费
-    /// 所有 key 是 wk.keyDown forward 不可靠的根因).
-    func setKeyboardForwardCallback(_ cb: @escaping (Int, UInt, String) -> Void) {
-        EventRouterView.forwardCmdKeyCallback = cb
-    }
-
-    /// 注册右键事件 forward callback. 与 keyboard 同构: swift EventRouterView 拦到
-    /// terminal 区域 rightMouseDown 后, 通过此 callback 把 (windowId, panelId, x, y)
-    /// 转给 main, main IPC 通知 renderer 弹菜单.
-    func setMouseForwardCallback(_ cb: @escaping (Int, String, Double, Double) -> Void) {
-        EventRouterView.forwardRightMouseCallback = cb
-    }
-
-    /// 注册 PWD forward callback: swift TerminalSurfacePwdDelegate 收到 OSC 7 后,
-    /// 把 (browserWindowId, panelId, cwd) 转给 main process. 与 keyboard forward
-    /// 路径同模式 (EventDelegate → C 函数指针 → N-API ThreadSafeFunction).
-    func setPwdForwardCallback(_ cb: @escaping (Int, String, String) -> Void) {
-        TerminalEventDelegate.forwardPwdCallback = cb
-    }
-
-    /// 注册 Title forward callback: swift TerminalSurfaceTitleDelegate 收到 OSC 0/2 后,
-    /// 把 (browserWindowId, panelId, title) 转给 main process. TUI 应用 (claude / vim)
-    /// 的自定义 title 通道, 与 PWD 同模式.
-    func setTitleForwardCallback(_ cb: @escaping (Int, String, String) -> Void) {
-        TerminalEventDelegate.forwardTitleCallback = cb
-    }
+    // Forward callback 注册 — 不经 GhosttyBridgeImpl 中间层. 整条 forward 链:
+    //
+    //   swift 输入 (NSEvent monitor / Ghostty delegate)
+    //   → EventRouterView.forwardCmd­Key/RightMouseCallback (输入事件)
+    //   或 TerminalEventDelegate.forwardPwd/TitleCallback (Ghostty 输出事件)
+    //   → C 函数指针 trampoline (C ABI export 持有)
+    //   → N-API ThreadSafeFunction (addon.mm 持有)
+    //   → main JS callback → webContents.send → renderer.
+    //
+    // EventRouterView / TerminalEventDelegate 的 static var 就是 forward 的源头,
+    // C ABI export 直接赋值过去 — 没有"impl method 转一层 static var"的中间步骤.
 
     // MARK: - Terminal lifecycle
 
@@ -815,48 +791,45 @@ public func ghosttyBridgeDetachWindow(_ nsWindowPtr: UnsafeMutableRawPointer) {
     }
 }
 
-/// C 函数指针类型: 接收 browserWindowId (Int), modifier flags (raw UInt), characters
-/// (C string UTF-8). addon.mm 包装成 ThreadSafeFunction 让 JS 端能安全接收.
+// C 函数指针 typealias 集中放在一起 — addon.mm 通过 ThreadSafeFunction 包装让
+// JS 端能安全接收. C string 在 @_cdecl 内 withCString 取临时指针调用 cb, cb 返回
+// 后字符串生命周期结束 (addon.mm 端 trampoline 已 std::string 拷贝, 不会 dangling).
 public typealias KeyboardForwardCallback = @convention(c) (Int, UInt, UnsafePointer<CChar>) -> Void
+public typealias MouseForwardCallback = @convention(c) (Int, UnsafePointer<CChar>, Double, Double) -> Void
+public typealias PwdForwardCallback = @convention(c) (Int, UnsafePointer<CChar>, UnsafePointer<CChar>) -> Void
+public typealias TitleForwardCallback = @convention(c) (Int, UnsafePointer<CChar>, UnsafePointer<CChar>) -> Void
 
 @_cdecl("ghostty_bridge_set_keyboard_forward_callback")
 public func ghosttyBridgeSetKeyboardForwardCallback(_ cb: KeyboardForwardCallback?) {
     MainActor.assumeIsolated {
         if let cb {
-            GhosttyBridgeImpl.shared.setKeyboardForwardCallback { wid, mods, chars in
+            EventRouterView.forwardCmdKeyCallback = { wid, mods, chars in
                 chars.withCString { ptr in cb(wid, mods, ptr) }
             }
         } else {
-            GhosttyBridgeImpl.shared.setKeyboardForwardCallback { _, _, _ in }
+            EventRouterView.forwardCmdKeyCallback = nil
         }
     }
 }
-
-/// C 函数指针: (browserWindowId, panelId C string, x, y).
-public typealias MouseForwardCallback = @convention(c) (Int, UnsafePointer<CChar>, Double, Double) -> Void
 
 @_cdecl("ghostty_bridge_set_mouse_forward_callback")
 public func ghosttyBridgeSetMouseForwardCallback(_ cb: MouseForwardCallback?) {
     MainActor.assumeIsolated {
         if let cb {
-            GhosttyBridgeImpl.shared.setMouseForwardCallback { wid, panelId, x, y in
+            EventRouterView.forwardRightMouseCallback = { wid, panelId, x, y in
                 panelId.withCString { ptr in cb(wid, ptr, x, y) }
             }
         } else {
-            GhosttyBridgeImpl.shared.setMouseForwardCallback { _, _, _, _ in }
+            EventRouterView.forwardRightMouseCallback = nil
         }
     }
 }
-
-/// C 函数指针类型: 接收 browserWindowId (Int), panelId UTF-8 C string, cwd UTF-8.
-/// addon.mm 包装成 ThreadSafeFunction 让 JS 端能安全接收.
-public typealias PwdForwardCallback = @convention(c) (Int, UnsafePointer<CChar>, UnsafePointer<CChar>) -> Void
 
 @_cdecl("ghostty_bridge_set_pwd_forward_callback")
 public func ghosttyBridgeSetPwdForwardCallback(_ cb: PwdForwardCallback?) {
     MainActor.assumeIsolated {
         if let cb {
-            GhosttyBridgeImpl.shared.setPwdForwardCallback { wid, panelId, cwd in
+            TerminalEventDelegate.forwardPwdCallback = { wid, panelId, cwd in
                 panelId.withCString { pidPtr in
                     cwd.withCString { cwdPtr in
                         cb(wid, pidPtr, cwdPtr)
@@ -864,19 +837,16 @@ public func ghosttyBridgeSetPwdForwardCallback(_ cb: PwdForwardCallback?) {
                 }
             }
         } else {
-            GhosttyBridgeImpl.shared.setPwdForwardCallback { _, _, _ in }
+            TerminalEventDelegate.forwardPwdCallback = nil
         }
     }
 }
-
-/// C 函数指针类型: 接收 browserWindowId (Int), panelId UTF-8, title UTF-8.
-public typealias TitleForwardCallback = @convention(c) (Int, UnsafePointer<CChar>, UnsafePointer<CChar>) -> Void
 
 @_cdecl("ghostty_bridge_set_title_forward_callback")
 public func ghosttyBridgeSetTitleForwardCallback(_ cb: TitleForwardCallback?) {
     MainActor.assumeIsolated {
         if let cb {
-            GhosttyBridgeImpl.shared.setTitleForwardCallback { wid, panelId, title in
+            TerminalEventDelegate.forwardTitleCallback = { wid, panelId, title in
                 panelId.withCString { pidPtr in
                     title.withCString { titlePtr in
                         cb(wid, pidPtr, titlePtr)
@@ -884,7 +854,7 @@ public func ghosttyBridgeSetTitleForwardCallback(_ cb: TitleForwardCallback?) {
                 }
             }
         } else {
-            GhosttyBridgeImpl.shared.setTitleForwardCallback { _, _, _ in }
+            TerminalEventDelegate.forwardTitleCallback = nil
         }
     }
 }

--- a/native/Sources/GhosttyBridge/GhosttyBridge.swift
+++ b/native/Sources/GhosttyBridge/GhosttyBridge.swift
@@ -133,22 +133,33 @@ final class EventRouterView: NSView {
     }
 }
 
-// MARK: - PWD delegate adapter
+// MARK: - Terminal event delegate adapter
 
-/// 实现 TerminalSurfacePwdDelegate, 每个 terminal 一个实例, 持有 panelId 用于
-/// 区分多 panel. cwd 变化时调全局 forwardPwdCallback 把 (panelId, path) 转给
-/// main process.
+/// 同时实现 PwdDelegate + TitleDelegate, 每个 terminal 一个实例, 持有 panelId 用于
+/// 区分多 panel. 利用 libghostty callbackBridge 的动态转型机制 (`as? any Protocol`),
+/// 单个 delegate 对象可被同时识别为多个 protocol — 因此可挂多个事件类型而 delegate
+/// 槽位只占用一个 (TerminalView.delegate 是单一 weak ref).
+///
+/// 后续 bell / focus / close / progress 等都可挂到这个 class — 只需 conform 对应
+/// protocol 并加 forward callback 通道.
 ///
 /// weak-set 到 terminalView.delegate, strong-hold 在 Terminal struct 中以保证
 /// 生命周期 (terminalView.delegate 是 weak — 没 strong owner 会立即 nil).
 @MainActor
-final class TerminalPwdDelegate: TerminalSurfacePwdDelegate {
+final class TerminalEventDelegate: TerminalSurfacePwdDelegate,
+    TerminalSurfaceTitleDelegate
+{
     let panelId: String
 
     /// 全局 callback: 收到 OSC 7 path 时调用, 把 (browserWindowId, panelId, path)
     /// 转给 main process. browserWindowId 由 GhosttyBridgeImpl 通过 panelId 反查
     /// (panel 所属 NSWindow → browserWindowId 映射).
     static var forwardPwdCallback: ((Int, String, String) -> Void)?
+
+    /// 全局 callback: 收到 OSC 0/2 title 时调用, 把 (browserWindowId, panelId, title)
+    /// 转给 main process. TUI 应用 (claude / vim / aider) 主动通过 OSC 0/2 写自定义
+    /// title — descriptor.long 的最高优先级来源.
+    static var forwardTitleCallback: ((Int, String, String) -> Void)?
 
     init(panelId: String) {
         self.panelId = panelId
@@ -158,7 +169,14 @@ final class TerminalPwdDelegate: TerminalSurfacePwdDelegate {
         guard let windowId = GhosttyBridgeImpl.shared.browserWindowId(forPanelId: panelId) else {
             return
         }
-        TerminalPwdDelegate.forwardPwdCallback?(windowId, panelId, path)
+        TerminalEventDelegate.forwardPwdCallback?(windowId, panelId, path)
+    }
+
+    func terminalDidChangeTitle(_ title: String) {
+        guard let windowId = GhosttyBridgeImpl.shared.browserWindowId(forPanelId: panelId) else {
+            return
+        }
+        TerminalEventDelegate.forwardTitleCallback?(windowId, panelId, title)
     }
 }
 
@@ -168,9 +186,10 @@ private struct Terminal {
     let containerView: NSView
     let terminalView: TerminalView
     let parentWindow: NSWindow
-    /// PwdDelegate adapter (strong-hold — terminalView.delegate 是 weak).
-    /// 随 Terminal 一起释放, terminalView weak ref 自动 nil, 不留 dangling.
-    let pwdDelegate: TerminalPwdDelegate
+    /// EventDelegate adapter (strong-hold — terminalView.delegate 是 weak).
+    /// 同时实现 PwdDelegate + TitleDelegate. 随 Terminal 一起释放, terminalView
+    /// weak ref 自动 nil, 不留 dangling.
+    let eventDelegate: TerminalEventDelegate
 }
 
 // MARK: - Bridge implementation
@@ -388,9 +407,16 @@ final class GhosttyBridgeImpl {
 
     /// 注册 PWD forward callback: swift TerminalSurfacePwdDelegate 收到 OSC 7 后,
     /// 把 (browserWindowId, panelId, cwd) 转给 main process. 与 keyboard forward
-    /// 路径同模式 (PwdDelegate → C 函数指针 → N-API ThreadSafeFunction).
+    /// 路径同模式 (EventDelegate → C 函数指针 → N-API ThreadSafeFunction).
     func setPwdForwardCallback(_ cb: @escaping (Int, String, String) -> Void) {
-        TerminalPwdDelegate.forwardPwdCallback = cb
+        TerminalEventDelegate.forwardPwdCallback = cb
+    }
+
+    /// 注册 Title forward callback: swift TerminalSurfaceTitleDelegate 收到 OSC 0/2 后,
+    /// 把 (browserWindowId, panelId, title) 转给 main process. TUI 应用 (claude / vim)
+    /// 的自定义 title 通道, 与 PWD 同模式.
+    func setTitleForwardCallback(_ cb: @escaping (Int, String, String) -> Void) {
+        TerminalEventDelegate.forwardTitleCallback = cb
     }
 
     // MARK: - Terminal lifecycle
@@ -411,10 +437,10 @@ final class GhosttyBridgeImpl {
         terminalView.configuration = TerminalSurfaceOptions(backend: .exec)
         terminalView.controller = controller(for: parent)
 
-        // 挂 PwdDelegate — 接 OSC 7, 转发 (panelId, path) 给 main process.
-        // delegate 是 weak ref, Terminal struct strong-hold pwdDelegate 保证生命周期.
-        let pwdDelegate = TerminalPwdDelegate(panelId: panelId)
-        terminalView.delegate = pwdDelegate
+        // 挂 EventDelegate — 同时接 OSC 7 (PwdDelegate) + OSC 0/2 (TitleDelegate).
+        // delegate 是 weak ref, Terminal struct strong-hold eventDelegate 保证生命周期.
+        let eventDelegate = TerminalEventDelegate(panelId: panelId)
+        terminalView.delegate = eventDelegate
 
         // Container 只是 frame holder, 自身不绘制. terminalView 内的 IOSurfaceLayer
         // (opaque=true) 已经渲染 terminal 全部像素, 不需要 container 再画 background —
@@ -438,7 +464,7 @@ final class GhosttyBridgeImpl {
             containerView: container,
             terminalView: terminalView,
             parentWindow: parent,
-            pwdDelegate: pwdDelegate
+            eventDelegate: eventDelegate
         )
 
         // 更新 EventRouter targets (inset 留出 sash 事件通道)
@@ -737,6 +763,26 @@ public func ghosttyBridgeSetPwdForwardCallback(_ cb: PwdForwardCallback?) {
             }
         } else {
             GhosttyBridgeImpl.shared.setPwdForwardCallback { _, _, _ in }
+        }
+    }
+}
+
+/// C 函数指针类型: 接收 browserWindowId (Int), panelId UTF-8, title UTF-8.
+public typealias TitleForwardCallback = @convention(c) (Int, UnsafePointer<CChar>, UnsafePointer<CChar>) -> Void
+
+@_cdecl("ghostty_bridge_set_title_forward_callback")
+public func ghosttyBridgeSetTitleForwardCallback(_ cb: TitleForwardCallback?) {
+    MainActor.assumeIsolated {
+        if let cb {
+            GhosttyBridgeImpl.shared.setTitleForwardCallback { wid, panelId, title in
+                panelId.withCString { pidPtr in
+                    title.withCString { titlePtr in
+                        cb(wid, pidPtr, titlePtr)
+                    }
+                }
+            }
+        } else {
+            GhosttyBridgeImpl.shared.setTitleForwardCallback { _, _, _ in }
         }
     }
 }

--- a/native/Sources/GhosttyBridge/GhosttyBridge.swift
+++ b/native/Sources/GhosttyBridge/GhosttyBridge.swift
@@ -133,12 +133,44 @@ final class EventRouterView: NSView {
     }
 }
 
+// MARK: - PWD delegate adapter
+
+/// 实现 TerminalSurfacePwdDelegate, 每个 terminal 一个实例, 持有 panelId 用于
+/// 区分多 panel. cwd 变化时调全局 forwardPwdCallback 把 (panelId, path) 转给
+/// main process.
+///
+/// weak-set 到 terminalView.delegate, strong-hold 在 Terminal struct 中以保证
+/// 生命周期 (terminalView.delegate 是 weak — 没 strong owner 会立即 nil).
+@MainActor
+final class TerminalPwdDelegate: TerminalSurfacePwdDelegate {
+    let panelId: String
+
+    /// 全局 callback: 收到 OSC 7 path 时调用, 把 (browserWindowId, panelId, path)
+    /// 转给 main process. browserWindowId 由 GhosttyBridgeImpl 通过 panelId 反查
+    /// (panel 所属 NSWindow → browserWindowId 映射).
+    static var forwardPwdCallback: ((Int, String, String) -> Void)?
+
+    init(panelId: String) {
+        self.panelId = panelId
+    }
+
+    func terminalDidChangeWorkingDirectory(_ path: String) {
+        guard let windowId = GhosttyBridgeImpl.shared.browserWindowId(forPanelId: panelId) else {
+            return
+        }
+        TerminalPwdDelegate.forwardPwdCallback?(windowId, panelId, path)
+    }
+}
+
 // MARK: - Terminal record
 
 private struct Terminal {
     let containerView: NSView
     let terminalView: TerminalView
     let parentWindow: NSWindow
+    /// PwdDelegate adapter (strong-hold — terminalView.delegate 是 weak).
+    /// 随 Terminal 一起释放, terminalView weak ref 自动 nil, 不留 dangling.
+    let pwdDelegate: TerminalPwdDelegate
 }
 
 // MARK: - Bridge implementation
@@ -179,6 +211,18 @@ final class GhosttyBridgeImpl {
 
     // per-window state, 跟 eventRouters 一样用 ObjectIdentifier(window) 作 key
     private var windowStates: [ObjectIdentifier: WindowKeyboardState] = [:]
+
+    /// panelId → browserWindowId 映射. createTerminal 时建立, close/closeAll 时清理.
+    /// PwdDelegate 收到 OSC 7 时需要反查 panel 所属窗口以路由 IPC.
+    private var panelIdToBrowserWindowId: [String: Int] = [:]
+
+    /// NSWindow → browserWindowId 映射. setupWindow 时建立, detachWindow 时清理.
+    /// createTerminal 用它把 panelId 关联到 browserWindowId.
+    private var windowToBrowserWindowId: [ObjectIdentifier: Int] = [:]
+
+    func browserWindowId(forPanelId panelId: String) -> Int? {
+        return panelIdToBrowserWindowId[panelId]
+    }
 
     func stateFor(window: NSWindow) -> WindowKeyboardState {
         return windowStates[ObjectIdentifier(window)] ?? WindowKeyboardState()
@@ -267,6 +311,9 @@ final class GhosttyBridgeImpl {
         // 初始化 per-window keyboard state (PanelKind 默认 .web — 安全, 不抢 firstResponder)
         windowStates[windowId] = WindowKeyboardState()
 
+        // 记录 browserWindowId 映射 — PwdDelegate 反查 panel→window→browserId 路由 IPC.
+        windowToBrowserWindowId[windowId] = browserWindowId
+
         return true
     }
 
@@ -339,6 +386,13 @@ final class GhosttyBridgeImpl {
         EventRouterView.forwardCmdKeyCallback = cb
     }
 
+    /// 注册 PWD forward callback: swift TerminalSurfacePwdDelegate 收到 OSC 7 后,
+    /// 把 (browserWindowId, panelId, cwd) 转给 main process. 与 keyboard forward
+    /// 路径同模式 (PwdDelegate → C 函数指针 → N-API ThreadSafeFunction).
+    func setPwdForwardCallback(_ cb: @escaping (Int, String, String) -> Void) {
+        TerminalPwdDelegate.forwardPwdCallback = cb
+    }
+
     // MARK: - Terminal lifecycle
 
     func createTerminal(parent: NSWindow, panelId: String, viewport: NSRect) -> Bool {
@@ -356,6 +410,11 @@ final class GhosttyBridgeImpl {
         terminalView.autoresizingMask = [.width, .height]
         terminalView.configuration = TerminalSurfaceOptions(backend: .exec)
         terminalView.controller = controller(for: parent)
+
+        // 挂 PwdDelegate — 接 OSC 7, 转发 (panelId, path) 给 main process.
+        // delegate 是 weak ref, Terminal struct strong-hold pwdDelegate 保证生命周期.
+        let pwdDelegate = TerminalPwdDelegate(panelId: panelId)
+        terminalView.delegate = pwdDelegate
 
         // Container 只是 frame holder, 自身不绘制. terminalView 内的 IOSurfaceLayer
         // (opaque=true) 已经渲染 terminal 全部像素, 不需要 container 再画 background —
@@ -378,7 +437,8 @@ final class GhosttyBridgeImpl {
         terminals[panelId] = Terminal(
             containerView: container,
             terminalView: terminalView,
-            parentWindow: parent
+            parentWindow: parent,
+            pwdDelegate: pwdDelegate
         )
 
         // 更新 EventRouter targets (inset 留出 sash 事件通道)
@@ -386,6 +446,11 @@ final class GhosttyBridgeImpl {
         eventRouters[windowId]?.targets[panelId] = EventRouterView.Target(
             rect: frame.insetBy(dx: Self.hitInset, dy: Self.hitInset), view: terminalView
         )
+
+        // 建立 panelId → browserWindowId 映射 (PwdDelegate 路由依赖)
+        if let bid = windowToBrowserWindowId[windowId] {
+            panelIdToBrowserWindowId[panelId] = bid
+        }
 
         activePanelId = panelId
 
@@ -456,6 +521,7 @@ final class GhosttyBridgeImpl {
         let parent = term.parentWindow
         term.containerView.removeFromSuperview()
         terminals.removeValue(forKey: panelId)
+        panelIdToBrowserWindowId.removeValue(forKey: panelId)
         if activePanelId == panelId { activePanelId = nil }
 
         let windowId = ObjectIdentifier(parent)
@@ -495,6 +561,7 @@ final class GhosttyBridgeImpl {
         for (panelId, term) in toClose {
             term.containerView.removeFromSuperview()
             terminals.removeValue(forKey: panelId)
+            panelIdToBrowserWindowId.removeValue(forKey: panelId)
         }
         if let activeId = activePanelId, terminals[activeId] == nil {
             activePanelId = nil
@@ -520,6 +587,7 @@ final class GhosttyBridgeImpl {
         // 释放该 window 的 TerminalController — 内部 session/PTY 列表跨 window 累积
         // 是潜在内存泄漏, swift ARC 让无引用 controller 自动 dealloc.
         controllers.removeValue(forKey: windowId)
+        windowToBrowserWindowId.removeValue(forKey: windowId)
     }
 
     // MARK: - Coordinate conversion
@@ -648,6 +716,27 @@ public func ghosttyBridgeSetKeyboardForwardCallback(_ cb: KeyboardForwardCallbac
             }
         } else {
             GhosttyBridgeImpl.shared.setKeyboardForwardCallback { _, _, _ in }
+        }
+    }
+}
+
+/// C 函数指针类型: 接收 browserWindowId (Int), panelId UTF-8 C string, cwd UTF-8.
+/// addon.mm 包装成 ThreadSafeFunction 让 JS 端能安全接收.
+public typealias PwdForwardCallback = @convention(c) (Int, UnsafePointer<CChar>, UnsafePointer<CChar>) -> Void
+
+@_cdecl("ghostty_bridge_set_pwd_forward_callback")
+public func ghosttyBridgeSetPwdForwardCallback(_ cb: PwdForwardCallback?) {
+    MainActor.assumeIsolated {
+        if let cb {
+            GhosttyBridgeImpl.shared.setPwdForwardCallback { wid, panelId, cwd in
+                panelId.withCString { pidPtr in
+                    cwd.withCString { cwdPtr in
+                        cb(wid, pidPtr, cwdPtr)
+                    }
+                }
+            }
+        } else {
+            GhosttyBridgeImpl.shared.setPwdForwardCallback { _, _, _ in }
         }
     }
 }

--- a/native/src/addon.mm
+++ b/native/src/addon.mm
@@ -21,6 +21,10 @@ extern "C" {
     // BrowserWindow.id, 让 main 端按 window id 路由 (多窗口下 getFocusedWindow 不准).
     typedef void (*KeyboardForwardFn)(long browserWindowId, unsigned long modifiers, const char* chars);
     void ghostty_bridge_set_keyboard_forward_callback(KeyboardForwardFn cb);
+    // PWD forward: swift TerminalSurfacePwdDelegate 收到 OSC 7 → 此 trampoline → JS.
+    // 签名 (browserWindowId, panelId UTF-8, cwd UTF-8). 与 keyboard forward 同模式.
+    typedef void (*PwdForwardFn)(long browserWindowId, const char* panelId, const char* cwd);
+    void ghostty_bridge_set_pwd_forward_callback(PwdForwardFn cb);
     void ghostty_bridge_set_active_panel_kind(void* nsWindow, long kindRaw, const char* panelId);
 }
 
@@ -163,6 +167,55 @@ static Napi::Value JsSetKeyboardForwardCallback(const Napi::CallbackInfo& info) 
     return env.Undefined();
 }
 
+// ---- PWD forward callback (swift → main JS) ----
+//
+// swift TerminalSurfacePwdDelegate 收到 OSC 7 → forwardPwdCallback → 这里. 通过
+// ThreadSafeFunction 把事件分发到 main JS 线程, 让 JS 端注册的 callback 收到
+// (browserWindowId, panelId, cwd).
+//
+// 与 keyboard forward 同模式 — 不能在 swift 线程直接调 napi function (会 crash),
+// ThreadSafeFunction 是 N-API 标准的跨线程 callback 桥.
+static Napi::ThreadSafeFunction g_pwdTSFN;
+
+struct PwdForwardPayload {
+    long windowId;
+    std::string panelId;  // heap-owned (跨线程持久化)
+    std::string cwd;
+};
+
+static void g_pwdForwardTrampoline(long windowId, const char* panelId, const char* cwd) {
+    if (!g_pwdTSFN) return;
+    auto* payload = new PwdForwardPayload{ windowId, std::string(panelId), std::string(cwd) };
+    auto status = g_pwdTSFN.BlockingCall(payload, [](Napi::Env env, Napi::Function jsCallback, PwdForwardPayload* p) {
+        jsCallback.Call({
+            Napi::Number::New(env, static_cast<double>(p->windowId)),
+            Napi::String::New(env, p->panelId),
+            Napi::String::New(env, p->cwd),
+        });
+        delete p;
+    });
+    if (status != napi_ok) {
+        delete payload;
+    }
+}
+
+static Napi::Value JsSetPwdForwardCallback(const Napi::CallbackInfo& info) {
+    Napi::Env env = info.Env();
+    if (info.Length() == 0 || info[0].IsNull() || info[0].IsUndefined()) {
+        if (g_pwdTSFN) {
+            g_pwdTSFN.Release();
+            g_pwdTSFN = Napi::ThreadSafeFunction();
+        }
+        ghostty_bridge_set_pwd_forward_callback(nullptr);
+        return env.Undefined();
+    }
+    Napi::Function jsFn = info[0].As<Napi::Function>();
+    if (g_pwdTSFN) g_pwdTSFN.Release();
+    g_pwdTSFN = Napi::ThreadSafeFunction::New(env, jsFn, "PierPwdForward", 0, 1);
+    ghostty_bridge_set_pwd_forward_callback(&g_pwdForwardTrampoline);
+    return env.Undefined();
+}
+
 static Napi::Value JsSetActivePanelKind(const Napi::CallbackInfo& info) {
     NSWindow* win = WindowFromHandle(info[0]);
     if (!win) return info.Env().Undefined();
@@ -189,6 +242,7 @@ static Napi::Object Init(Napi::Env env, Napi::Object exports) {
     exports.Set("closeAllTerminals", Napi::Function::New(env, JsCloseAll));
     exports.Set("detachWindow",    Napi::Function::New(env, JsDetachWindow));
     exports.Set("setKeyboardForwardCallback", Napi::Function::New(env, JsSetKeyboardForwardCallback));
+    exports.Set("setPwdForwardCallback", Napi::Function::New(env, JsSetPwdForwardCallback));
     exports.Set("setActivePanelKind", Napi::Function::New(env, JsSetActivePanelKind));
     return exports;
 }

--- a/native/src/addon.mm
+++ b/native/src/addon.mm
@@ -25,6 +25,10 @@ extern "C" {
     // 签名 (browserWindowId, panelId UTF-8, cwd UTF-8). 与 keyboard forward 同模式.
     typedef void (*PwdForwardFn)(long browserWindowId, const char* panelId, const char* cwd);
     void ghostty_bridge_set_pwd_forward_callback(PwdForwardFn cb);
+    // Title forward: swift TerminalSurfaceTitleDelegate 收到 OSC 0/2 → 此 trampoline → JS.
+    // 签名 (browserWindowId, panelId UTF-8, title UTF-8). 与 PWD 同模式.
+    typedef void (*TitleForwardFn)(long browserWindowId, const char* panelId, const char* title);
+    void ghostty_bridge_set_title_forward_callback(TitleForwardFn cb);
     void ghostty_bridge_set_active_panel_kind(void* nsWindow, long kindRaw, const char* panelId);
 }
 
@@ -216,6 +220,52 @@ static Napi::Value JsSetPwdForwardCallback(const Napi::CallbackInfo& info) {
     return env.Undefined();
 }
 
+// ---- Title forward callback (swift OSC 0/2 → main JS) ----
+//
+// 与 PWD forward 同模式. TUI 应用 (claude / vim / aider) 主动通过 OSC 0/2 写
+// 自定义 title, swift TerminalSurfaceTitleDelegate 接, 经 ThreadSafeFunction
+// 跨线程到 JS.
+static Napi::ThreadSafeFunction g_titleTSFN;
+
+struct TitleForwardPayload {
+    long windowId;
+    std::string panelId;
+    std::string title;
+};
+
+static void g_titleForwardTrampoline(long windowId, const char* panelId, const char* title) {
+    if (!g_titleTSFN) return;
+    auto* payload = new TitleForwardPayload{ windowId, std::string(panelId), std::string(title) };
+    auto status = g_titleTSFN.BlockingCall(payload, [](Napi::Env env, Napi::Function jsCallback, TitleForwardPayload* p) {
+        jsCallback.Call({
+            Napi::Number::New(env, static_cast<double>(p->windowId)),
+            Napi::String::New(env, p->panelId),
+            Napi::String::New(env, p->title),
+        });
+        delete p;
+    });
+    if (status != napi_ok) {
+        delete payload;
+    }
+}
+
+static Napi::Value JsSetTitleForwardCallback(const Napi::CallbackInfo& info) {
+    Napi::Env env = info.Env();
+    if (info.Length() == 0 || info[0].IsNull() || info[0].IsUndefined()) {
+        if (g_titleTSFN) {
+            g_titleTSFN.Release();
+            g_titleTSFN = Napi::ThreadSafeFunction();
+        }
+        ghostty_bridge_set_title_forward_callback(nullptr);
+        return env.Undefined();
+    }
+    Napi::Function jsFn = info[0].As<Napi::Function>();
+    if (g_titleTSFN) g_titleTSFN.Release();
+    g_titleTSFN = Napi::ThreadSafeFunction::New(env, jsFn, "PierTitleForward", 0, 1);
+    ghostty_bridge_set_title_forward_callback(&g_titleForwardTrampoline);
+    return env.Undefined();
+}
+
 static Napi::Value JsSetActivePanelKind(const Napi::CallbackInfo& info) {
     NSWindow* win = WindowFromHandle(info[0]);
     if (!win) return info.Env().Undefined();
@@ -243,6 +293,7 @@ static Napi::Object Init(Napi::Env env, Napi::Object exports) {
     exports.Set("detachWindow",    Napi::Function::New(env, JsDetachWindow));
     exports.Set("setKeyboardForwardCallback", Napi::Function::New(env, JsSetKeyboardForwardCallback));
     exports.Set("setPwdForwardCallback", Napi::Function::New(env, JsSetPwdForwardCallback));
+    exports.Set("setTitleForwardCallback", Napi::Function::New(env, JsSetTitleForwardCallback));
     exports.Set("setActivePanelKind", Napi::Function::New(env, JsSetActivePanelKind));
     return exports;
 }

--- a/native/src/addon.mm
+++ b/native/src/addon.mm
@@ -138,195 +138,161 @@ static Napi::Value JsDetachWindow(const Napi::CallbackInfo& info) {
     return info.Env().Undefined();
 }
 
-// ---- Keyboard forward callback (swift → main JS) ----
+// ---- Forward channel template (swift → main JS) ----
 //
-// swift NSEvent monitor 捕获 Cmd+key 时, 通过 C 函数指针 (g_keyForwardTrampoline)
-// 调到这里, 我们通过 ThreadSafeFunction 把事件分发到 main 进程的 JS 线程, 让 JS
-// 端注册的 callback 收到 { modifiers, chars }.
+// 通用 ThreadSafeFunction 桥. 每条 forward (keyboard / mouse / pwd / title) 都是:
+//   swift 线程触发 C 函数指针 → trampoline 构 Payload → TSFN 跨线程到 JS 线程 →
+//   payload.callJs(env, jsCallback) → delete payload.
 //
-// 不能直接在 swift 线程调 napi function (会 crash) — ThreadSafeFunction 是 N-API
-// 标准的跨线程 callback 桥.
-static Napi::ThreadSafeFunction g_keyboardTSFN;
+// Payload 是 plain struct, 各自字段 + 一个 callJs 方法负责把字段映射到 napi 值.
+// 添加新 forward 只需:声明 Payload、声明 g_xxx ForwardChannel、1 行 trampoline、
+// 1 行 JsSet handler.
+template <typename Payload>
+class ForwardChannel {
+public:
+    explicit ForwardChannel(const char* debugName) : debugName_(debugName) {}
 
-struct KeyForwardPayload {
-    long windowId;
-    unsigned long modifiers;
-    std::string chars;  // heap-owned (跨线程持久化)
+    void bindJs(Napi::Env env, Napi::Function jsFn) {
+        releaseJs();
+        tsfn_ = Napi::ThreadSafeFunction::New(env, jsFn, debugName_, 0, 1);
+    }
+
+    void releaseJs() {
+        if (tsfn_) {
+            tsfn_.Release();
+            tsfn_ = Napi::ThreadSafeFunction();
+        }
+    }
+
+    void emit(Payload payload) {
+        if (!tsfn_) return;
+        auto* heap = new Payload(std::move(payload));
+        auto status = tsfn_.BlockingCall(heap, [](Napi::Env env, Napi::Function jsCallback, Payload* p) {
+            p->callJs(env, jsCallback);
+            delete p;
+        });
+        if (status != napi_ok) {
+            delete heap;
+        }
+    }
+
+private:
+    Napi::ThreadSafeFunction tsfn_;
+    const char* debugName_;
 };
 
-static void g_keyForwardTrampoline(long windowId, unsigned long modifiers, const char* chars) {
-    if (!g_keyboardTSFN) return;
-    auto* payload = new KeyForwardPayload{ windowId, modifiers, std::string(chars) };
-    auto status = g_keyboardTSFN.BlockingCall(payload, [](Napi::Env env, Napi::Function jsCallback, KeyForwardPayload* p) {
-        jsCallback.Call({
-            Napi::Number::New(env, static_cast<double>(p->windowId)),
-            Napi::Number::New(env, static_cast<double>(p->modifiers)),
-            Napi::String::New(env, p->chars),
-        });
-        delete p;
-    });
-    if (status != napi_ok) {
-        delete payload;
-    }
-}
-
-static Napi::Value JsSetKeyboardForwardCallback(const Napi::CallbackInfo& info) {
+// JsSet handler 通用实现: 把 (release-or-bind + swift-setter 调用) 这两步合一.
+// trampoline 总是非 null — 解绑时只断 JS 端, swift 端调用 setter(nullptr).
+template <typename Channel, typename Trampoline>
+static Napi::Value JsSetForwardCallback(
+    const Napi::CallbackInfo& info,
+    Channel& channel,
+    void (*setter)(Trampoline),
+    Trampoline trampoline)
+{
     Napi::Env env = info.Env();
     if (info.Length() == 0 || info[0].IsNull() || info[0].IsUndefined()) {
-        if (g_keyboardTSFN) {
-            g_keyboardTSFN.Release();
-            g_keyboardTSFN = Napi::ThreadSafeFunction();
-        }
-        ghostty_bridge_set_keyboard_forward_callback(nullptr);
+        channel.releaseJs();
+        setter(nullptr);
         return env.Undefined();
     }
-    Napi::Function jsFn = info[0].As<Napi::Function>();
-    if (g_keyboardTSFN) g_keyboardTSFN.Release();
-    g_keyboardTSFN = Napi::ThreadSafeFunction::New(env, jsFn, "PierKeyForward", 0, 1);
-    ghostty_bridge_set_keyboard_forward_callback(&g_keyForwardTrampoline);
+    channel.bindJs(env, info[0].As<Napi::Function>());
+    setter(trampoline);
     return env.Undefined();
 }
 
-// ---- Right-mouse forward callback (swift → main JS) ----
-//
-// 同 keyboard forward 模式: swift NSEvent monitor 命中 terminal 区域右键时调
-// trampoline, ThreadSafeFunction 把 (windowId, panelId, x, y) 转到 JS 线程.
-static Napi::ThreadSafeFunction g_mouseTSFN;
+// ---- Keyboard forward (Cmd+key 全局快捷键转 renderer) ----
+struct KeyForwardPayload {
+    long windowId;
+    unsigned long modifiers;
+    std::string chars;
+    void callJs(Napi::Env env, Napi::Function jsCallback) {
+        jsCallback.Call({
+            Napi::Number::New(env, static_cast<double>(windowId)),
+            Napi::Number::New(env, static_cast<double>(modifiers)),
+            Napi::String::New(env, chars),
+        });
+    }
+};
+static ForwardChannel<KeyForwardPayload> g_keyboardChannel("PierKeyForward");
+static void g_keyForwardTrampoline(long windowId, unsigned long modifiers, const char* chars) {
+    g_keyboardChannel.emit({ windowId, modifiers, std::string(chars) });
+}
+static Napi::Value JsSetKeyboardForwardCallback(const Napi::CallbackInfo& info) {
+    return JsSetForwardCallback(info, g_keyboardChannel,
+                                ghostty_bridge_set_keyboard_forward_callback,
+                                &g_keyForwardTrampoline);
+}
 
+// ---- Right-mouse forward (terminal 区域右键转 native menu trigger) ----
 struct MouseForwardPayload {
     long windowId;
     std::string panelId;
     double x;
     double y;
-};
-
-static void g_mouseForwardTrampoline(long windowId, const char* panelId, double x, double y) {
-    if (!g_mouseTSFN) return;
-    auto* payload = new MouseForwardPayload{ windowId, std::string(panelId), x, y };
-    auto status = g_mouseTSFN.BlockingCall(payload, [](Napi::Env env, Napi::Function jsCallback, MouseForwardPayload* p) {
+    void callJs(Napi::Env env, Napi::Function jsCallback) {
         jsCallback.Call({
-            Napi::Number::New(env, static_cast<double>(p->windowId)),
-            Napi::String::New(env, p->panelId),
-            Napi::Number::New(env, p->x),
-            Napi::Number::New(env, p->y),
+            Napi::Number::New(env, static_cast<double>(windowId)),
+            Napi::String::New(env, panelId),
+            Napi::Number::New(env, x),
+            Napi::Number::New(env, y),
         });
-        delete p;
-    });
-    if (status != napi_ok) {
-        delete payload;
     }
+};
+static ForwardChannel<MouseForwardPayload> g_mouseChannel("PierMouseForward");
+static void g_mouseForwardTrampoline(long windowId, const char* panelId, double x, double y) {
+    g_mouseChannel.emit({ windowId, std::string(panelId), x, y });
 }
-
 static Napi::Value JsSetMouseForwardCallback(const Napi::CallbackInfo& info) {
-    Napi::Env env = info.Env();
-    if (info.Length() == 0 || info[0].IsNull() || info[0].IsUndefined()) {
-        if (g_mouseTSFN) {
-            g_mouseTSFN.Release();
-            g_mouseTSFN = Napi::ThreadSafeFunction();
-        }
-        ghostty_bridge_set_mouse_forward_callback(nullptr);
-        return env.Undefined();
-    }
-    Napi::Function jsFn = info[0].As<Napi::Function>();
-    if (g_mouseTSFN) g_mouseTSFN.Release();
-    g_mouseTSFN = Napi::ThreadSafeFunction::New(env, jsFn, "PierMouseForward", 0, 1);
-    ghostty_bridge_set_mouse_forward_callback(&g_mouseForwardTrampoline);
-    return env.Undefined();
+    return JsSetForwardCallback(info, g_mouseChannel,
+                                ghostty_bridge_set_mouse_forward_callback,
+                                &g_mouseForwardTrampoline);
 }
 
-// ---- PWD forward callback (swift → main JS) ----
-//
-// swift TerminalSurfacePwdDelegate 收到 OSC 7 → forwardPwdCallback → 这里. 通过
-// ThreadSafeFunction 把事件分发到 main JS 线程, 让 JS 端注册的 callback 收到
-// (browserWindowId, panelId, cwd).
-//
-// 与 keyboard forward 同模式 — 不能在 swift 线程直接调 napi function (会 crash),
-// ThreadSafeFunction 是 N-API 标准的跨线程 callback 桥.
-static Napi::ThreadSafeFunction g_pwdTSFN;
-
+// ---- PWD forward (OSC 7 cwd → renderer panel descriptor) ----
 struct PwdForwardPayload {
     long windowId;
-    std::string panelId;  // heap-owned (跨线程持久化)
+    std::string panelId;
     std::string cwd;
-};
-
-static void g_pwdForwardTrampoline(long windowId, const char* panelId, const char* cwd) {
-    if (!g_pwdTSFN) return;
-    auto* payload = new PwdForwardPayload{ windowId, std::string(panelId), std::string(cwd) };
-    auto status = g_pwdTSFN.BlockingCall(payload, [](Napi::Env env, Napi::Function jsCallback, PwdForwardPayload* p) {
+    void callJs(Napi::Env env, Napi::Function jsCallback) {
         jsCallback.Call({
-            Napi::Number::New(env, static_cast<double>(p->windowId)),
-            Napi::String::New(env, p->panelId),
-            Napi::String::New(env, p->cwd),
+            Napi::Number::New(env, static_cast<double>(windowId)),
+            Napi::String::New(env, panelId),
+            Napi::String::New(env, cwd),
         });
-        delete p;
-    });
-    if (status != napi_ok) {
-        delete payload;
     }
+};
+static ForwardChannel<PwdForwardPayload> g_pwdChannel("PierPwdForward");
+static void g_pwdForwardTrampoline(long windowId, const char* panelId, const char* cwd) {
+    g_pwdChannel.emit({ windowId, std::string(panelId), std::string(cwd) });
 }
-
 static Napi::Value JsSetPwdForwardCallback(const Napi::CallbackInfo& info) {
-    Napi::Env env = info.Env();
-    if (info.Length() == 0 || info[0].IsNull() || info[0].IsUndefined()) {
-        if (g_pwdTSFN) {
-            g_pwdTSFN.Release();
-            g_pwdTSFN = Napi::ThreadSafeFunction();
-        }
-        ghostty_bridge_set_pwd_forward_callback(nullptr);
-        return env.Undefined();
-    }
-    Napi::Function jsFn = info[0].As<Napi::Function>();
-    if (g_pwdTSFN) g_pwdTSFN.Release();
-    g_pwdTSFN = Napi::ThreadSafeFunction::New(env, jsFn, "PierPwdForward", 0, 1);
-    ghostty_bridge_set_pwd_forward_callback(&g_pwdForwardTrampoline);
-    return env.Undefined();
+    return JsSetForwardCallback(info, g_pwdChannel,
+                                ghostty_bridge_set_pwd_forward_callback,
+                                &g_pwdForwardTrampoline);
 }
 
-// ---- Title forward callback (swift OSC 0/2 → main JS) ----
-//
-// 与 PWD forward 同模式. TUI 应用 (claude / vim / aider) 主动通过 OSC 0/2 写
-// 自定义 title, swift TerminalSurfaceTitleDelegate 接, 经 ThreadSafeFunction
-// 跨线程到 JS.
-static Napi::ThreadSafeFunction g_titleTSFN;
-
+// ---- Title forward (OSC 0/2 → renderer panel descriptor) ----
 struct TitleForwardPayload {
     long windowId;
     std::string panelId;
     std::string title;
-};
-
-static void g_titleForwardTrampoline(long windowId, const char* panelId, const char* title) {
-    if (!g_titleTSFN) return;
-    auto* payload = new TitleForwardPayload{ windowId, std::string(panelId), std::string(title) };
-    auto status = g_titleTSFN.BlockingCall(payload, [](Napi::Env env, Napi::Function jsCallback, TitleForwardPayload* p) {
+    void callJs(Napi::Env env, Napi::Function jsCallback) {
         jsCallback.Call({
-            Napi::Number::New(env, static_cast<double>(p->windowId)),
-            Napi::String::New(env, p->panelId),
-            Napi::String::New(env, p->title),
+            Napi::Number::New(env, static_cast<double>(windowId)),
+            Napi::String::New(env, panelId),
+            Napi::String::New(env, title),
         });
-        delete p;
-    });
-    if (status != napi_ok) {
-        delete payload;
     }
+};
+static ForwardChannel<TitleForwardPayload> g_titleChannel("PierTitleForward");
+static void g_titleForwardTrampoline(long windowId, const char* panelId, const char* title) {
+    g_titleChannel.emit({ windowId, std::string(panelId), std::string(title) });
 }
-
 static Napi::Value JsSetTitleForwardCallback(const Napi::CallbackInfo& info) {
-    Napi::Env env = info.Env();
-    if (info.Length() == 0 || info[0].IsNull() || info[0].IsUndefined()) {
-        if (g_titleTSFN) {
-            g_titleTSFN.Release();
-            g_titleTSFN = Napi::ThreadSafeFunction();
-        }
-        ghostty_bridge_set_title_forward_callback(nullptr);
-        return env.Undefined();
-    }
-    Napi::Function jsFn = info[0].As<Napi::Function>();
-    if (g_titleTSFN) g_titleTSFN.Release();
-    g_titleTSFN = Napi::ThreadSafeFunction::New(env, jsFn, "PierTitleForward", 0, 1);
-    ghostty_bridge_set_title_forward_callback(&g_titleForwardTrampoline);
-    return env.Undefined();
+    return JsSetForwardCallback(info, g_titleChannel,
+                                ghostty_bridge_set_title_forward_callback,
+                                &g_titleForwardTrampoline);
 }
 
 static Napi::Value JsApplyTerminalTheme(const Napi::CallbackInfo& info) {

--- a/src/main/ipc/terminal.ts
+++ b/src/main/ipc/terminal.ts
@@ -104,97 +104,82 @@ function loadNativeAddon(): {
   }
 }
 
+/**
+ * Forward swift-originated event to a specific BrowserWindow's renderer.
+ *
+ * 所有 swift→main→renderer forward 共用这一条路由 (keyboard / mouse / pwd / title):
+ * 1. 按 browserWindowId 精准定位 BrowserWindow — swift NSEvent monitor / delegate
+ *    跨线程, callback 执行时 focused window 可能已切换, 不能用 getFocusedWindow.
+ * 2. 守 isDestroyed (window/webContents 在 swift 触发 → main JS dispatch 间可能销毁).
+ * 3. send 抛任何错误 (window 关闭瞬间) 都 catch + log + 继续 — 不影响其他 channel.
+ */
+function forwardToWindow<P>(
+  browserWindowId: number,
+  channel: string,
+  payload: P,
+  errorLabel: string
+): void {
+  try {
+    const targetWindow = BrowserWindow.fromId(browserWindowId);
+    if (!targetWindow || targetWindow.isDestroyed()) {
+      return;
+    }
+    const wc = targetWindow.webContents;
+    if (wc.isDestroyed()) {
+      return;
+    }
+    wc.send(channel, payload);
+  } catch (err) {
+    console.error(`[${errorLabel}] send failed:`, err);
+  }
+}
+
 export function registerTerminalIpc(ipcMain: IpcMain): void {
   const { addon, error: loadError } = loadNativeAddon();
   cachedAddon = addon;
 
-  // 注册 keyboard forward callback: swift NSEvent monitor 捕获 Cmd+key 后,
-  // 通过 ThreadSafeFunction 调到这里. callback 收到 (browserWindowId, modifierFlags,
-  // chars), 用 windowId 精准路由到对应 BrowserWindow 的 renderer.
+  // 四条 swift → renderer forward channel, 全部走 forwardToWindow helper.
+  // 不能用 BrowserWindow.getFocusedWindow():swift 触发时 (NSEvent monitor / OSC
+  // parser delegate) 跨线程, focused window 不一定是事件源 window — 必须用 setupWindow
+  // 时记录的 BrowserWindow.id 精准路由.
   //
-  // 多窗口: 不能用 BrowserWindow.getFocusedWindow() —  swift NSEvent monitor 与
-  // main 主线程不同, callback 执行时 focused window 可能已切换, 会把 window-A 的
-  // keystroke 错送到 window-B. 用 windowId 是唯一可靠路由.
-  //
-  // 这是 Pier "terminal 透明 + web overlay" 架构里 keyboard 全局快捷键唯一可靠
-  // 路径 — 不能用 wk.keyDown forward (Electron 42 ViewsCompositorSuperview 架构
-  // 下 WKWebView 不是真正渲染 web 的层) 也不能依赖 firstResponder chain (Ghostty
-  // terminalView focus 时消费所有 key).
-  addon?.setKeyboardForwardCallback((browserWindowId, modifierFlags, chars) => {
-    try {
-      const targetWindow = BrowserWindow.fromId(browserWindowId);
-      if (!targetWindow || targetWindow.isDestroyed()) {
-        return;
-      }
-      const wc = targetWindow.webContents;
-      if (wc.isDestroyed()) {
-        return;
-      }
-      wc.send("pier:keybinding:forward", { modifierFlags, chars });
-    } catch (err) {
-      // window 在 send 瞬间销毁等 edge case — 不影响其他功能
-      console.error("[pier-key-forward] send failed:", err);
-    }
+  // - keyboard:Cmd+key 全局快捷键 (terminal 透明 + web overlay 架构下唯一可靠通道,
+  //   不能依赖 wk.keyDown forward 或 firstResponder chain — Electron 42 ViewsCompositor-
+  //   Superview 架构下 WKWebView 不是真正渲染层, Ghostty terminalView focus 时消费所有 key).
+  // - mouse:terminal 区域右键 → renderer 调 popupContextMenuAt 弹 native menu.
+  // - pwd:OSC 7 → 真实 cwd → descriptor.path / descriptor.short basename.
+  // - title:OSC 0/2 → TUI 应用 (claude / vim) 自定义 title → descriptor.long.
+  addon?.setKeyboardForwardCallback((id, modifierFlags, chars) => {
+    forwardToWindow(
+      id,
+      "pier:keybinding:forward",
+      { modifierFlags, chars },
+      "pier-key-forward"
+    );
   });
-
-  // Right-mouse forward: swift NSEvent monitor 命中 terminal 区域时调到这里, 通过
-  // windowId 找 BrowserWindow, send IPC 通知 renderer 弹菜单. 与 keyboard forward
-  // 同构 — 不能用 getFocusedWindow (swift monitor 跨线程 + 多窗口下不准).
-  addon?.setMouseForwardCallback((browserWindowId, panelId, x, y) => {
-    try {
-      const targetWindow = BrowserWindow.fromId(browserWindowId);
-      if (!targetWindow || targetWindow.isDestroyed()) {
-        return;
-      }
-      const wc = targetWindow.webContents;
-      if (wc.isDestroyed()) {
-        return;
-      }
-      wc.send("pier:terminal:request-context-menu", { panelId, x, y });
-    } catch (err) {
-      console.error("[pier-mouse-forward] send failed:", err);
-    }
+  addon?.setMouseForwardCallback((id, panelId, x, y) => {
+    forwardToWindow(
+      id,
+      "pier:terminal:request-context-menu",
+      { panelId, x, y },
+      "pier-mouse-forward"
+    );
   });
-
-  // 注册 PWD forward callback: swift TerminalSurfacePwdDelegate 收到 OSC 7 后,
-  // 通过 ThreadSafeFunction 调到这里. callback 收到 (browserWindowId, panelId, cwd),
-  // 用 windowId 精准路由到对应 BrowserWindow 的 renderer.
-  //
-  // 这是 terminal panel tab title / 系统 title 反映 cwd 的唯一通道. 不依赖
-  // proc_pidinfo polling — Ghostty 已完整解析 OSC 7, 被动接收即可.
-  addon?.setPwdForwardCallback((browserWindowId, panelId, cwd) => {
-    try {
-      const targetWindow = BrowserWindow.fromId(browserWindowId);
-      if (!targetWindow || targetWindow.isDestroyed()) {
-        return;
-      }
-      const wc = targetWindow.webContents;
-      if (wc.isDestroyed()) {
-        return;
-      }
-      wc.send("pier:terminal:cwd-change", { panelId, cwd });
-    } catch (err) {
-      console.error("[pier-cwd-forward] send failed:", err);
-    }
+  addon?.setPwdForwardCallback((id, panelId, cwd) => {
+    forwardToWindow(
+      id,
+      "pier:terminal:cwd-change",
+      { panelId, cwd },
+      "pier-cwd-forward"
+    );
   });
-
-  // 注册 Title forward callback: swift TerminalSurfaceTitleDelegate 收到 OSC 0/2 后,
-  // 通过 ThreadSafeFunction 调到这里. TUI 应用 (claude / vim) 主动写的 title, 是
-  // descriptor.long 的最高优先级来源 (sequence > cwd > fallback).
-  addon?.setTitleForwardCallback((browserWindowId, panelId, title) => {
-    try {
-      const targetWindow = BrowserWindow.fromId(browserWindowId);
-      if (!targetWindow || targetWindow.isDestroyed()) {
-        return;
-      }
-      const wc = targetWindow.webContents;
-      if (wc.isDestroyed()) {
-        return;
-      }
-      wc.send("pier:terminal:title-change", { panelId, title });
-    } catch (err) {
-      console.error("[pier-title-forward] send failed:", err);
-    }
+  addon?.setTitleForwardCallback((id, panelId, title) => {
+    forwardToWindow(
+      id,
+      "pier:terminal:title-change",
+      { panelId, title },
+      "pier-title-forward"
+    );
   });
 
   ipcMain.handle("pier:terminal:setup", (event) => {
@@ -240,28 +225,38 @@ export function registerTerminalIpc(ipcMain: IpcMain): void {
     }
   });
 
+  // Renderer → addon 单参数透传 (fire-and-forget): renderer.ipcRenderer.send 单向
+  // 触发 addon 同名 method. addon 可能未加载 (非 darwin / native load 失败), 用
+  // optional chain 让 callback 仍注册但 noop — 不让 renderer 端 send 静默丢但接收侧
+  // "No handler".
+  const panelIdRelays = [
+    {
+      channel: "pier:terminal:show",
+      call: (panelId: string) => addon?.showTerminal(panelId),
+    },
+    {
+      channel: "pier:terminal:hide",
+      call: (panelId: string) => addon?.hideTerminal(panelId),
+    },
+    {
+      channel: "pier:terminal:focus",
+      call: (panelId: string) => addon?.focusTerminal(panelId),
+    },
+    {
+      channel: "pier:terminal:close",
+      call: (panelId: string) => addon?.closeTerminal(panelId),
+    },
+  ] as const;
+  for (const { channel, call } of panelIdRelays) {
+    ipcMain.on(channel, (_event, panelId: string) => call(panelId));
+  }
+  // set-frame 多一个 frame 参数, 不进数组单独写.
   ipcMain.on(
     "pier:terminal:set-frame",
     (_event, panelId: string, frame: TerminalFrame) => {
       addon?.setFrame(panelId, frame);
     }
   );
-
-  ipcMain.on("pier:terminal:show", (_event, panelId: string) => {
-    addon?.showTerminal(panelId);
-  });
-
-  ipcMain.on("pier:terminal:hide", (_event, panelId: string) => {
-    addon?.hideTerminal(panelId);
-  });
-
-  ipcMain.handle("pier:terminal:close", (_event, panelId: string) => {
-    addon?.closeTerminal(panelId);
-  });
-
-  ipcMain.on("pier:terminal:focus", (_event, panelId: string) => {
-    addon?.focusTerminal(panelId);
-  });
 
   ipcMain.on("pier:terminal:set-overlay", (event, active: boolean) => {
     if (!addon) {

--- a/src/main/ipc/terminal.ts
+++ b/src/main/ipc/terminal.ts
@@ -46,6 +46,16 @@ interface NativeAddon {
   setPwdForwardCallback(
     cb: ((browserWindowId: number, panelId: string, cwd: string) => void) | null
   ): void;
+  /**
+   * 注册 Title forward callback. swift TerminalSurfaceTitleDelegate 收到 OSC 0/2 后调用,
+   * 传 (browserWindowId, panelId, title). TUI 应用 (claude / vim / aider) 自定义 title
+   * 通道. 与 PWD 路由方式相同, 按 windowId 精准送到对应 BrowserWindow renderer.
+   */
+  setTitleForwardCallback(
+    cb:
+      | ((browserWindowId: number, panelId: string, title: string) => void)
+      | null
+  ): void;
   setupWindow(parentHandle: Buffer, browserWindowId: number): boolean;
   showTerminal(panelId: string): void;
 }
@@ -128,6 +138,25 @@ export function registerTerminalIpc(ipcMain: IpcMain): void {
       wc.send("pier:terminal:cwd-change", { panelId, cwd });
     } catch (err) {
       console.error("[pier-cwd-forward] send failed:", err);
+    }
+  });
+
+  // 注册 Title forward callback: swift TerminalSurfaceTitleDelegate 收到 OSC 0/2 后,
+  // 通过 ThreadSafeFunction 调到这里. TUI 应用 (claude / vim) 主动写的 title, 是
+  // descriptor.long 的最高优先级来源 (sequence > cwd > fallback).
+  addon?.setTitleForwardCallback((browserWindowId, panelId, title) => {
+    try {
+      const targetWindow = BrowserWindow.fromId(browserWindowId);
+      if (!targetWindow || targetWindow.isDestroyed()) {
+        return;
+      }
+      const wc = targetWindow.webContents;
+      if (wc.isDestroyed()) {
+        return;
+      }
+      wc.send("pier:terminal:title-change", { panelId, title });
+    } catch (err) {
+      console.error("[pier-title-forward] send failed:", err);
     }
   });
 

--- a/src/main/ipc/terminal.ts
+++ b/src/main/ipc/terminal.ts
@@ -38,6 +38,14 @@ interface NativeAddon {
       | null
   ): void;
   setOverlayActive(parentHandle: Buffer, active: boolean): void;
+  /**
+   * 注册 PWD forward callback. swift TerminalSurfacePwdDelegate 收到 OSC 7 后调用,
+   * 传 (browserWindowId, panelId, cwd). 用 windowId 路由到对应 BrowserWindow 的
+   * renderer (多窗口下避免广播污染). 传 null 解绑.
+   */
+  setPwdForwardCallback(
+    cb: ((browserWindowId: number, panelId: string, cwd: string) => void) | null
+  ): void;
   setupWindow(parentHandle: Buffer, browserWindowId: number): boolean;
   showTerminal(panelId: string): void;
 }
@@ -98,6 +106,28 @@ export function registerTerminalIpc(ipcMain: IpcMain): void {
     } catch (err) {
       // window 在 send 瞬间销毁等 edge case — 不影响其他功能
       console.error("[pier-key-forward] send failed:", err);
+    }
+  });
+
+  // 注册 PWD forward callback: swift TerminalSurfacePwdDelegate 收到 OSC 7 后,
+  // 通过 ThreadSafeFunction 调到这里. callback 收到 (browserWindowId, panelId, cwd),
+  // 用 windowId 精准路由到对应 BrowserWindow 的 renderer.
+  //
+  // 这是 terminal panel tab title / 系统 title 反映 cwd 的唯一通道. 不依赖
+  // proc_pidinfo polling — Ghostty 已完整解析 OSC 7, 被动接收即可.
+  addon?.setPwdForwardCallback((browserWindowId, panelId, cwd) => {
+    try {
+      const targetWindow = BrowserWindow.fromId(browserWindowId);
+      if (!targetWindow || targetWindow.isDestroyed()) {
+        return;
+      }
+      const wc = targetWindow.webContents;
+      if (wc.isDestroyed()) {
+        return;
+      }
+      wc.send("pier:terminal:cwd-change", { panelId, cwd });
+    } catch (err) {
+      console.error("[pier-cwd-forward] send failed:", err);
     }
   });
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -75,62 +75,42 @@ export interface PierWindowAPI {
   workspace: PierWorkspaceAPI;
 }
 
+/**
+ * 订阅 main → renderer IPC 事件, 返回 dispose 函数.
+ *
+ * 所有 forward 类 API (keybinding.onForward / terminal.onCwdChange /
+ * onTitleChange / onContextMenuRequest / preferences.onChanged) 共用此模板.
+ * 加新订阅:一行 (channel, cb).
+ */
+function subscribeIpc<P>(
+  channel: string,
+  cb: (payload: P) => void
+): () => void {
+  const listener = (_event: unknown, payload: P): void => {
+    cb(payload);
+  };
+  ipcRenderer.on(channel, listener);
+  return () => {
+    ipcRenderer.off(channel, listener);
+  };
+}
+
 const preferencesApi: PierPreferencesAPI = {
-  onChanged: (cb) => {
-    const listener = (_event: unknown, next: PreferencesSnapshot): void => {
-      cb(next);
-    };
-    ipcRenderer.on("pier:preferences:changed", listener);
-    return () => {
-      ipcRenderer.off("pier:preferences:changed", listener);
-    };
-  },
+  onChanged: (cb) => subscribeIpc("pier:preferences:changed", cb),
   read: () => ipcRenderer.invoke("pier:preferences:read"),
   update: (patch) => ipcRenderer.invoke("pier:preferences:update", patch),
 };
 
 const terminalApi: TerminalAPI = {
   applyTheme: (colors) => ipcRenderer.send("pier:terminal:apply-theme", colors),
-  close: (panelId) => ipcRenderer.invoke("pier:terminal:close", panelId),
+  close: (panelId) => ipcRenderer.send("pier:terminal:close", panelId),
   create: (args) => ipcRenderer.invoke("pier:terminal:create", args),
   focus: (panelId) => ipcRenderer.send("pier:terminal:focus", panelId),
   hide: (panelId) => ipcRenderer.send("pier:terminal:hide", panelId),
-  onContextMenuRequest: (cb) => {
-    const listener = (
-      _event: unknown,
-      req: { panelId: string; x: number; y: number }
-    ) => {
-      cb(req);
-    };
-    ipcRenderer.on("pier:terminal:request-context-menu", listener);
-    return () => {
-      ipcRenderer.off("pier:terminal:request-context-menu", listener);
-    };
-  },
-  onCwdChange: (cb) => {
-    const listener = (
-      _event: unknown,
-      payload: { cwd: string; panelId: string }
-    ) => {
-      cb(payload);
-    };
-    ipcRenderer.on("pier:terminal:cwd-change", listener);
-    return () => {
-      ipcRenderer.off("pier:terminal:cwd-change", listener);
-    };
-  },
-  onTitleChange: (cb) => {
-    const listener = (
-      _event: unknown,
-      payload: { panelId: string; title: string }
-    ) => {
-      cb(payload);
-    };
-    ipcRenderer.on("pier:terminal:title-change", listener);
-    return () => {
-      ipcRenderer.off("pier:terminal:title-change", listener);
-    };
-  },
+  onContextMenuRequest: (cb) =>
+    subscribeIpc("pier:terminal:request-context-menu", cb),
+  onCwdChange: (cb) => subscribeIpc("pier:terminal:cwd-change", cb),
+  onTitleChange: (cb) => subscribeIpc("pier:terminal:title-change", cb),
   setActivePanelKind: (kind, panelId) =>
     ipcRenderer.send("pier:terminal:set-active-panel-kind", kind, panelId),
   setFrame: (panelId, frame) =>
@@ -160,18 +140,7 @@ const menuApi: PierMenuAPI = {
 };
 
 const keybindingApi: PierKeybindingAPI = {
-  onForward: (cb) => {
-    const listener = (
-      _event: unknown,
-      chord: { modifierFlags: number; chars: string }
-    ) => {
-      cb(chord);
-    };
-    ipcRenderer.on("pier:keybinding:forward", listener);
-    return () => {
-      ipcRenderer.off("pier:keybinding:forward", listener);
-    };
-  },
+  onForward: (cb) => subscribeIpc("pier:keybinding:forward", cb),
 };
 
 const api: PierWindowAPI = {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -90,6 +90,18 @@ const terminalApi: TerminalAPI = {
       ipcRenderer.off("pier:terminal:cwd-change", listener);
     };
   },
+  onTitleChange: (cb) => {
+    const listener = (
+      _event: unknown,
+      payload: { panelId: string; title: string }
+    ) => {
+      cb(payload);
+    };
+    ipcRenderer.on("pier:terminal:title-change", listener);
+    return () => {
+      ipcRenderer.off("pier:terminal:title-change", listener);
+    };
+  },
   setActivePanelKind: (kind, panelId) =>
     ipcRenderer.send("pier:terminal:set-active-panel-kind", kind, panelId),
   setFrame: (panelId, frame) =>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -78,6 +78,18 @@ const terminalApi: TerminalAPI = {
   create: (args) => ipcRenderer.invoke("pier:terminal:create", args),
   focus: (panelId) => ipcRenderer.send("pier:terminal:focus", panelId),
   hide: (panelId) => ipcRenderer.send("pier:terminal:hide", panelId),
+  onCwdChange: (cb) => {
+    const listener = (
+      _event: unknown,
+      payload: { cwd: string; panelId: string }
+    ) => {
+      cb(payload);
+    };
+    ipcRenderer.on("pier:terminal:cwd-change", listener);
+    return () => {
+      ipcRenderer.off("pier:terminal:cwd-change", listener);
+    };
+  },
   setActivePanelKind: (kind, panelId) =>
     ipcRenderer.send("pier:terminal:set-active-panel-kind", kind, panelId),
   setFrame: (panelId, frame) =>

--- a/src/renderer/components/common/app-shell.tsx
+++ b/src/renderer/components/common/app-shell.tsx
@@ -1,4 +1,5 @@
 import { CommandPalette } from "@/components/common/command-palette.tsx";
+import { DocumentTitle } from "@/components/common/document-title.tsx";
 import { ShellKeybindings } from "@/components/common/shell-keybindings.tsx";
 import { TitleBar } from "@/components/common/title-bar.tsx";
 import { WorkspaceHost } from "@/components/workspace/workspace-host.tsx";
@@ -9,6 +10,7 @@ const IS_MAC = window.pier?.platform === "darwin";
 export function AppShell() {
   return (
     <div className="flex h-full flex-col">
+      <DocumentTitle />
       {IS_MAC && <TitleBar />}
       <ShellKeybindings />
       <CommandPalette />

--- a/src/renderer/components/common/document-title.tsx
+++ b/src/renderer/components/common/document-title.tsx
@@ -7,12 +7,19 @@ import {
 /**
  * 解析"长形式"字符串 — sink 共享的 fallback 链.
  *
- * 优先级:path (绝对路径, 信息密度最高) > long > short.
- * terminal panel cd 后 sink 自然显示完整 cwd; 没 path 的 panel 走 long; 都没
- * 兜底 short (descriptor 契约保证 short 必填).
+ * 优先级:long > path > short.
+ *
+ * - long 由 panel 主动计算 (terminal 内部已做 sequenceTitle ?? cwd 优先级),
+ *   是 sink "应该显示什么"的权威来源.
+ * - path 是真实绝对路径, 给没填 long 的 panel 类型兜底 (理论上 terminal 也会
+ *   走这里, 但 terminal 一定填 long).
+ * - short 是最终兜底, descriptor 契约保证必填.
+ *
+ * 注意: 不能让 path 排在 long 前面 — 否则 terminal 的 sequenceTitle 永远被
+ * 真实 cwd 覆盖, OSC 0/2 失效.
  */
 export function resolveLong(d: PanelDescriptor): string {
-  return d.path ?? d.long ?? d.short;
+  return d.long ?? d.path ?? d.short;
 }
 
 /**

--- a/src/renderer/components/common/document-title.tsx
+++ b/src/renderer/components/common/document-title.tsx
@@ -1,0 +1,33 @@
+import { useEffect } from "react";
+import {
+  type PanelDescriptor,
+  useActiveDescriptor,
+} from "@/stores/panel-descriptor.store.ts";
+
+/**
+ * 解析"长形式"字符串 — sink 共享的 fallback 链.
+ *
+ * 优先级:path (绝对路径, 信息密度最高) > long > short.
+ * terminal panel cd 后 sink 自然显示完整 cwd; 没 path 的 panel 走 long; 都没
+ * 兜底 short (descriptor 契约保证 short 必填).
+ */
+export function resolveLong(d: PanelDescriptor): string {
+  return d.path ?? d.long ?? d.short;
+}
+
+/**
+ * DocumentTitle — 把当前 active panel 的 descriptor 同步到 document.title.
+ *
+ * Electron BrowserWindow.title 默认跟随 webContents.document.title 变化, 主进程
+ * 不需要 IPC. 无 active panel 时 fallback "Pier".
+ *
+ * 渲染 null:这是个纯 side-effect 组件, 不占 DOM.
+ */
+export function DocumentTitle(): null {
+  const active = useActiveDescriptor();
+  useEffect(() => {
+    const text = active ? resolveLong(active) : null;
+    document.title = text ? `${text} — Pier` : "Pier";
+  }, [active]);
+  return null;
+}

--- a/src/renderer/components/common/document-title.tsx
+++ b/src/renderer/components/common/document-title.tsx
@@ -9,10 +9,10 @@ import {
  *
  * 优先级:long > path > short.
  *
- * - long 由 panel 主动计算 (terminal 内部已做 sequenceTitle ?? cwd 优先级),
- *   是 sink "应该显示什么"的权威来源.
- * - path 是真实绝对路径, 给没填 long 的 panel 类型兜底 (理论上 terminal 也会
- *   走这里, 但 terminal 一定填 long).
+ * - long 由 panel 主动计算 (terminal 内部做 sequenceTitle ?? cwd ?? undefined),
+ *   是 sink "应该显示什么"的权威来源. 注意 terminal panel 首次 mount 还没收到
+ *   任何 OSC 时 long 是 undefined, 此时 fall through 到 path (也 undefined) 再到 short.
+ * - path 是真实绝对路径, 给只填 path 不填 long 的 panel 类型兜底.
  * - short 是最终兜底, descriptor 契约保证必填.
  *
  * 注意: 不能让 path 排在 long 前面 — 否则 terminal 的 sequenceTitle 永远被

--- a/src/renderer/components/common/title-bar.tsx
+++ b/src/renderer/components/common/title-bar.tsx
@@ -1,17 +1,22 @@
+import { resolveLong } from "@/components/common/document-title.tsx";
+import { useActiveDescriptor } from "@/stores/panel-descriptor.store.ts";
+
 /**
  * TitleBar — macOS hiddenInset 自定义标题栏.
  *
  * 仅在 macOS 下渲染, 替代被隐藏的原生标题栏:
  * - 整条区域设为 drag region (窗口拖动手柄)
- * - 居中显示窗口标题
+ * - 居中显示当前 active panel 的长形式 (resolveLong: path > long > short, 都无 fallback "Pier")
  * - 背景色 sidebar (= --muted), 与下方 dockview tab 栏同色, 消除色差
  * - 高度 38px, 为 traffic-light 按钮预留足够空间 (trafficLightPosition y:12 + 12px 按钮 + 余量)
  */
 export function TitleBar() {
+  const active = useActiveDescriptor();
+  const text = active ? resolveLong(active) : "Pier";
   return (
     <div className="app-drag flex h-[38px] shrink-0 items-center justify-center border-[var(--sidebar-border)] border-b bg-[var(--sidebar)]">
       <span className="select-none font-medium text-muted-foreground text-xs">
-        Pier
+        {text}
       </span>
     </div>
   );

--- a/src/renderer/components/common/title-bar.tsx
+++ b/src/renderer/components/common/title-bar.tsx
@@ -6,13 +6,15 @@ import { useActiveDescriptor } from "@/stores/panel-descriptor.store.ts";
  *
  * 仅在 macOS 下渲染, 替代被隐藏的原生标题栏:
  * - 整条区域设为 drag region (窗口拖动手柄)
- * - 居中显示当前 active panel 的长形式 (resolveLong: path > long > short, 都无 fallback "Pier")
+ * - 居中显示 active panel 的长形式 (resolveLong: long > path > short), 空值兜底 "Pier"
  * - 背景色 sidebar (= --muted), 与下方 dockview tab 栏同色, 消除色差
  * - 高度 38px, 为 traffic-light 按钮预留足够空间 (trafficLightPosition y:12 + 12px 按钮 + 余量)
  */
 export function TitleBar() {
   const active = useActiveDescriptor();
-  const text = active ? resolveLong(active) : "Pier";
+  // resolveLong 可能返回空字符串 (descriptor 字段空值降级时), `||` 而非 `??`,
+  // 让空串也回退到 "Pier" — 与 document-title.tsx 的兜底行为对齐.
+  const text = (active && resolveLong(active)) || "Pier";
   return (
     <div className="app-drag flex h-[38px] shrink-0 items-center justify-center border-[var(--sidebar-border)] border-b bg-[var(--sidebar)]">
       <span className="select-none font-medium text-muted-foreground text-xs">

--- a/src/renderer/components/workspace/welcome-panel.tsx
+++ b/src/renderer/components/workspace/welcome-panel.tsx
@@ -1,6 +1,8 @@
 import type { IDockviewPanelProps } from "dockview-react";
+import { usePanelDescriptor } from "@/hooks/use-panel-descriptor.ts";
 
-export function WelcomePanel(_props: IDockviewPanelProps) {
+export function WelcomePanel(props: IDockviewPanelProps) {
+  usePanelDescriptor(props.api, { short: "Welcome", long: "Welcome" });
   return (
     <div className="flex h-full items-center justify-center bg-background p-6">
       <div className="text-center">

--- a/src/renderer/components/workspace/workspace-host.tsx
+++ b/src/renderer/components/workspace/workspace-host.tsx
@@ -7,6 +7,7 @@ import {
 import { useCallback } from "react";
 import "dockview-react/dist/styles/dockview.css";
 import { useKeybindingScope } from "@/stores/keybinding-scope.store.ts";
+import { usePanelDescriptorStore } from "@/stores/panel-descriptor.store.ts";
 import { useWorkspaceStore } from "@/stores/workspace.store.ts";
 import { AddPanelAction } from "./add-panel-action.tsx";
 import { panelComponents, panelKindOf } from "./panel-registry.ts";
@@ -102,6 +103,10 @@ export function WorkspaceHost() {
       // null (无 active panel), 此时 fall back 到 "web" + null panelId 防 terminal
       // 抢 firstResponder. getState() 是 imperative 用法, 不是 React hook.
       event.api.onDidActivePanelChange((panel) => {
+        // dockview 是 active 的唯一来源 — 集中推送给 PanelDescriptorStore,
+        // 各 sink (DocumentTitle / TitleBar) 据此显示当前聚焦 panel 的呈现信息.
+        usePanelDescriptorStore.getState().setActive(panel?.id ?? null);
+
         if (!panel) {
           useKeybindingScope.getState().setActivePanel(null, null, null);
           window.pier?.terminal?.setActivePanelKind?.("web", null);

--- a/src/renderer/components/workspace/workspace-host.tsx
+++ b/src/renderer/components/workspace/workspace-host.tsx
@@ -105,7 +105,19 @@ export function WorkspaceHost() {
       event.api.onDidActivePanelChange((panel) => {
         // dockview 是 active 的唯一来源 — 集中推送给 PanelDescriptorStore,
         // 各 sink (DocumentTitle / TitleBar) 据此显示当前聚焦 panel 的呈现信息.
-        usePanelDescriptorStore.getState().setActive(panel?.id ?? null);
+        //
+        // 占位 descriptor:setActive 是同步, 但 panel React 组件的 useEffect
+        // (内含 usePanelDescriptor.upsert) 要 commit 后异步跑. 新建 panel 时
+        // 有一帧 activeId=new 但 descriptors[new]=undefined, sink 退回 "Pier"
+        // 造成闪烁. 先用 panel.title 占位 (panel.title 是 dockview 同步可读的初始值),
+        // panel 自己的 useEffect 跑起来时会用真实计算结果覆盖.
+        const descriptorStore = usePanelDescriptorStore.getState();
+        if (panel && !descriptorStore.descriptors[panel.id]) {
+          descriptorStore.upsert(panel.id, {
+            short: panel.title || "Panel",
+          });
+        }
+        descriptorStore.setActive(panel?.id ?? null);
 
         if (!panel) {
           useKeybindingScope.getState().setActivePanel(null, null, null);

--- a/src/renderer/hooks/use-panel-descriptor.ts
+++ b/src/renderer/hooks/use-panel-descriptor.ts
@@ -1,0 +1,50 @@
+import { useEffect } from "react";
+import {
+  type PanelDescriptor,
+  usePanelDescriptorStore,
+} from "@/stores/panel-descriptor.store.ts";
+
+/**
+ * PanelHandle — dockview panel api 的结构子集.
+ *
+ * 用结构类型而非 import IDockviewPanelApi 是为了让 hook 不依赖 dockview-react,
+ * 任何"有 id + setTitle"的对象都能用 (便于测试 mock + 未来如果换布局库不破坏).
+ * IDockviewPanelApi 形状兼容, 调用方直接传 props.api 即可.
+ */
+export interface PanelHandle {
+  readonly id: string;
+  setTitle(title: string): void;
+}
+
+/**
+ * usePanelDescriptor — panel 向中心 store 注册呈现信息.
+ *
+ * 职责:
+ * - 同步 short 到 dockview tab (api.setTitle)
+ * - upsert 整个 descriptor 到 store (供 active sink 消费)
+ * - 卸载时 remove
+ *
+ * Active 状态由 workspace-host 统一推送 store.activeId, panel 端不参与判断.
+ */
+export function usePanelDescriptor(
+  panel: PanelHandle,
+  descriptor: PanelDescriptor
+): void {
+  const { short, long, path } = descriptor;
+  const upsert = usePanelDescriptorStore((s) => s.upsert);
+  const remove = usePanelDescriptorStore((s) => s.remove);
+
+  useEffect(() => {
+    panel.setTitle(short);
+    // exactOptionalPropertyTypes — 按字段是否定义条件构造, 不显式写 undefined.
+    const next: PanelDescriptor = { short };
+    if (long !== undefined) {
+      next.long = long;
+    }
+    if (path !== undefined) {
+      next.path = path;
+    }
+    upsert(panel.id, next);
+    return () => remove(panel.id);
+  }, [panel, short, long, path, upsert, remove]);
+}

--- a/src/renderer/hooks/use-panel-descriptor.ts
+++ b/src/renderer/hooks/use-panel-descriptor.ts
@@ -21,10 +21,13 @@ export interface PanelHandle {
  *
  * 职责:
  * - 同步 short 到 dockview tab (api.setTitle)
- * - upsert 整个 descriptor 到 store (供 active sink 消费)
+ * - upsert descriptor 到 store (供 active sink 消费)
  * - 卸载时 remove
  *
  * Active 状态由 workspace-host 统一推送 store.activeId, panel 端不参与判断.
+ *
+ * 字段值允许显式 `undefined` (PanelDescriptor 类型已开放), sink 端 `??` 链对
+ * "字段不存在"和"字段值 undefined"行为一致, 不需要在 hook 内过滤.
  */
 export function usePanelDescriptor(
   panel: PanelHandle,
@@ -36,15 +39,7 @@ export function usePanelDescriptor(
 
   useEffect(() => {
     panel.setTitle(short);
-    // exactOptionalPropertyTypes — 按字段是否定义条件构造, 不显式写 undefined.
-    const next: PanelDescriptor = { short };
-    if (long !== undefined) {
-      next.long = long;
-    }
-    if (path !== undefined) {
-      next.path = path;
-    }
-    upsert(panel.id, next);
+    upsert(panel.id, { short, long, path });
     return () => remove(panel.id);
   }, [panel, short, long, path, upsert, remove]);
 }

--- a/src/renderer/hooks/use-panel-event-state.ts
+++ b/src/renderer/hooks/use-panel-event-state.ts
@@ -1,0 +1,45 @@
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * 订阅一个跨进程 panel-scoped 事件流, 按 panelId 过滤后把 extract 出的字段存入
+ * React state. 适用于 terminal-panel 这类"single global listener + per-panel
+ * filter"的场景 (cwd / OSC title / 未来 bell / focus 都同模式).
+ *
+ * 空字符串 / null / undefined 一律视为"无变化"忽略 — IPC 边界协议允许空载荷
+ * (vim set notitle / tmux detach / shell precmd 重置), 不应让 sink 退到 fallback,
+ * 应保留上一次有效值.
+ *
+ * @param subscribe  preload 暴露的订阅函数, 返回 dispose. 引用必须稳定 (contextBridge
+ *                   提供的 API 天然满足).
+ * @param panelId    本 panel 的 id, 用于在 callback 中按 event.panelId 过滤.
+ * @param extract    从 event 提取目标字段的函数. 允许 inline lambda — hook 内用
+ *                   useRef 保最新引用, 避免 re-subscribe.
+ */
+export function usePanelEventState<E extends { panelId: string }, V>(
+  subscribe: (cb: (event: E) => void) => () => void,
+  panelId: string,
+  extract: (event: E) => V | null | undefined
+): V | null {
+  const [value, setValue] = useState<V | null>(null);
+
+  // extract 通常是 inline lambda, 每次渲染新引用. useRef 让 effect 总是用最新的
+  // 但不把 extract 放进 deps — 避免每次渲染 re-subscribe + re-add listener.
+  const extractRef = useRef(extract);
+  extractRef.current = extract;
+
+  useEffect(() => {
+    const dispose = subscribe((event) => {
+      if (event.panelId !== panelId) {
+        return;
+      }
+      const next = extractRef.current(event);
+      if (next === null || next === undefined || next === "") {
+        return;
+      }
+      setValue(next);
+    });
+    return dispose;
+  }, [panelId, subscribe]);
+
+  return value;
+}

--- a/src/renderer/panel-kits/terminal/terminal-panel.tsx
+++ b/src/renderer/panel-kits/terminal/terminal-panel.tsx
@@ -25,16 +25,47 @@ function waitForRealSize(anchor: HTMLDivElement): Promise<void> {
   });
 }
 
+/**
+ * 路径 basename — POSIX 形式 (终端始终在 macOS).
+ * 末尾 '/' 容错: "/" → "/"; "/a/b/" → "b"; "/a/b" → "b"; "" → "Terminal".
+ */
+export function basename(path: string): string {
+  if (path === "" || path === "/") {
+    return path === "" ? "Terminal" : "/";
+  }
+  const trimmed = path.endsWith("/") ? path.slice(0, -1) : path;
+  const idx = trimmed.lastIndexOf("/");
+  return idx === -1 ? trimmed : trimmed.slice(idx + 1);
+}
+
 export function TerminalPanel(props: IDockviewPanelProps) {
   const { api } = props;
   const panelId = api.id;
   const anchorRef = useRef<HTMLDivElement>(null);
   const parentRef = useRef<HTMLDivElement>(null);
   const [error, setError] = useState<string | null>(null);
+  const [cwd, setCwd] = useState<string | null>(null);
 
-  // 注册呈现信息 — 当前固定 "Terminal", 后续接入 OSC 0/2 / 前台进程名 / cwd 时
-  // 只换这里传入的字符串, hook / store / sink 不变.
-  usePanelDescriptor(api, { short: "Terminal", long: "Terminal" });
+  // 订阅 swift OSC 7 → main → 这里. cwd 变化 setState 触发 descriptor 重新计算.
+  // 单 listener 接所有 panel 的事件 — 按 panelId 自行过滤.
+  useEffect(() => {
+    const dispose = window.pier.terminal.onCwdChange((event) => {
+      if (event.panelId === panelId) {
+        setCwd(event.cwd);
+      }
+    });
+    return dispose;
+  }, [panelId]);
+
+  // 把 cwd 翻译成 descriptor 三字段:
+  // - short: basename(cwd) — tab strip
+  // - long:  cwd            — sink 长形式 (resolveLong 会优先用 path)
+  // - path:  cwd            — sink 优先字段, 也是未来 breadcrumb / status bar 用的数据
+  // 没 cwd 时 fallback "Terminal" (只填 short, 不传 long/path).
+  usePanelDescriptor(
+    api,
+    cwd ? { short: basename(cwd), long: cwd, path: cwd } : { short: "Terminal" }
+  );
 
   useLayoutEffect(() => {
     const parent = parentRef.current?.parentElement;

--- a/src/renderer/panel-kits/terminal/terminal-panel.tsx
+++ b/src/renderer/panel-kits/terminal/terminal-panel.tsx
@@ -45,27 +45,55 @@ export function TerminalPanel(props: IDockviewPanelProps) {
   const parentRef = useRef<HTMLDivElement>(null);
   const [error, setError] = useState<string | null>(null);
   const [cwd, setCwd] = useState<string | null>(null);
+  const [sequenceTitle, setSequenceTitle] = useState<string | null>(null);
 
   // 订阅 swift OSC 7 → main → 这里. cwd 变化 setState 触发 descriptor 重新计算.
   // 单 listener 接所有 panel 的事件 — 按 panelId 自行过滤.
   useEffect(() => {
-    const dispose = window.pier.terminal.onCwdChange((event) => {
+    const disposeCwd = window.pier.terminal.onCwdChange((event) => {
       if (event.panelId === panelId) {
         setCwd(event.cwd);
       }
     });
-    return dispose;
+    // 订阅 OSC 0/2 title — TUI 应用 (claude / vim / aider) 主动设的自定义 title.
+    // 退出 TUI 后 shell 通常不会"清空" title, sequenceTitle 会保留直到下一个应用
+    // 写新值; 如果想"退出 claude 后 long 回到 cwd", 可以接 process-exit 事件主动
+    // 清空 — v1 暂不做.
+    const disposeTitle = window.pier.terminal.onTitleChange((event) => {
+      if (event.panelId === panelId) {
+        setSequenceTitle(event.title);
+      }
+    });
+    return () => {
+      disposeCwd();
+      disposeTitle();
+    };
   }, [panelId]);
 
-  // 把 cwd 翻译成 descriptor 三字段:
-  // - short: basename(cwd) — tab strip
-  // - long:  cwd            — sink 长形式 (resolveLong 会优先用 path)
-  // - path:  cwd            — sink 优先字段, 也是未来 breadcrumb / status bar 用的数据
-  // 没 cwd 时 fallback "Terminal" (只填 short, 不传 long/path).
-  usePanelDescriptor(
-    api,
-    cwd ? { short: basename(cwd), long: cwd, path: cwd } : { short: "Terminal" }
-  );
+  // descriptor 三字段优先级链:
+  // - short: basename(cwd) — tab strip 始终显示目录, 不被 OSC 干扰 (稳定锚点)
+  // - long:  sequenceTitle ?? cwd — sink 优先 OSC 自定义 ("Claude Code"),
+  //          没 OSC 时 fallback cwd 完整路径
+  // - path:  cwd — 真实 cwd, 不被 OSC override (breadcrumb / status bar 用)
+  // 没 cwd 没 OSC 时只传 short = "Terminal".
+  const descriptor = ((): {
+    short: string;
+    long?: string;
+    path?: string;
+  } => {
+    const short = cwd ? basename(cwd) : "Terminal";
+    const long = sequenceTitle ?? cwd ?? undefined;
+    const path = cwd ?? undefined;
+    const result: { short: string; long?: string; path?: string } = { short };
+    if (long !== undefined) {
+      result.long = long;
+    }
+    if (path !== undefined) {
+      result.path = path;
+    }
+    return result;
+  })();
+  usePanelDescriptor(api, descriptor);
 
   useLayoutEffect(() => {
     const parent = parentRef.current?.parentElement;

--- a/src/renderer/panel-kits/terminal/terminal-panel.tsx
+++ b/src/renderer/panel-kits/terminal/terminal-panel.tsx
@@ -2,6 +2,7 @@ import type { TerminalFrame } from "@shared/contracts/terminal.ts";
 import type { IDockviewPanelProps } from "dockview-react";
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { usePanelDescriptor } from "@/hooks/use-panel-descriptor.ts";
+import { usePanelEventState } from "@/hooks/use-panel-event-state.ts";
 import { popupContextMenuAt } from "@/lib/context-menu/use-context-menu.ts";
 
 function getAnchorFrame(anchor: HTMLDivElement): TerminalFrame | null {
@@ -45,57 +46,31 @@ export function TerminalPanel(props: IDockviewPanelProps) {
   const anchorRef = useRef<HTMLDivElement>(null);
   const parentRef = useRef<HTMLDivElement>(null);
   const [error, setError] = useState<string | null>(null);
-  const [cwd, setCwd] = useState<string | null>(null);
-  const [sequenceTitle, setSequenceTitle] = useState<string | null>(null);
 
-  // 订阅 swift OSC 7 → main → 这里. cwd 变化 setState 触发 descriptor 重新计算.
-  // 单 listener 接所有 panel 的事件 — 按 panelId 自行过滤.
-  //
-  // 空字符串过滤:OSC 0/2 / OSC 7 协议允许发空载荷 ("clear title"),
-  // 例如 vim `set notitle` / tmux detach / 自定义 precmd 重置. 若把空串放进 store,
-  // `??` 不捕获空串会让 long="" 一路泄漏到 sink, macOS titlebar 渲染空白条.
-  // 在最上游过滤掉空串 — 保留上一次有效值, 避免回退到 fallback 闪烁.
-  useEffect(() => {
-    const disposeCwd = window.pier.terminal.onCwdChange((event) => {
-      if (event.panelId === panelId && event.cwd) {
-        setCwd(event.cwd);
-      }
-    });
-    const disposeTitle = window.pier.terminal.onTitleChange((event) => {
-      if (event.panelId === panelId && event.title) {
-        setSequenceTitle(event.title);
-      }
-    });
-    return () => {
-      disposeCwd();
-      disposeTitle();
-    };
-  }, [panelId]);
+  // 订阅 swift OSC 7 → main → 这里. usePanelEventState 自动按 panelId 过滤 +
+  // 空字符串忽略 (vim set notitle / tmux detach 等清空场景不污染上一次有效值).
+  const cwd = usePanelEventState(
+    window.pier.terminal.onCwdChange,
+    panelId,
+    (e) => e.cwd
+  );
+  const sequenceTitle = usePanelEventState(
+    window.pier.terminal.onTitleChange,
+    panelId,
+    (e) => e.title
+  );
 
   // descriptor 三字段优先级链:
   // - short: basename(cwd) — tab strip 始终显示目录, 不被 OSC 干扰 (稳定锚点)
   // - long:  sequenceTitle ?? cwd — sink 优先 OSC 自定义 ("Claude Code"),
   //          没 OSC 时 fallback cwd 完整路径
   // - path:  cwd — 真实 cwd, 不被 OSC override (breadcrumb / status bar 用)
-  // 没 cwd 没 OSC 时只传 short = "Terminal".
-  const descriptor = ((): {
-    short: string;
-    long?: string;
-    path?: string;
-  } => {
-    const short = cwd ? basename(cwd) : "Terminal";
-    const long = sequenceTitle ?? cwd ?? undefined;
-    const path = cwd ?? undefined;
-    const result: { short: string; long?: string; path?: string } = { short };
-    if (long !== undefined) {
-      result.long = long;
-    }
-    if (path !== undefined) {
-      result.path = path;
-    }
-    return result;
-  })();
-  usePanelDescriptor(api, descriptor);
+  // hook input 接受 undefined; hook 内部按字段存在性条件 upsert 到 store.
+  usePanelDescriptor(api, {
+    short: cwd ? basename(cwd) : "Terminal",
+    long: sequenceTitle ?? cwd ?? undefined,
+    path: cwd ?? undefined,
+  });
 
   useLayoutEffect(() => {
     const parent = parentRef.current?.parentElement;

--- a/src/renderer/panel-kits/terminal/terminal-panel.tsx
+++ b/src/renderer/panel-kits/terminal/terminal-panel.tsx
@@ -1,6 +1,7 @@
 import type { TerminalFrame } from "@shared/contracts/terminal.ts";
 import type { IDockviewPanelProps } from "dockview-react";
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { usePanelDescriptor } from "@/hooks/use-panel-descriptor.ts";
 
 function getAnchorFrame(anchor: HTMLDivElement): TerminalFrame | null {
   const r = anchor.getBoundingClientRect();
@@ -30,6 +31,10 @@ export function TerminalPanel(props: IDockviewPanelProps) {
   const anchorRef = useRef<HTMLDivElement>(null);
   const parentRef = useRef<HTMLDivElement>(null);
   const [error, setError] = useState<string | null>(null);
+
+  // 注册呈现信息 — 当前固定 "Terminal", 后续接入 OSC 0/2 / 前台进程名 / cwd 时
+  // 只换这里传入的字符串, hook / store / sink 不变.
+  usePanelDescriptor(api, { short: "Terminal", long: "Terminal" });
 
   useLayoutEffect(() => {
     const parent = parentRef.current?.parentElement;

--- a/src/renderer/panel-kits/terminal/terminal-panel.tsx
+++ b/src/renderer/panel-kits/terminal/terminal-panel.tsx
@@ -49,18 +49,19 @@ export function TerminalPanel(props: IDockviewPanelProps) {
 
   // 订阅 swift OSC 7 → main → 这里. cwd 变化 setState 触发 descriptor 重新计算.
   // 单 listener 接所有 panel 的事件 — 按 panelId 自行过滤.
+  //
+  // 空字符串过滤:OSC 0/2 / OSC 7 协议允许发空载荷 ("clear title"),
+  // 例如 vim `set notitle` / tmux detach / 自定义 precmd 重置. 若把空串放进 store,
+  // `??` 不捕获空串会让 long="" 一路泄漏到 sink, macOS titlebar 渲染空白条.
+  // 在最上游过滤掉空串 — 保留上一次有效值, 避免回退到 fallback 闪烁.
   useEffect(() => {
     const disposeCwd = window.pier.terminal.onCwdChange((event) => {
-      if (event.panelId === panelId) {
+      if (event.panelId === panelId && event.cwd) {
         setCwd(event.cwd);
       }
     });
-    // 订阅 OSC 0/2 title — TUI 应用 (claude / vim / aider) 主动设的自定义 title.
-    // 退出 TUI 后 shell 通常不会"清空" title, sequenceTitle 会保留直到下一个应用
-    // 写新值; 如果想"退出 claude 后 long 回到 cwd", 可以接 process-exit 事件主动
-    // 清空 — v1 暂不做.
     const disposeTitle = window.pier.terminal.onTitleChange((event) => {
-      if (event.panelId === panelId) {
+      if (event.panelId === panelId && event.title) {
         setSequenceTitle(event.title);
       }
     });

--- a/src/renderer/stores/panel-descriptor.store.ts
+++ b/src/renderer/stores/panel-descriptor.store.ts
@@ -29,11 +29,12 @@ interface PanelDescriptorState {
  * 写入方:
  * - panel 端通过 usePanelDescriptor hook 注册/更新/卸载 (upsert/remove)
  * - workspace-host 通过 dockview onDidActivePanelChange 推送 activeId
+ *   (同时同步 upsert 占位 descriptor, 避免 panel useEffect 异步 commit 间隙闪烁)
  *
- * 读取方:
- * - DocumentTitle:document.title (long ?? short)
- * - TitleBar (macOS):自定义标题栏 (同上)
- * - 未来:全局 panel 列表 / breadcrumb / agent 状态总览
+ * 读取方 (经 resolveLong, 优先级 long > path > short):
+ * - DocumentTitle:document.title
+ * - TitleBar (macOS):自定义标题栏
+ * - 未来:全局 panel 列表 / breadcrumb (消费 path) / agent 状态总览
  *
  * 不在 hook 里监听 isActive — active 唯一来源是 dockview, 集中推 store, 防止
  * N 个 panel 各自判断 active 的竞态.

--- a/src/renderer/stores/panel-descriptor.store.ts
+++ b/src/renderer/stores/panel-descriptor.store.ts
@@ -1,0 +1,62 @@
+import { create } from "zustand";
+
+/**
+ * PanelDescriptor — panel 向系统汇报的"如何展示"信息.
+ *
+ * 字段保持开放, 后续按需扩展 (tooltip / status / icon / breadcrumb 等).
+ * Sink 侧约定:取不到字段时 fallback 到 short.
+ */
+export interface PanelDescriptor {
+  /** 完整形式 — document.title / titlebar / 单 tab 模式 */
+  long?: string;
+  /** 当前工作目录绝对路径 — terminal 由 OSC 7 提供; 其他 panel 可不填. sink 优先消费. */
+  path?: string;
+  /** 紧凑形式 — tab strip 等空间受限处 */
+  short: string;
+}
+
+interface PanelDescriptorState {
+  activeId: string | null;
+  descriptors: Record<string, PanelDescriptor>;
+  remove: (id: string) => void;
+  setActive: (id: string | null) => void;
+  upsert: (id: string, descriptor: PanelDescriptor) => void;
+}
+
+/**
+ * PanelDescriptorStore — 所有 panel 呈现信息的中心.
+ *
+ * 写入方:
+ * - panel 端通过 usePanelDescriptor hook 注册/更新/卸载 (upsert/remove)
+ * - workspace-host 通过 dockview onDidActivePanelChange 推送 activeId
+ *
+ * 读取方:
+ * - DocumentTitle:document.title (long ?? short)
+ * - TitleBar (macOS):自定义标题栏 (同上)
+ * - 未来:全局 panel 列表 / breadcrumb / agent 状态总览
+ *
+ * 不在 hook 里监听 isActive — active 唯一来源是 dockview, 集中推 store, 防止
+ * N 个 panel 各自判断 active 的竞态.
+ */
+export const usePanelDescriptorStore = create<PanelDescriptorState>((set) => ({
+  descriptors: {},
+  activeId: null,
+  upsert: (id, descriptor) =>
+    set((s) => ({ descriptors: { ...s.descriptors, [id]: descriptor } })),
+  remove: (id) =>
+    set((s) => {
+      if (!(id in s.descriptors)) {
+        return s;
+      }
+      const next = { ...s.descriptors };
+      delete next[id];
+      return { descriptors: next };
+    }),
+  setActive: (id) => set({ activeId: id }),
+}));
+
+export function useActiveDescriptor(): PanelDescriptor | null {
+  return usePanelDescriptorStore((s) =>
+    s.activeId ? (s.descriptors[s.activeId] ?? null) : null
+  );
+}

--- a/src/renderer/stores/panel-descriptor.store.ts
+++ b/src/renderer/stores/panel-descriptor.store.ts
@@ -8,9 +8,9 @@ import { create } from "zustand";
  */
 export interface PanelDescriptor {
   /** 完整形式 — document.title / titlebar / 单 tab 模式 */
-  long?: string;
+  long?: string | undefined;
   /** 当前工作目录绝对路径 — terminal 由 OSC 7 提供; 其他 panel 可不填. sink 优先消费. */
-  path?: string;
+  path?: string | undefined;
   /** 紧凑形式 — tab strip 等空间受限处 */
   short: string;
 }

--- a/src/shared/contracts/terminal.ts
+++ b/src/shared/contracts/terminal.ts
@@ -24,6 +24,16 @@ export interface TerminalCwdEvent {
   panelId: string;
 }
 
+/**
+ * Terminal title 变化事件 — swift OSC 0/2 解析后通过 IPC 推送到 renderer.
+ * title 是 TUI 应用 (claude / vim / aider) 主动设置的自定义 window title,
+ * descriptor.long 的最高优先级来源.
+ */
+export interface TerminalTitleEvent {
+  panelId: string;
+  title: string;
+}
+
 export interface TerminalAPI {
   close(panelId: string): Promise<void>;
   create(args: CreateTerminalArgs): Promise<CreateTerminalResult>;
@@ -34,6 +44,11 @@ export interface TerminalAPI {
    * 单个 listener 接收所有 panel 的事件 — 调用方按 panelId 自行过滤.
    */
   onCwdChange(cb: (event: TerminalCwdEvent) => void): () => void;
+  /**
+   * 订阅 terminal title (OSC 0/2) 变化. 回调返回 dispose 函数.
+   * 单 listener 接所有 panel 事件 — 调用方按 panelId 过滤.
+   */
+  onTitleChange(cb: (event: TerminalTitleEvent) => void): () => void;
   setActivePanelKind: (
     kind: "terminal" | "web",
     panelId: string | null

--- a/src/shared/contracts/terminal.ts
+++ b/src/shared/contracts/terminal.ts
@@ -15,11 +15,25 @@ export interface CreateTerminalResult {
   ok: boolean;
 }
 
+/**
+ * Terminal cwd 变化事件 — swift OSC 7 解析后通过 IPC 推送到 renderer.
+ * cwd 是绝对路径 (file:// 前缀已由 swift 端从 URL 提取掉).
+ */
+export interface TerminalCwdEvent {
+  cwd: string;
+  panelId: string;
+}
+
 export interface TerminalAPI {
   close(panelId: string): Promise<void>;
   create(args: CreateTerminalArgs): Promise<CreateTerminalResult>;
   focus(panelId: string): void;
   hide(panelId: string): void;
+  /**
+   * 订阅 terminal cwd 变化. 回调返回 dispose 函数, 调用即取消订阅.
+   * 单个 listener 接收所有 panel 的事件 — 调用方按 panelId 自行过滤.
+   */
+  onCwdChange(cb: (event: TerminalCwdEvent) => void): () => void;
   setActivePanelKind: (
     kind: "terminal" | "web",
     panelId: string | null

--- a/src/shared/contracts/terminal.ts
+++ b/src/shared/contracts/terminal.ts
@@ -85,7 +85,11 @@ export interface TerminalColors {
 
 export interface TerminalAPI {
   applyTheme(colors: TerminalColors): void;
-  close(panelId: string): Promise<void>;
+  /**
+   * 关闭 terminal panel 的 native NSView. fire-and-forget — swift 端 close 是同步
+   * 调用, 调用方不需要 await. 调用 idempotent (panelId 不存在时 no-op).
+   */
+  close(panelId: string): void;
   create(args: CreateTerminalArgs): Promise<CreateTerminalResult>;
   focus(panelId: string): void;
   hide(panelId: string): void;

--- a/src/shared/contracts/terminal.ts
+++ b/src/shared/contracts/terminal.ts
@@ -41,12 +41,13 @@ export interface TerminalAPI {
   hide(panelId: string): void;
   /**
    * 订阅 terminal cwd 变化. 回调返回 dispose 函数, 调用即取消订阅.
-   * 单个 listener 接收所有 panel 的事件 — 调用方按 panelId 自行过滤.
+   * 每次调用建立一个独立 listener — 调用方收到所有 panel 的事件并自行按
+   * panelId 过滤. 多 panel 场景下会有 N 个 listener, 每个 panel 自行 dispose.
    */
   onCwdChange(cb: (event: TerminalCwdEvent) => void): () => void;
   /**
    * 订阅 terminal title (OSC 0/2) 变化. 回调返回 dispose 函数.
-   * 单 listener 接所有 panel 事件 — 调用方按 panelId 过滤.
+   * 与 onCwdChange 相同的"多 listener 各自过滤"模式.
    */
   onTitleChange(cb: (event: TerminalTitleEvent) => void): () => void;
   setActivePanelKind: (

--- a/tests/component/welcome-panel.test.tsx
+++ b/tests/component/welcome-panel.test.tsx
@@ -1,12 +1,12 @@
 import { render, screen } from "@testing-library/react";
 import type { IDockviewPanelProps } from "dockview-react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { WelcomePanel } from "@/components/workspace/welcome-panel.tsx";
 
-// WelcomePanel 不读 props, 测试只需喂满足类型的最小 mock.
-// dockview 的 api/containerApi 在此组件不被调用, 用空对象满足结构即可.
+// WelcomePanel 现在调 usePanelDescriptor, 需要 mock api.id + api.setTitle.
+// dockview 的 containerApi 在此组件不被调用, 用空对象满足结构即可.
 const mockProps = {
-  api: {},
+  api: { id: "welcome-test", setTitle: vi.fn() },
   containerApi: {},
 } as unknown as IDockviewPanelProps;
 

--- a/tests/unit/cwd-derive.test.ts
+++ b/tests/unit/cwd-derive.test.ts
@@ -21,21 +21,32 @@ describe("basename", () => {
 });
 
 describe("resolveLong", () => {
-  it("prefers path over long", () => {
+  it("prefers long over path (long 是 panel 主动计算的权威值)", () => {
     expect(
       resolveLong({
         short: "pier",
-        long: "Pier project",
+        long: "Claude Code",
         path: "/Users/x/pier",
       })
-    ).toBe("/Users/x/pier");
+    ).toBe("Claude Code");
   });
 
-  it("falls back to long when no path", () => {
-    expect(resolveLong({ short: "x", long: "long text" })).toBe("long text");
+  it("falls back to path when no long", () => {
+    expect(resolveLong({ short: "x", path: "/tmp/abc" })).toBe("/tmp/abc");
   });
 
-  it("falls back to short when neither path nor long", () => {
+  it("falls back to short when neither long nor path", () => {
     expect(resolveLong({ short: "x" })).toBe("x");
+  });
+
+  it("OSC sequenceTitle 在 long 里时优先于真实 cwd path", () => {
+    // 模拟 terminal-panel 真实输入:long=sequenceTitle, path=cwd
+    expect(
+      resolveLong({
+        short: "pier",
+        long: "Claude Code",
+        path: "/Users/x/ABC/pier",
+      })
+    ).toBe("Claude Code");
   });
 });

--- a/tests/unit/cwd-derive.test.ts
+++ b/tests/unit/cwd-derive.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { resolveLong } from "@/components/common/document-title.tsx";
+
+describe("resolveLong", () => {
+  it("prefers path over long", () => {
+    expect(
+      resolveLong({
+        short: "pier",
+        long: "Pier project",
+        path: "/Users/x/pier",
+      })
+    ).toBe("/Users/x/pier");
+  });
+
+  it("falls back to long when no path", () => {
+    expect(resolveLong({ short: "x", long: "long text" })).toBe("long text");
+  });
+
+  it("falls back to short when neither path nor long", () => {
+    expect(resolveLong({ short: "x" })).toBe("x");
+  });
+});

--- a/tests/unit/cwd-derive.test.ts
+++ b/tests/unit/cwd-derive.test.ts
@@ -1,5 +1,24 @@
 import { describe, expect, it } from "vitest";
 import { resolveLong } from "@/components/common/document-title.tsx";
+import { basename } from "@/panel-kits/terminal/terminal-panel.tsx";
+
+describe("basename", () => {
+  it('handles "/" root', () => {
+    expect(basename("/")).toBe("/");
+  });
+  it("strips trailing slash", () => {
+    expect(basename("/a/b/")).toBe("b");
+  });
+  it("returns last segment", () => {
+    expect(basename("/Users/x/ABC/pier")).toBe("pier");
+  });
+  it("returns input when no slash", () => {
+    expect(basename("pier")).toBe("pier");
+  });
+  it('fallback "Terminal" for empty input', () => {
+    expect(basename("")).toBe("Terminal");
+  });
+});
 
 describe("resolveLong", () => {
   it("prefers path over long", () => {

--- a/tests/unit/panel-descriptor.test.ts
+++ b/tests/unit/panel-descriptor.test.ts
@@ -1,4 +1,6 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { usePanelDescriptor } from "@/hooks/use-panel-descriptor.ts";
 import { usePanelDescriptorStore } from "@/stores/panel-descriptor.store.ts";
 
 describe("PanelDescriptor store", () => {
@@ -24,5 +26,39 @@ describe("PanelDescriptor store", () => {
     const d = usePanelDescriptorStore.getState().descriptors.p1;
     expect(d).toBeDefined();
     expect(d?.path).toBeUndefined();
+  });
+});
+
+describe("usePanelDescriptor hook", () => {
+  beforeEach(() => {
+    usePanelDescriptorStore.setState({ descriptors: {}, activeId: null });
+  });
+
+  it("upserts path field into store and sets tab title to short", () => {
+    const setTitle = vi.fn();
+    const panel = { id: "term-1", setTitle };
+
+    renderHook(() =>
+      usePanelDescriptor(panel, {
+        short: "pier",
+        long: "/Users/x/ABC/pier",
+        path: "/Users/x/ABC/pier",
+      })
+    );
+
+    const stored = usePanelDescriptorStore.getState().descriptors["term-1"];
+    expect(stored).toBeDefined();
+    expect(stored?.path).toBe("/Users/x/ABC/pier");
+    expect(setTitle).toHaveBeenCalledWith("pier");
+  });
+
+  it("descriptor without path stores only short/long", () => {
+    const panel = { id: "term-2", setTitle: vi.fn() };
+    renderHook(() => usePanelDescriptor(panel, { short: "Terminal" }));
+
+    const stored = usePanelDescriptorStore.getState().descriptors["term-2"];
+    expect(stored).toBeDefined();
+    expect(stored?.path).toBeUndefined();
+    expect(stored?.short).toBe("Terminal");
   });
 });

--- a/tests/unit/panel-descriptor.test.ts
+++ b/tests/unit/panel-descriptor.test.ts
@@ -1,0 +1,28 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { usePanelDescriptorStore } from "@/stores/panel-descriptor.store.ts";
+
+describe("PanelDescriptor store", () => {
+  beforeEach(() => {
+    usePanelDescriptorStore.setState({ descriptors: {}, activeId: null });
+  });
+
+  it("stores path field alongside short/long", () => {
+    usePanelDescriptorStore.getState().upsert("p1", {
+      short: "pier",
+      long: "/Users/x/ABC/pier",
+      path: "/Users/x/ABC/pier",
+    });
+    const d = usePanelDescriptorStore.getState().descriptors.p1;
+    expect(d).toBeDefined();
+    expect(d?.path).toBe("/Users/x/ABC/pier");
+    expect(d?.long).toBe("/Users/x/ABC/pier");
+    expect(d?.short).toBe("pier");
+  });
+
+  it("path is optional — descriptor without path is valid", () => {
+    usePanelDescriptorStore.getState().upsert("p1", { short: "Welcome" });
+    const d = usePanelDescriptorStore.getState().descriptors.p1;
+    expect(d).toBeDefined();
+    expect(d?.path).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

打通 shell → Ghostty → swift → C++ → main → preload → renderer 完整链路, 让 terminal panel 的 tab 和窗口 title 反映真实的当前工作目录 (OSC 7) 和 TUI 应用自定义 title (OSC 0/2).

### 之前
- panel tab 都叫 "Terminal"(5 处硬编码), 多终端无法区分
- macOS 自定义标题栏硬编码 "Pier"
- 没有任何 cwd / OSC title 上报通道

### 现在
- tab 显示 cwd basename (`pier`, `tmp`, ...), cd 后实时变
- 系统 title / titlebar 显示 OSC 自定义 (`Claude Code`, `vim foo.ts`) 或 cwd 全路径
- 架构是通用的 `PanelDescriptor` + 中心 store + 多 sink, 后续 welcome / file-viewer / code-changes panel 走同一套

## 架构

```
shell OSC 7 / TUI OSC 0/2
  ↓ Ghostty parser
  ↓ swift TerminalEventDelegate (PwdDelegate + TitleDelegate)
  ↓ C trampoline + N-API ThreadSafeFunction (g_pwdTSFN / g_titleTSFN)
  ↓ webContents.send('pier:terminal:cwd-change' | 'title-change')
  ↓ preload onCwdChange / onTitleChange
  ↓ terminal-panel useState(cwd / sequenceTitle)
  ↓ usePanelDescriptor → PanelDescriptorStore (descriptors map + activeId)
  ↓ DocumentTitle / TitleBar sinks → resolveLong (long > path > short)
```

### Renderer 端架构

- **\`PanelDescriptor\`**: \`{ short, long?, path? }\` 三字段 slot 设计, 后续可扩 status / tooltip / icon
- **\`usePanelDescriptor(api, descriptor)\`**: panel 注册接口, 用结构类型 \`PanelHandle\` 抽象避免依赖 dockview-react
- **\`usePanelDescriptorStore\`**: 中心 store, panel 端 upsert, workspace-host 推 activeId
- **\`resolveLong\`**: sink 共享的 fallback 链 (long > path > short)
- **\`<DocumentTitle />\`**: 纯 effect 写 \`document.title\`, Electron 自动同步 \`BrowserWindow.title\`
- **\`<TitleBar />\`**: macOS 自定义标题栏读 activeDescriptor

### Native 端

- **\`TerminalEventDelegate\`**: 同时实现 \`TerminalSurfacePwdDelegate\` + \`TerminalSurfaceTitleDelegate\`(libghostty callback bridge 动态转型支持单 delegate 多 protocol). 自持 \`browserWindowId\` 避免全局 panelId 反查跨窗口冲突.
- **C++ trampoline**: \`g_pwdTSFN\` / \`g_titleTSFN\` 跨线程桥 (与已有 keyboard forward 同模式)

### Terminal 端优先级 (terminal-panel.tsx)

| 字段 | 公式 | 用途 |
|---|---|---|
| \`short\` | \`basename(cwd) ?? "Terminal"\` | tab strip (稳定, 不受 OSC 影响) |
| \`long\` | \`sequenceTitle ?? cwd ?? undefined\` | document.title / titlebar (OSC 优先) |
| \`path\` | \`cwd ?? undefined\` | 真实 cwd, 给未来 breadcrumb / status bar |

## What's changed

### 链路代码
- \`native/Sources/GhosttyBridge/GhosttyBridge.swift\` — TerminalEventDelegate + C ABI export
- \`native/src/addon.mm\` — 两个新 ThreadSafeFunction + JsSet\\*ForwardCallback
- \`src/main/ipc/terminal.ts\` — 两条 forward callback 注册
- \`src/shared/contracts/terminal.ts\` — TerminalCwdEvent / TerminalTitleEvent + 订阅 API
- \`src/preload/index.ts\` — onCwdChange / onTitleChange
- \`src/renderer/stores/panel-descriptor.store.ts\` — 中心 store
- \`src/renderer/hooks/use-panel-descriptor.ts\` — panel 注册 hook
- \`src/renderer/components/common/document-title.tsx\` — sink + resolveLong
- \`src/renderer/components/common/title-bar.tsx\` — sink
- \`src/renderer/components/workspace/workspace-host.tsx\` — 推 activeId + 占位 descriptor
- \`src/renderer/panel-kits/terminal/terminal-panel.tsx\` — useState(cwd/sequenceTitle) + 订阅

### 测试
- \`tests/unit/panel-descriptor.test.ts\` — store + hook (4 cases)
- \`tests/unit/cwd-derive.test.ts\` — basename + resolveLong (9 cases)
- \`tests/component/welcome-panel.test.tsx\` — mock 修复(api 加 id + setTitle)

### 文档
- \`docs/superpowers/plans/2026-06-23-terminal-cwd-pipeline.md\` — 实施 plan

## Test plan

### 自动化(本地已验证全绿)

- [x] \`pnpm typecheck\` — 0 errors
- [x] \`pnpm test:unit\` — 27 passed
- [x] \`pnpm test:component\` — 1 passed (welcome-panel 修复)
- [x] \`pnpm depcruise\` — 0 violations
- [x] \`pnpm check:file-size\` — pass
- [x] native rebuild — 85K, link 成功

### 手动验证(需 \`pnpm dev\` 在 macOS 桌面跑)

| 操作 | 预期 tab | 预期窗口 title |
|---|---|---|
| 启动 | \`Terminal\` | \`Pier\` |
| \`cd /tmp\` | \`tmp\` | \`/tmp — Pier\` |
| \`cd ~/ABC/pier\` | \`pier\` | \`/Users/.../pier — Pier\` |
| 跑 \`claude\` | \`pier\`(不变) | \`Claude Code — Pier\` |
| 跑 \`vim foo.ts\` | \`pier\`(不变) | \`vim foo.ts — Pier\` |
| Cmd+T 新建 panel | 立即显示新 panel title(无闪烁) | 同步切换 |

### 已知依赖

- **OSC 7 cwd 上报**:需要 shell 配 shell-integration(zsh/bash 默认不发). 没生效时 tab 仍是 \`Terminal\` fallback — 此时需要把 Ghostty \`shell-integration\` 脚本通过 \`XDG_DATA_DIRS\` 注入到 PTY env (本 PR 范围外, 留给后续).
- **OSC 0/2 title**:TUI 应用主动发, 无依赖.

## Code review

本地跑了 max-effort review(63 agents,10 finder angles + verify + sweep),发现并修复了 9 处问题:

- **真 bug**(5):welcome-panel test regression / 空 OSC 字符串泄漏 / TitleBar 空串渲染 / swift panelId 跨窗口冲突 / Cmd+T 闪烁一帧
- **文档不一致**(4):resolveLong 优先级注释反 / "terminal 一定填 long" 错前提 / store JSDoc 漏 path / contract listener 说明

剩 5 个 cleanup(三段 TSFN 同构 / forward handler 同构 / IPC subscriber 同构 / basename 应迁 lib/ / welcome long 冗余)留给下一个 PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)