### PR TITLE
feat(command-palette): MRU 分组+组内双层 frecency 排序 + 多窗口持久化

### DIFF
--- a/docs/superpowers/plans/2026-06-23-command-palette-mru.md
+++ b/docs/superpowers/plans/2026-06-23-command-palette-mru.md
@@ -1,0 +1,1538 @@
+# 命令面板 MRU 排序 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 给命令面板加上分组与组内双层 MRU（frecency）排序，并把使用记录持久化到 `userData/command-palette-mru.json`，多窗口同步。
+
+**Architecture:** main 进程独占持有 entries 状态（lockfile + atomic write），renderer 启动时拉一次、之后订阅广播。renderer 计算 frecency map 注入 `groupActions`，未用过的命令/分组回退原 `sortOrder` / `CATEGORY_META.order`。有 query 时不重排，把排序权完全交给 cmdk。
+
+**Tech Stack:** Electron 42 IPC（invoke + send + webContents.send）+ zod schema + proper-lockfile + write-file-atomic + zustand + cmdk + vitest（jsdom）+ playwright。
+
+**Spec:** [docs/superpowers/specs/2026-06-23-command-palette-mru-design.md](../specs/2026-06-23-command-palette-mru-design.md)
+
+**Reference:**
+- 持久化层 pattern: [src/main/state/preferences.ts](../../../src/main/state/preferences.ts)
+- IPC 注册 pattern: [src/main/ipc/preferences.ts](../../../src/main/ipc/preferences.ts) + [src/main/index.ts:168-172](../../../src/main/index.ts#L168)
+- preload 挂载 pattern: [src/preload/index.ts](../../../src/preload/index.ts)
+- Action 注册 pattern: [src/renderer/lib/actions/settings-actions.ts](../../../src/renderer/lib/actions/settings-actions.ts)
+- 现有命令面板逻辑: [src/renderer/components/common/command-palette.tsx](../../../src/renderer/components/common/command-palette.tsx)
+- 现有单测 pattern: [tests/unit/cmd-palette-keybinding.test.ts](../../../tests/unit/cmd-palette-keybinding.test.ts)
+
+---
+
+### Task 1: 数据契约 — schema + 类型
+
+**Files:**
+- Create: `src/shared/contracts/command-palette-mru.ts`
+- Test: `tests/unit/command-palette-mru-schema.test.ts`
+
+- [ ] **Step 1: 写失败测试**
+
+```ts
+// tests/unit/command-palette-mru-schema.test.ts
+import { describe, expect, it } from "vitest";
+import {
+  mruEntrySchema,
+  mruStateSchema,
+} from "@shared/contracts/command-palette-mru.ts";
+
+describe("command-palette-mru schema", () => {
+  it("接受最小合法 entry", () => {
+    const parsed = mruEntrySchema.parse({
+      actionId: "pier.x",
+      useCount: 1,
+      lastUsedAt: 1_700_000_000_000,
+    });
+    expect(parsed.actionId).toBe("pier.x");
+  });
+
+  it("拒绝空 actionId", () => {
+    expect(() =>
+      mruEntrySchema.parse({ actionId: "", useCount: 0, lastUsedAt: 0 })
+    ).toThrow();
+  });
+
+  it("拒绝负 useCount", () => {
+    expect(() =>
+      mruEntrySchema.parse({ actionId: "x", useCount: -1, lastUsedAt: 0 })
+    ).toThrow();
+  });
+
+  it("默认 state 通过校验", () => {
+    const parsed = mruStateSchema.parse({ version: 1, entries: [] });
+    expect(parsed.entries).toEqual([]);
+  });
+
+  it("拒绝超过 200 条 entries", () => {
+    const entries = Array.from({ length: 201 }, (_, i) => ({
+      actionId: `a${i}`,
+      useCount: 1,
+      lastUsedAt: 0,
+    }));
+    expect(() => mruStateSchema.parse({ version: 1, entries })).toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: 跑测试看失败**
+
+Run: `pnpm test:unit -- command-palette-mru-schema`
+Expected: FAIL — `Cannot find module '@shared/contracts/command-palette-mru.ts'`
+
+- [ ] **Step 3: 实现 schema**
+
+```ts
+// src/shared/contracts/command-palette-mru.ts
+/**
+ * 命令面板 MRU 持久化 schema. 详见 docs/superpowers/specs/2026-06-23-command-palette-mru-design.md
+ */
+import { z } from "zod";
+
+export const mruEntrySchema = z.object({
+  actionId: z.string().min(1),
+  useCount: z.number().int().nonnegative(),
+  lastUsedAt: z.number().int(),
+});
+
+export const mruStateSchema = z.object({
+  version: z.literal(1),
+  entries: z.array(mruEntrySchema).max(200),
+});
+
+export type MruEntry = z.infer<typeof mruEntrySchema>;
+export type MruState = z.infer<typeof mruStateSchema>;
+
+export const EMPTY_MRU_STATE: MruState = { version: 1, entries: [] };
+export const MRU_MAX_ENTRIES = 200;
+```
+
+- [ ] **Step 4: 跑测试看通过**
+
+Run: `pnpm test:unit -- command-palette-mru-schema`
+Expected: PASS (5 passed)
+
+- [ ] **Step 5: 类型检查**
+
+Run: `pnpm typecheck`
+Expected: 退出码 0
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/shared/contracts/command-palette-mru.ts tests/unit/command-palette-mru-schema.test.ts
+git commit -m "$(cat <<'EOF'
+feat(contracts): command-palette MRU schema (entries cap=200)
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 2: ActionMetadata 加 excludeFromMru 字段
+
+**Files:**
+- Modify: `src/renderer/lib/actions/types.ts`
+
+- [ ] **Step 1: 修改类型**
+
+把 [src/renderer/lib/actions/types.ts](../../../src/renderer/lib/actions/types.ts) 中的 `ActionMetadata` 改成：
+
+```ts
+export interface ActionMetadata {
+  iconComponent?: LucideIcon;
+  keywords?: readonly string[];
+  sortOrder?: number;
+  /** true = 执行后不计入命令面板 MRU。仅给 clearRecent 这类元命令用 */
+  excludeFromMru?: boolean;
+}
+```
+
+- [ ] **Step 2: 类型检查**
+
+Run: `pnpm typecheck`
+Expected: 退出码 0
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/renderer/lib/actions/types.ts
+git commit -m "$(cat <<'EOF'
+feat(actions): ActionMetadata 加 excludeFromMru 字段
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3: main state 模块（读写、record、clear、cap 逐出）
+
+**Files:**
+- Create: `src/main/state/command-palette-mru.ts`
+- Test: `tests/unit/command-palette-mru-state.test.ts`
+
+State 模块要求：
+- `readState(file)`: 不存在/损坏 → 返回 `EMPTY_MRU_STATE`
+- `recordUse(state, actionId, now)`: 纯函数，返回新 state。entries 已含 → useCount++ + lastUsedAt=now；不含 → append；满 200 → 先逐出 `useCount * 0.5^(ageDays/14)` 最低的 entry 再 append
+- `clearState()`: 返回 `EMPTY_MRU_STATE`
+- `persistState(file, state)`: lockfile + write-file-atomic
+
+main 进程会维护一个内存副本 + 串行化 IO。
+
+- [ ] **Step 1: 写失败测试**
+
+```ts
+// tests/unit/command-palette-mru-state.test.ts
+import { describe, expect, it } from "vitest";
+import {
+  EMPTY_MRU_STATE,
+  type MruState,
+} from "@shared/contracts/command-palette-mru.ts";
+import {
+  evictWeakest,
+  recordUse,
+} from "@main/state/command-palette-mru.ts";
+
+const day = 86_400_000;
+
+describe("recordUse", () => {
+  it("新 actionId → append entry, useCount=1", () => {
+    const next = recordUse(EMPTY_MRU_STATE, "pier.x", 1000);
+    expect(next.entries).toEqual([
+      { actionId: "pier.x", useCount: 1, lastUsedAt: 1000 },
+    ]);
+  });
+
+  it("已存在 actionId → useCount++ + lastUsedAt 刷新", () => {
+    const base: MruState = {
+      version: 1,
+      entries: [{ actionId: "pier.x", useCount: 3, lastUsedAt: 1000 }],
+    };
+    const next = recordUse(base, "pier.x", 2000);
+    expect(next.entries).toEqual([
+      { actionId: "pier.x", useCount: 4, lastUsedAt: 2000 },
+    ]);
+  });
+
+  it("不破坏旧引用 (immutable)", () => {
+    const base: MruState = {
+      version: 1,
+      entries: [{ actionId: "pier.x", useCount: 1, lastUsedAt: 0 }],
+    };
+    recordUse(base, "pier.x", 2000);
+    expect(base.entries[0].useCount).toBe(1);
+  });
+});
+
+describe("evictWeakest (满 200 时使用)", () => {
+  it("frecency 最低的被剔除", () => {
+    const now = 100 * day;
+    const entries = [
+      // useCount=10, age=0 → frecency=10
+      { actionId: "hot", useCount: 10, lastUsedAt: now },
+      // useCount=1, age=100d → frecency≈0.0073, 最低
+      { actionId: "cold", useCount: 1, lastUsedAt: 0 },
+      // useCount=2, age=14d → frecency=1
+      { actionId: "warm", useCount: 2, lastUsedAt: now - 14 * day },
+    ];
+    const survivors = evictWeakest(entries, now);
+    expect(survivors.map((e) => e.actionId).sort()).toEqual(["hot", "warm"]);
+  });
+});
+
+describe("recordUse + cap 200", () => {
+  it("满 200 时新插入触发逐出 weakest", () => {
+    const now = 100 * day;
+    const entries = Array.from({ length: 200 }, (_, i) => ({
+      actionId: `a${i}`,
+      // a0 是最弱的: useCount=1, age=200d
+      useCount: i === 0 ? 1 : 5,
+      lastUsedAt: i === 0 ? 0 : now - 7 * day,
+    }));
+    const base: MruState = { version: 1, entries };
+    const next = recordUse(base, "fresh", now);
+    expect(next.entries).toHaveLength(200);
+    expect(next.entries.some((e) => e.actionId === "fresh")).toBe(true);
+    expect(next.entries.some((e) => e.actionId === "a0")).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: 跑测试看失败**
+
+Run: `pnpm test:unit -- command-palette-mru-state`
+Expected: FAIL — `Cannot find module '@main/state/command-palette-mru.ts'`
+
+- [ ] **Step 3: 实现纯函数 + IO**
+
+```ts
+// src/main/state/command-palette-mru.ts
+/**
+ * 命令面板 MRU 持久化层. 纯函数 (recordUse, evictWeakest) 暴露给单测;
+ * IO 函数 (readFile, persistFile) 走 lockfile + atomic write.
+ *
+ * IO pattern 抄自 src/main/state/preferences.ts.
+ */
+import { existsSync } from "node:fs";
+import { mkdir, readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import {
+  EMPTY_MRU_STATE,
+  MRU_MAX_ENTRIES,
+  type MruEntry,
+  type MruState,
+  mruStateSchema,
+} from "@shared/contracts/command-palette-mru.ts";
+import { app } from "electron";
+import lockfile from "proper-lockfile";
+import writeFileAtomic from "write-file-atomic";
+
+const HALF_LIFE_DAYS = 14;
+const MS_PER_DAY = 86_400_000;
+
+function frecency(entry: MruEntry, now: number): number {
+  const ageDays = (now - entry.lastUsedAt) / MS_PER_DAY;
+  return entry.useCount * Math.pow(0.5, ageDays / HALF_LIFE_DAYS);
+}
+
+export function evictWeakest(
+  entries: readonly MruEntry[],
+  now: number
+): MruEntry[] {
+  if (entries.length === 0) return [];
+  let weakestIdx = 0;
+  let weakestScore = frecency(entries[0], now);
+  for (let i = 1; i < entries.length; i++) {
+    const s = frecency(entries[i], now);
+    if (s < weakestScore) {
+      weakestScore = s;
+      weakestIdx = i;
+    }
+  }
+  return entries.filter((_, i) => i !== weakestIdx);
+}
+
+export function recordUse(
+  state: MruState,
+  actionId: string,
+  now: number
+): MruState {
+  const idx = state.entries.findIndex((e) => e.actionId === actionId);
+  if (idx >= 0) {
+    const updated: MruEntry = {
+      ...state.entries[idx],
+      useCount: state.entries[idx].useCount + 1,
+      lastUsedAt: now,
+    };
+    const entries = state.entries.slice();
+    entries[idx] = updated;
+    return { ...state, entries };
+  }
+  const incoming: MruEntry = { actionId, useCount: 1, lastUsedAt: now };
+  const base =
+    state.entries.length >= MRU_MAX_ENTRIES
+      ? evictWeakest(state.entries, now)
+      : state.entries;
+  return { ...state, entries: [...base, incoming] };
+}
+
+function resolveFilePath(): string {
+  return join(app.getPath("userData"), "command-palette-mru.json");
+}
+
+async function ensureDir(filePath: string): Promise<void> {
+  await mkdir(dirname(filePath), { recursive: true });
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    const { stat } = await import("node:fs/promises");
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function readMruState(): Promise<MruState> {
+  const path = resolveFilePath();
+  if (!existsSync(path)) return EMPTY_MRU_STATE;
+  try {
+    const raw = await readFile(path, "utf-8");
+    return mruStateSchema.parse(JSON.parse(raw));
+  } catch (err) {
+    console.warn("[command-palette-mru] schema 校验失败, 回到空状态:", err);
+    return EMPTY_MRU_STATE;
+  }
+}
+
+export async function writeMruState(state: MruState): Promise<void> {
+  const path = resolveFilePath();
+  await ensureDir(path);
+  let release: (() => Promise<void>) | undefined;
+  try {
+    if (await fileExists(path)) {
+      release = await lockfile.lock(path);
+    }
+    await writeFileAtomic(path, `${JSON.stringify(state, null, 2)}\n`);
+  } finally {
+    await release?.();
+  }
+}
+```
+
+- [ ] **Step 4: 跑测试看通过**
+
+Run: `pnpm test:unit -- command-palette-mru-state`
+Expected: PASS (5 passed)
+
+- [ ] **Step 5: 类型检查**
+
+Run: `pnpm typecheck`
+Expected: 退出码 0
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/main/state/command-palette-mru.ts tests/unit/command-palette-mru-state.test.ts
+git commit -m "$(cat <<'EOF'
+feat(main): command-palette MRU state 模块 + cap=200 时逐出 weakest
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 4: main IPC + 多窗口广播
+
+**Files:**
+- Create: `src/main/ipc/command-palette-mru.ts`
+
+main 进程层职责：
+- 单实例持有当前 state 内存副本（初始 `null`，首次 `read` 时拉 + 落盘 sync）
+- `record(actionId)`: 内存 record → 异步 `writeMruState` → `webContents.send` 广播给所有窗口
+- `clear()`: 重置内存 + 落盘 + 广播
+- 并发 record/clear: 用一个内部 promise 队列串行化，避免锁竞争
+
+不写单测，行为靠 task 11 的 E2E 覆盖（IPC + Electron runtime mock 在 vitest 里成本太高）。
+
+- [ ] **Step 1: 实现 IPC 注册函数**
+
+```ts
+// src/main/ipc/command-palette-mru.ts
+/**
+ * IPC 桥接 + 多窗口广播.
+ * - read: invoke, 返回当前 state (首次会从磁盘读)
+ * - record: send (fire-and-forget), 内存写 + 异步落盘 + 广播
+ * - clear: invoke, 重置 + 落盘 + 广播
+ *
+ * 串行化: 用一个 promise 链让 record/clear 顺序执行, 避免 lockfile 抢占.
+ */
+import {
+  EMPTY_MRU_STATE,
+  type MruState,
+} from "@shared/contracts/command-palette-mru.ts";
+import { BrowserWindow, type IpcMain } from "electron";
+import {
+  readMruState,
+  recordUse,
+  writeMruState,
+} from "../state/command-palette-mru.ts";
+
+const CHANNEL_READ = "pier:command-palette-mru:read";
+const CHANNEL_RECORD = "pier:command-palette-mru:record";
+const CHANNEL_CLEAR = "pier:command-palette-mru:clear";
+const CHANNEL_CHANGED = "pier:command-palette-mru:changed";
+
+let memo: MruState | null = null;
+let queue: Promise<unknown> = Promise.resolve();
+
+function enqueue<T>(work: () => Promise<T>): Promise<T> {
+  const next = queue.then(work, work);
+  // 吞掉错误避免毒化 queue, 但保留链
+  queue = next.catch(() => undefined);
+  return next;
+}
+
+async function ensureLoaded(): Promise<MruState> {
+  if (memo) return memo;
+  memo = await readMruState();
+  return memo;
+}
+
+function broadcast(state: MruState): void {
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (!win.isDestroyed()) {
+      win.webContents.send(CHANNEL_CHANGED, state);
+    }
+  }
+}
+
+export function registerCommandPaletteMruIpc(ipcMain: IpcMain): void {
+  ipcMain.handle(CHANNEL_READ, async () => ensureLoaded());
+
+  ipcMain.on(CHANNEL_RECORD, (_event, actionId: string) => {
+    if (typeof actionId !== "string" || actionId.length === 0) return;
+    enqueue(async () => {
+      const current = await ensureLoaded();
+      const next = recordUse(current, actionId, Date.now());
+      memo = next;
+      try {
+        await writeMruState(next);
+      } catch (err) {
+        console.error("[command-palette-mru] 落盘失败:", err);
+      }
+      broadcast(next);
+    });
+  });
+
+  ipcMain.handle(CHANNEL_CLEAR, async () =>
+    enqueue(async () => {
+      memo = EMPTY_MRU_STATE;
+      try {
+        await writeMruState(EMPTY_MRU_STATE);
+      } catch (err) {
+        console.error("[command-palette-mru] 清空落盘失败:", err);
+      }
+      broadcast(EMPTY_MRU_STATE);
+      return EMPTY_MRU_STATE;
+    })
+  );
+}
+```
+
+- [ ] **Step 2: 类型检查**
+
+Run: `pnpm typecheck`
+Expected: 退出码 0
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/main/ipc/command-palette-mru.ts
+git commit -m "$(cat <<'EOF'
+feat(ipc): command-palette MRU read/record/clear + 多窗口 changed 广播
+
+- 内存副本 + queue 串行化避免 lockfile 抢占
+- record 用 send (fire-and-forget), read/clear 用 invoke
+- 落盘失败仅日志, 不阻塞 IPC 响应
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 5: main 入口注册 IPC
+
+**Files:**
+- Modify: `src/main/index.ts`
+
+- [ ] **Step 1: 导入新 IPC 注册函数**
+
+在 [src/main/index.ts:11](../../../src/main/index.ts#L11) 之后追加一行：
+
+```ts
+import { registerCommandPaletteMruIpc } from "./ipc/command-palette-mru.ts";
+```
+
+- [ ] **Step 2: 调用注册函数**
+
+在 [src/main/index.ts:172](../../../src/main/index.ts#L172) `registerWorkspaceIpc(ipcMain);` 之后追加：
+
+```ts
+  registerCommandPaletteMruIpc(ipcMain);
+```
+
+- [ ] **Step 3: 类型检查**
+
+Run: `pnpm typecheck`
+Expected: 退出码 0
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main/index.ts
+git commit -m "$(cat <<'EOF'
+feat(main): 注册 command-palette-mru IPC
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 6: preload 挂 commandPaletteMru API
+
+**Files:**
+- Modify: `src/preload/index.ts`
+
+- [ ] **Step 1: 增加 API 接口与实现**
+
+在 [src/preload/index.ts](../../../src/preload/index.ts) 顶部导入区追加：
+
+```ts
+import type { MruState } from "@shared/contracts/command-palette-mru.ts";
+```
+
+在 `PierWorkspaceAPI` 接口下方追加：
+
+```ts
+export interface PierCommandPaletteMruAPI {
+  read: () => Promise<MruState>;
+  recordUse: (actionId: string) => void;
+  clear: () => Promise<MruState>;
+  /** 订阅 changed 广播, 返回解绑函数 */
+  onChange: (handler: (state: MruState) => void) => () => void;
+}
+```
+
+在 `PierWindowAPI` 接口内追加字段：
+
+```ts
+  commandPaletteMru: PierCommandPaletteMruAPI;
+```
+
+在 `workspaceApi` 定义之后追加 API 实现：
+
+```ts
+const commandPaletteMruApi: PierCommandPaletteMruAPI = {
+  read: () => ipcRenderer.invoke("pier:command-palette-mru:read"),
+  recordUse: (actionId) =>
+    ipcRenderer.send("pier:command-palette-mru:record", actionId),
+  clear: () => ipcRenderer.invoke("pier:command-palette-mru:clear"),
+  onChange: (handler) => {
+    const listener = (_event: unknown, state: MruState) => {
+      handler(state);
+    };
+    ipcRenderer.on("pier:command-palette-mru:changed", listener);
+    return () => {
+      ipcRenderer.off("pier:command-palette-mru:changed", listener);
+    };
+  },
+};
+```
+
+在 `api: PierWindowAPI = { ... }` 对象中追加字段：
+
+```ts
+  commandPaletteMru: commandPaletteMruApi,
+```
+
+- [ ] **Step 2: 类型检查**
+
+Run: `pnpm typecheck`
+Expected: 退出码 0
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/preload/index.ts
+git commit -m "$(cat <<'EOF'
+feat(preload): 挂 window.pier.commandPaletteMru API
+
+- read/recordUse/clear/onChange 全套
+- onChange 返回解绑闭包
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 7: frecency 公式 + actionRank / groupRank
+
+**Files:**
+- Create: `src/renderer/lib/command-palette/frecency.ts`
+- Test: `tests/unit/command-palette-frecency.test.ts`
+
+renderer 端不写 entries，只算 frecency map。`buildFrecencyMap(entries, now)` 在 store 拿到 entries 时一次性算出 `Map<actionId, score>`。
+
+- [ ] **Step 1: 写失败测试**
+
+```ts
+// tests/unit/command-palette-frecency.test.ts
+import { describe, expect, it } from "vitest";
+import type { MruEntry } from "@shared/contracts/command-palette-mru.ts";
+import {
+  actionRank,
+  buildFrecencyMap,
+  groupRank,
+} from "@/lib/command-palette/frecency.ts";
+
+const day = 86_400_000;
+
+describe("buildFrecencyMap", () => {
+  it("0 天: frecency = useCount", () => {
+    const now = 1000 * day;
+    const entries: MruEntry[] = [
+      { actionId: "x", useCount: 4, lastUsedAt: now },
+    ];
+    const map = buildFrecencyMap(entries, now);
+    expect(map.get("x")).toBeCloseTo(4);
+  });
+
+  it("14 天 (一个半衰期): frecency = useCount/2", () => {
+    const now = 1000 * day;
+    const entries: MruEntry[] = [
+      { actionId: "x", useCount: 4, lastUsedAt: now - 14 * day },
+    ];
+    expect(buildFrecencyMap(entries, now).get("x")).toBeCloseTo(2);
+  });
+
+  it("28 天 (两个半衰期): frecency = useCount/4", () => {
+    const now = 1000 * day;
+    const entries: MruEntry[] = [
+      { actionId: "x", useCount: 4, lastUsedAt: now - 28 * day },
+    ];
+    expect(buildFrecencyMap(entries, now).get("x")).toBeCloseTo(1);
+  });
+});
+
+describe("actionRank", () => {
+  const baseAction = (id: string, sortOrder?: number) => ({
+    id,
+    category: "View",
+    title: () => id,
+    handler: () => undefined,
+    metadata: sortOrder != null ? { sortOrder } : undefined,
+  });
+
+  it("有 frecency → tier=frecency", () => {
+    const map = new Map([["a", 5]]);
+    const r = actionRank(baseAction("a"), map);
+    expect(r.tier).toBe("frecency");
+    if (r.tier === "frecency") expect(r.score).toBe(5);
+  });
+
+  it("无 frecency → tier=fallback + sortOrder", () => {
+    const map = new Map<string, number>();
+    const r = actionRank(baseAction("a", 7), map);
+    expect(r.tier).toBe("fallback");
+    if (r.tier === "fallback") expect(r.sortOrder).toBe(7);
+  });
+
+  it("无 frecency 且无 sortOrder → fallback + 0", () => {
+    const r = actionRank(baseAction("a"), new Map());
+    if (r.tier === "fallback") expect(r.sortOrder).toBe(0);
+  });
+});
+
+describe("groupRank", () => {
+  const baseAction = (id: string, category: string) => ({
+    id,
+    category,
+    title: () => id,
+    handler: () => undefined,
+  });
+
+  it("组内任一 action 有 frecency → tier=frecency + maxScore", () => {
+    const actions = [baseAction("a", "View"), baseAction("b", "View")];
+    const map = new Map([
+      ["a", 3],
+      ["b", 7],
+    ]);
+    const r = groupRank(actions, map);
+    expect(r.tier).toBe("frecency");
+    if (r.tier === "frecency") expect(r.maxScore).toBe(7);
+  });
+
+  it("组内全无 frecency → tier=fallback + CATEGORY_META.order", () => {
+    const actions = [baseAction("a", "Settings")];
+    const r = groupRank(actions, new Map());
+    expect(r.tier).toBe("fallback");
+    // Settings.order = 4 (见 command-palette.tsx CATEGORY_META)
+    if (r.tier === "fallback") expect(r.order).toBe(4);
+  });
+});
+```
+
+- [ ] **Step 2: 跑测试看失败**
+
+Run: `pnpm test:unit -- command-palette-frecency`
+Expected: FAIL — `Cannot find module '@/lib/command-palette/frecency.ts'`
+
+- [ ] **Step 3: 实现 frecency**
+
+```ts
+// src/renderer/lib/command-palette/frecency.ts
+/**
+ * 命令面板 MRU 排序算法.
+ *
+ *   frecency = useCount × 0.5^(ageDays / HALF_LIFE_DAYS)
+ *
+ * 半衰期 14 天: 两周不用, 权重折半. 参数硬编码, 后续观察体感再调.
+ */
+import type { MruEntry } from "@shared/contracts/command-palette-mru.ts";
+import type { Action } from "@/lib/actions/types.ts";
+
+const HALF_LIFE_DAYS = 14;
+const MS_PER_DAY = 86_400_000;
+
+export const CATEGORY_META: Record<string, { labelKey: string; order: number }> =
+  {
+    View: { order: 0, labelKey: "view" },
+    Workspace: { order: 1, labelKey: "workspace" },
+    Panel: { order: 2, labelKey: "panel" },
+    Window: { order: 3, labelKey: "window" },
+    Settings: { order: 4, labelKey: "settings" },
+  };
+
+export const UNKNOWN_ORDER = Object.keys(CATEGORY_META).length;
+
+export function buildFrecencyMap(
+  entries: readonly MruEntry[],
+  now: number
+): ReadonlyMap<string, number> {
+  const map = new Map<string, number>();
+  for (const entry of entries) {
+    const ageDays = (now - entry.lastUsedAt) / MS_PER_DAY;
+    map.set(entry.actionId, entry.useCount * Math.pow(0.5, ageDays / HALF_LIFE_DAYS));
+  }
+  return map;
+}
+
+export type ActionRank =
+  | { tier: "frecency"; score: number }
+  | { tier: "fallback"; sortOrder: number };
+
+export function actionRank(
+  action: Action,
+  frecencyMap: ReadonlyMap<string, number>
+): ActionRank {
+  const score = frecencyMap.get(action.id);
+  return score != null
+    ? { tier: "frecency", score }
+    : { tier: "fallback", sortOrder: action.metadata?.sortOrder ?? 0 };
+}
+
+export type GroupRank =
+  | { tier: "frecency"; maxScore: number }
+  | { tier: "fallback"; order: number };
+
+export function groupRank(
+  actions: readonly Action[],
+  frecencyMap: ReadonlyMap<string, number>
+): GroupRank {
+  let maxScore = -Infinity;
+  for (const a of actions) {
+    const s = frecencyMap.get(a.id);
+    if (s != null && s > maxScore) maxScore = s;
+  }
+  if (maxScore > -Infinity) return { tier: "frecency", maxScore };
+  const category = actions[0]?.category ?? "";
+  return {
+    tier: "fallback",
+    order: CATEGORY_META[category]?.order ?? UNKNOWN_ORDER,
+  };
+}
+
+export function compareActions(
+  a: Action,
+  b: Action,
+  frecencyMap: ReadonlyMap<string, number>
+): number {
+  const ra = actionRank(a, frecencyMap);
+  const rb = actionRank(b, frecencyMap);
+  // frecency tier 在前
+  if (ra.tier === "frecency" && rb.tier === "fallback") return -1;
+  if (ra.tier === "fallback" && rb.tier === "frecency") return 1;
+  if (ra.tier === "frecency" && rb.tier === "frecency") {
+    return rb.score - ra.score; // 高分在前
+  }
+  if (ra.tier === "fallback" && rb.tier === "fallback") {
+    return ra.sortOrder - rb.sortOrder; // 小 sortOrder 在前
+  }
+  return 0;
+}
+
+export function compareGroups(
+  ga: readonly Action[],
+  gb: readonly Action[],
+  frecencyMap: ReadonlyMap<string, number>
+): number {
+  const ra = groupRank(ga, frecencyMap);
+  const rb = groupRank(gb, frecencyMap);
+  if (ra.tier === "frecency" && rb.tier === "fallback") return -1;
+  if (ra.tier === "fallback" && rb.tier === "frecency") return 1;
+  if (ra.tier === "frecency" && rb.tier === "frecency") {
+    return rb.maxScore - ra.maxScore;
+  }
+  if (ra.tier === "fallback" && rb.tier === "fallback") {
+    return ra.order - rb.order;
+  }
+  return 0;
+}
+```
+
+- [ ] **Step 4: 跑测试看通过**
+
+Run: `pnpm test:unit -- command-palette-frecency`
+Expected: PASS (9 passed)
+
+- [ ] **Step 5: 类型检查**
+
+Run: `pnpm typecheck`
+Expected: 退出码 0
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/renderer/lib/command-palette/frecency.ts tests/unit/command-palette-frecency.test.ts
+git commit -m "$(cat <<'EOF'
+feat(command-palette): frecency 公式 + actionRank/groupRank
+
+- 半衰期 14 天: useCount × 0.5^(ageDays/14)
+- frecency tier 一律排在 fallback tier 前
+- CATEGORY_META 从 command-palette.tsx 提取到 frecency.ts 复用
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 8: 改造 groupActions 用 frecency 排序
+
+**Files:**
+- Modify: `src/renderer/components/common/command-palette.tsx`
+- Test: `tests/unit/command-palette-group-actions.test.ts`
+
+策略：把 [groupActions](../../../src/renderer/components/common/command-palette.tsx#L66) 改成接收 `frecencyMap` 与 `query`：query 非空时维持 CATEGORY_META 顺序、不重排组内（cmdk 接管）；query 为空时按 `compareActions` / `compareGroups` 排。
+
+把原来定义在 command-palette.tsx 内的 `CATEGORY_META` 删除，从 `frecency.ts` 复用（避免重复声明）。
+
+- [ ] **Step 1: 写失败测试**
+
+```ts
+// tests/unit/command-palette-group-actions.test.ts
+import { describe, expect, it } from "vitest";
+import type { Action } from "@/lib/actions/types.ts";
+import {
+  groupActionsForPalette,
+} from "@/components/common/command-palette.tsx";
+
+const mk = (id: string, category: string, sortOrder?: number): Action => ({
+  id,
+  category,
+  title: () => id,
+  handler: () => undefined,
+  surfaces: ["command-palette"],
+  metadata: sortOrder != null ? { sortOrder } : undefined,
+});
+
+describe("groupActionsForPalette", () => {
+  it("query 非空 → 按 CATEGORY_META.order 排, 组内保持入参顺序", () => {
+    const actions = [
+      mk("s1", "Settings", 10),
+      mk("v1", "View", 5),
+      mk("v2", "View", 1),
+    ];
+    const groups = groupActionsForPalette(actions, new Map(), "foo");
+    expect(groups.map((g) => g.category)).toEqual(["View", "Settings"]);
+    expect(groups[0].actions.map((a) => a.id)).toEqual(["v1", "v2"]);
+  });
+
+  it("query 空 + 全无 frecency → 等同 CATEGORY_META.order + sortOrder", () => {
+    const actions = [
+      mk("v1", "View", 5),
+      mk("v2", "View", 1),
+      mk("s1", "Settings", 10),
+    ];
+    const groups = groupActionsForPalette(actions, new Map(), "");
+    expect(groups.map((g) => g.category)).toEqual(["View", "Settings"]);
+    expect(groups[0].actions.map((a) => a.id)).toEqual(["v2", "v1"]);
+  });
+
+  it("query 空 + 有 frecency → 组间按 max(score) 排, 组内按 score 排", () => {
+    const actions = [
+      mk("v1", "View"),
+      mk("v2", "View"),
+      mk("s1", "Settings"),
+      mk("s2", "Settings"),
+    ];
+    const map = new Map([
+      ["v1", 3],
+      ["s1", 10],
+      ["s2", 7],
+    ]);
+    const groups = groupActionsForPalette(actions, map, "");
+    expect(groups[0].category).toBe("Settings");
+    expect(groups[0].actions.map((a) => a.id)).toEqual(["s1", "s2"]);
+    expect(groups[1].category).toBe("View");
+    expect(groups[1].actions.map((a) => a.id)).toEqual(["v1", "v2"]);
+  });
+
+  it("frecency tier 整组排在 fallback tier 整组之前", () => {
+    const actions = [mk("v1", "View", 5), mk("p1", "Panel")];
+    const map = new Map([["p1", 1]]);
+    const groups = groupActionsForPalette(actions, map, "");
+    expect(groups.map((g) => g.category)).toEqual(["Panel", "View"]);
+  });
+});
+```
+
+- [ ] **Step 2: 跑测试看失败**
+
+Run: `pnpm test:unit -- command-palette-group-actions`
+Expected: FAIL — `groupActionsForPalette` 不存在
+
+- [ ] **Step 3: 改造 command-palette.tsx**
+
+在 [src/renderer/components/common/command-palette.tsx](../../../src/renderer/components/common/command-palette.tsx) 顶部 import 区追加：
+
+```ts
+import {
+  CATEGORY_META,
+  compareActions,
+  compareGroups,
+  UNKNOWN_ORDER,
+} from "@/lib/command-palette/frecency.ts";
+```
+
+删除文件内原 `CATEGORY_META` / `UNKNOWN_ORDER` / `categoryRank` 定义（lines 39–59，与 frecency.ts 重复）。
+
+把原 `groupActions` 替换为 export 出去的版本：
+
+```ts
+export function groupActionsForPalette(
+  actions: readonly Action[],
+  frecencyMap: ReadonlyMap<string, number>,
+  query: string
+): ActionGroup[] {
+  const map = new Map<string, Action[]>();
+  for (const action of actions) {
+    const list = map.get(action.category) ?? [];
+    list.push(action);
+    map.set(action.category, list);
+  }
+  const groups = Array.from(map.entries()).map(([category, list]) => ({
+    category,
+    actions: list,
+  }));
+
+  if (query.length > 0) {
+    // 有搜索时不重排组内, 让 cmdk fuzzy score 接管
+    return groups.sort(
+      (a, b) =>
+        (CATEGORY_META[a.category]?.order ?? UNKNOWN_ORDER) -
+        (CATEGORY_META[b.category]?.order ?? UNKNOWN_ORDER)
+    );
+  }
+
+  for (const g of groups) {
+    g.actions.sort((a, b) => compareActions(a, b, frecencyMap));
+  }
+  return groups.sort((ga, gb) =>
+    compareGroups(ga.actions, gb.actions, frecencyMap)
+  );
+}
+```
+
+更新 `CommandPalette` 组件内调用点，让 `groups` 计算依赖 `frecencyMap` 与 `query`（[command-palette.tsx:119](../../../src/renderer/components/common/command-palette.tsx#L119)）。`frecencyMap` 来源在 Task 9 接入；这一步先用空 Map 占位：
+
+```ts
+const groups = groupActionsForPalette(actions, new Map(), query);
+```
+
+`CommandsView` 内部继续用 `CATEGORY_META` 取 heading labelKey，这里改成从 `@/lib/command-palette/frecency.ts` import 的版本。
+
+- [ ] **Step 4: 跑测试看通过**
+
+Run: `pnpm test:unit -- command-palette-group-actions`
+Expected: PASS (4 passed)
+
+- [ ] **Step 5: 跑全部已有单测确认无回归**
+
+Run: `pnpm test:unit`
+Expected: 全 PASS
+
+- [ ] **Step 6: 类型检查**
+
+Run: `pnpm typecheck`
+Expected: 退出码 0
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/renderer/components/common/command-palette.tsx tests/unit/command-palette-group-actions.test.ts
+git commit -m "$(cat <<'EOF'
+refactor(command-palette): 抽 groupActionsForPalette + 接 frecency 排序
+
+- CATEGORY_META 改从 frecency.ts 复用
+- query 非空走 cmdk fuzzy score, 不重排组内
+- query 为空按 compareActions / compareGroups 双层排序
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 9: renderer store + 启动 bootstrap
+
+**Files:**
+- Create: `src/renderer/stores/command-palette-mru.store.ts`
+- Modify: `src/renderer/main.tsx`
+
+store 职责：
+- 初始 `entries = []`、`frecencyMap = empty`
+- `init()`：调 `window.pier.commandPaletteMru.read()` 拉 entries + 算 frecencyMap + 订阅 onChange
+- `recordUse(actionId)`：本地先 `recordUse(state, ...)` 改 entries + 重算 map（保证本会话排序立即反馈），再 IPC fire
+- `clear()`：IPC invoke，等 main 广播回来再清
+
+frecencyMap 仅在 entries 引用变化时重算，**不**按"现在时间"在 render 时实时重算（spec 明确说"打开瞬间算一次就够"）。
+
+- [ ] **Step 1: 实现 store**
+
+```ts
+// src/renderer/stores/command-palette-mru.store.ts
+/**
+ * 命令面板 MRU store. 详见 specs/2026-06-23-command-palette-mru-design.md.
+ *
+ * - init: read + 订阅 onChange (main 端 record/clear 都会广播)
+ * - recordUse: 本地立即更新 + fire-and-forget IPC
+ * - frecencyMap 仅 entries 引用变化时重算
+ */
+import {
+  EMPTY_MRU_STATE,
+  type MruEntry,
+  type MruState,
+} from "@shared/contracts/command-palette-mru.ts";
+import { create } from "zustand";
+import { buildFrecencyMap } from "@/lib/command-palette/frecency.ts";
+
+interface CommandPaletteMruStore {
+  entries: readonly MruEntry[];
+  frecencyMap: ReadonlyMap<string, number>;
+  recordUse(actionId: string): void;
+  clear(): Promise<void>;
+}
+
+function recompute(entries: readonly MruEntry[]): ReadonlyMap<string, number> {
+  return buildFrecencyMap(entries, Date.now());
+}
+
+function applyLocal(
+  prev: readonly MruEntry[],
+  actionId: string,
+  now: number
+): readonly MruEntry[] {
+  const idx = prev.findIndex((e) => e.actionId === actionId);
+  if (idx >= 0) {
+    const updated: MruEntry = {
+      ...prev[idx],
+      useCount: prev[idx].useCount + 1,
+      lastUsedAt: now,
+    };
+    const next = prev.slice();
+    next[idx] = updated;
+    return next;
+  }
+  return [...prev, { actionId, useCount: 1, lastUsedAt: now }];
+}
+
+export const useCommandPaletteMru = create<CommandPaletteMruStore>(
+  (set, get) => ({
+    entries: EMPTY_MRU_STATE.entries,
+    frecencyMap: new Map(),
+
+    recordUse: (actionId) => {
+      const nextEntries = applyLocal(get().entries, actionId, Date.now());
+      set({ entries: nextEntries, frecencyMap: recompute(nextEntries) });
+      window.pier?.commandPaletteMru?.recordUse?.(actionId);
+    },
+
+    clear: async () => {
+      try {
+        await window.pier?.commandPaletteMru?.clear?.();
+        // 广播回来会通过 onChange 重置, 这里不直接 set 避免双写
+      } catch (err) {
+        console.error("[command-palette-mru] clear 失败:", err);
+        // 仍然本地清空保持 UI 一致
+        set({ entries: [], frecencyMap: new Map() });
+      }
+    },
+  })
+);
+
+export async function initCommandPaletteMru(): Promise<void> {
+  const api = window.pier?.commandPaletteMru;
+  if (!api) return;
+  try {
+    const state = await api.read();
+    useCommandPaletteMru.setState({
+      entries: state.entries,
+      frecencyMap: recompute(state.entries),
+    });
+  } catch (err) {
+    console.error("[command-palette-mru] init read 失败:", err);
+  }
+  api.onChange((state: MruState) => {
+    useCommandPaletteMru.setState({
+      entries: state.entries,
+      frecencyMap: recompute(state.entries),
+    });
+  });
+}
+```
+
+- [ ] **Step 2: 接入 main.tsx bootstrap**
+
+修改 [src/renderer/main.tsx](../../../src/renderer/main.tsx)：
+
+顶部导入区追加：
+
+```ts
+import { initCommandPaletteMru } from "./stores/command-palette-mru.store.ts";
+```
+
+在 `installDragWatcher();` 之后追加：
+
+```ts
+  initCommandPaletteMru().catch(() => undefined);
+```
+
+- [ ] **Step 3: 类型检查**
+
+Run: `pnpm typecheck`
+Expected: 退出码 0
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/renderer/stores/command-palette-mru.store.ts src/renderer/main.tsx
+git commit -m "$(cat <<'EOF'
+feat(stores): command-palette MRU store + bootstrap init
+
+- recordUse 本地立即更新 + IPC fire-and-forget (保证本会话排序反馈)
+- onChange 订阅 main 广播保持多窗口一致
+- frecencyMap 仅 entries 变化时重算
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 10: CommandPalette 接 store + 改 handleExecuteAction
+
+**Files:**
+- Modify: `src/renderer/components/common/command-palette.tsx`
+
+- [ ] **Step 1: 在组件内订阅 store**
+
+在 [src/renderer/components/common/command-palette.tsx](../../../src/renderer/components/common/command-palette.tsx) 顶部 import 区追加：
+
+```ts
+import { useCommandPaletteMru } from "@/stores/command-palette-mru.store.ts";
+```
+
+在 `CommandPalette` 函数体内（`useActions()` 之后）追加：
+
+```ts
+const frecencyMap = useCommandPaletteMru((s) => s.frecencyMap);
+```
+
+把 Task 8 留下的占位 `groups = groupActionsForPalette(actions, new Map(), query)` 改为：
+
+```ts
+const groups = groupActionsForPalette(actions, frecencyMap, query);
+```
+
+- [ ] **Step 2: 改 handleExecuteAction 加 recordUse 调用**
+
+把原 `handleExecuteAction`（[command-palette.tsx:258-273](../../../src/renderer/components/common/command-palette.tsx#L258)）改为：
+
+```ts
+const handleExecuteAction = async (action: Action) => {
+  if (action.enabled?.() === false) {
+    return;
+  }
+  const before = useCommandPaletteController.getState().requestId;
+  try {
+    await action.handler();
+    if (!action.metadata?.excludeFromMru) {
+      useCommandPaletteMru.getState().recordUse(action.id);
+    }
+    const after = useCommandPaletteController.getState();
+    if (after.requestId === before && after.mode === "commands") {
+      useCommandPaletteController.getState().close();
+    }
+  } catch (err) {
+    console.error(`[command-palette] action ${action.id} threw:`, err);
+  }
+};
+```
+
+- [ ] **Step 3: 跑全部已有单测确认无回归**
+
+Run: `pnpm test:unit`
+Expected: 全 PASS
+
+- [ ] **Step 4: 类型检查**
+
+Run: `pnpm typecheck`
+Expected: 退出码 0
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/renderer/components/common/command-palette.tsx
+git commit -m "$(cat <<'EOF'
+feat(command-palette): 接 frecency store + 执行后 recordUse
+
+- handler throw 不记录
+- excludeFromMru === true 不记录
+- handler 成功后才 recordUse, 保持失败命令不污染 MRU
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 11: clearRecent action + i18n
+
+**Files:**
+- Create: `src/renderer/lib/actions/command-palette-mru-action.ts`
+- Modify: `src/renderer/i18n/locales/zh-cn.ts`
+- Modify: `src/renderer/i18n/locales/en.ts`
+- Modify: `src/renderer/main.tsx`
+
+- [ ] **Step 1: 新增 i18n key (zh-cn)**
+
+在 [src/renderer/i18n/locales/zh-cn.ts](../../../src/renderer/i18n/locales/zh-cn.ts) 的 `commandPalette.action` 对象中追加一行（在 `resetLayout` 之后）：
+
+```ts
+      clearRecent: "清空命令面板使用记录",
+```
+
+- [ ] **Step 2: 新增 i18n key (en)**
+
+在 [src/renderer/i18n/locales/en.ts](../../../src/renderer/i18n/locales/en.ts) 的对应位置追加：
+
+```ts
+      clearRecent: "Clear command palette history",
+```
+
+- [ ] **Step 3: 注册 action**
+
+```ts
+// src/renderer/lib/actions/command-palette-mru-action.ts
+/**
+ * "清空命令面板使用记录" 元命令.
+ *
+ * 自身设 excludeFromMru = true, 避免清空后立刻把自己写回 MRU 顶部
+ * (体感上违反 "清空" 语义).
+ */
+import i18next from "i18next";
+import { Eraser } from "lucide-react";
+import { actionRegistry } from "@/lib/actions/registry.ts";
+import { useCommandPaletteMru } from "@/stores/command-palette-mru.store.ts";
+
+export function registerCommandPaletteMruAction(): () => void {
+  return actionRegistry.register({
+    id: "pier.commandPalette.clearRecent",
+    category: "Settings",
+    title: () => i18next.t("commandPalette.action.clearRecent"),
+    surfaces: ["command-palette"],
+    metadata: {
+      iconComponent: Eraser,
+      sortOrder: 30,
+      excludeFromMru: true,
+      keywords: ["clear", "reset", "history", "清空", "重置", "历史"],
+    },
+    handler: () => {
+      useCommandPaletteMru.getState().clear().catch(() => undefined);
+    },
+  });
+}
+```
+
+- [ ] **Step 4: 在 bootstrap 中注册**
+
+修改 [src/renderer/main.tsx](../../../src/renderer/main.tsx)：
+
+顶部导入区追加：
+
+```ts
+import { registerCommandPaletteMruAction } from "./lib/actions/command-palette-mru-action.ts";
+```
+
+在 `registerSettingsActions();` 之后追加：
+
+```ts
+  registerCommandPaletteMruAction();
+```
+
+- [ ] **Step 5: 类型检查**
+
+Run: `pnpm typecheck`
+Expected: 退出码 0
+
+- [ ] **Step 6: Lint**
+
+Run: `pnpm lint`
+Expected: 退出码 0（若有 Biome 报警，按规则修）
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/renderer/lib/actions/command-palette-mru-action.ts src/renderer/i18n/locales/zh-cn.ts src/renderer/i18n/locales/en.ts src/renderer/main.tsx
+git commit -m "$(cat <<'EOF'
+feat(command-palette): "清空命令面板使用记录" action + i18n
+
+- excludeFromMru 防止清空后自己回到顶部
+- Settings 分类 sortOrder=30, Eraser 图标
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 12: E2E 验证
+
+**Files:**
+- Modify: `tests/e2e/command-palette.spec.ts`
+
+补一个 E2E 场景：执行 "打开设置" 后再次打开命令面板，"打开设置" 应排在第一位。
+选 "打开设置" 是因为它的 handler 不开 quick-pick，行为可预测。
+
+E2E selector 复用现有的 `[cmdk-input]` / `[cmdk-item]` / `[cmdk-group-heading]`（[tests/e2e/command-palette.spec.ts](../../../tests/e2e/command-palette.spec.ts) 既有用法），launch 走 `out/main/index.js`，所以跑前必须先 `pnpm build`。
+
+每个 E2E test 用 fresh Electron 实例（既有用例同款 pattern）；两个新增用例之间需要清空 `userData/command-palette-mru.json` 隔离状态——通过启动参数 `--user-data-dir=<tmpdir>` 给每个用例独立 userData，最干净。
+
+- [ ] **Step 1: 在 tests/e2e/command-palette.spec.ts 末尾追加用例**
+
+```ts
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+
+// 既有 import 已包含 join / _electron / expect / test, 这里只补 fs+os
+
+test("MRU 顶置最近执行的 action", async () => {
+  const userDataDir = mkdtempSync(join(tmpdir(), "pier-mru-e2e-"));
+  const app = await electron.launch({
+    args: [OUT_MAIN, `--user-data-dir=${userDataDir}`],
+  });
+  try {
+    const win = await app.firstWindow();
+    await win.waitForLoadState("domcontentloaded");
+
+    // 1. 打开命令面板, 执行 "打开设置" (handler 不开 quick-pick)
+    await win.keyboard.press("Meta+Shift+KeyP");
+    await win.waitForTimeout(800);
+    await win.locator("[cmdk-item]").filter({ hasText: "打开设置" }).click();
+    // 设置弹窗会打开, Esc 关掉
+    await win.keyboard.press("Escape");
+    await win.waitForTimeout(300);
+
+    // 2. 重开命令面板
+    await win.keyboard.press("Meta+Shift+KeyP");
+    await win.waitForTimeout(800);
+
+    // 3. 第一个 cmdk-item 应是 "打开设置"
+    const firstItem = win.locator("[cmdk-item]").first();
+    await expect(firstItem).toContainText("打开设置");
+  } finally {
+    await app.close();
+    rmSync(userDataDir, { recursive: true, force: true });
+  }
+});
+
+test("清空命令面板使用记录后恢复默认顺序", async () => {
+  const userDataDir = mkdtempSync(join(tmpdir(), "pier-mru-e2e-"));
+  const app = await electron.launch({
+    args: [OUT_MAIN, `--user-data-dir=${userDataDir}`],
+  });
+  try {
+    const win = await app.firstWindow();
+    await win.waitForLoadState("domcontentloaded");
+
+    // 1. 执行 "打开设置" 让它进 MRU
+    await win.keyboard.press("Meta+Shift+KeyP");
+    await win.waitForTimeout(800);
+    await win.locator("[cmdk-item]").filter({ hasText: "打开设置" }).click();
+    await win.keyboard.press("Escape");
+    await win.waitForTimeout(300);
+
+    // 2. 验证它确实顶置 (sanity check)
+    await win.keyboard.press("Meta+Shift+KeyP");
+    await win.waitForTimeout(800);
+    await expect(win.locator("[cmdk-item]").first()).toContainText("打开设置");
+
+    // 3. 触发清空
+    await win
+      .locator("[cmdk-item]")
+      .filter({ hasText: "清空命令面板使用记录" })
+      .click();
+    await win.waitForTimeout(500);
+
+    // 4. 重开命令面板, "打开设置" 不应在第一位 (CATEGORY_META.View=0 排前)
+    await win.keyboard.press("Meta+Shift+KeyP");
+    await win.waitForTimeout(800);
+    await expect(win.locator("[cmdk-item]").first()).not.toContainText(
+      "打开设置"
+    );
+  } finally {
+    await app.close();
+    rmSync(userDataDir, { recursive: true, force: true });
+  }
+});
+```
+
+- [ ] **Step 2: 先构建再跑 E2E**
+
+Run: `pnpm build && pnpm test:e2e`
+Expected: 全 PASS（既有用例 + 两个新增 MRU 用例）
+
+- [ ] **Step 3: 跑完整 check + 全单测**
+
+Run: `pnpm check && pnpm test:unit`
+Expected: 全部 PASS
+
+- [ ] **Step 4: 手工验证**
+
+Run: `pnpm dev`
+1. 打开命令面板，连续执行 "打开设置" 三次（每次 Esc 关掉设置弹窗）
+2. 关闭命令面板，重新打开
+3. 确认 "打开设置" 出现在 Settings 分组顶部，并且 Settings 分组出现在最上面
+4. 触发 "清空命令面板使用记录"
+5. 重开命令面板，确认顺序回到 CATEGORY_META 默认（View → Workspace → Panel → Window → Settings）
+6. 退出 dev → 检查 `~/Library/Application Support/Pier-dev/userData/command-palette-mru.json` 内容是 `{ "version": 1, "entries": [] }`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/e2e/command-palette.spec.ts
+git commit -m "$(cat <<'EOF'
+test(e2e): MRU 顶置最近执行的 action + clear 恢复默认顺序
+
+每个用例独立 userDataDir 隔离 MRU 状态
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## 完工后建议
+
+- 收集一周内部使用数据观察半衰期 14 天是否合适。如果"老命令一直压顶"，降到 7 天；如果"偶尔用一次就跳顶部"，升到 21 天。
+- 后续如果引入超过 50 个 surfaces 为 "command-palette" 的 action，再考虑是否要给 cap 200 加 GC（按 frecency < 0.01 自动剪枝）。

--- a/docs/superpowers/specs/2026-06-23-command-palette-mru-design.md
+++ b/docs/superpowers/specs/2026-06-23-command-palette-mru-design.md
@@ -225,7 +225,7 @@ interface ActionMetadata {
 - `zh-CN`: "清空命令面板使用记录"
 - `en`: "Clear command palette history"
 
-handler 调 `window.pier.commandPaletteMru.clear()` 并 toast 提示。surface 设 `["command-palette"]`，让它本身也出现在命令面板里。`metadata.excludeFromMru = true` 让它清空后不会把自己写回 MRU（否则下一次打开命令面板就会看到 clearRecent 排在顶端，违反"清空"语义）。
+handler 调 `window.pier.commandPaletteMru.clear()` 并 console.error 记录失败 (Pier 暂无 toast 系统, 后续接入后可升级到 toast). surface 设 `["command-palette"]`，让它本身也出现在命令面板里。`metadata.excludeFromMru = true` 让它清空后不会把自己写回 MRU（否则下一次打开命令面板就会看到 clearRecent 排在顶端，违反"清空"语义）。
 
 ## 错误处理
 

--- a/docs/superpowers/specs/2026-06-23-command-palette-mru-design.md
+++ b/docs/superpowers/specs/2026-06-23-command-palette-mru-design.md
@@ -1,0 +1,279 @@
+# 命令面板 MRU 排序设计
+
+> 日期: 2026-06-23
+> 状态: 待批准
+
+## 概述
+
+给命令面板加上"最近使用优先级"排序。分组顺序和组内顺序都按 frecency（频次 × 近期度）排，最常用的命令出现在最上面、所在分组也提到最前。完全没用过的分组和命令回退到现有的 `CATEGORY_META.order` 与 `metadata.sortOrder`，保证新用户首次打开看到的就是当前设计意图的顺序。
+
+目的不是当下命中率，而是为后续命令池扩张（Git / AI / Terminal 等新 surface 接入）做承重，避免"分类多、每类条目多"之后用户每次都得手动滚屏找。
+
+## 方案选型
+
+评估了三种方案，最终采用方案 C：
+
+| 方案 | 核心思路 | 放弃原因 |
+| --- | --- | --- |
+| A. 顶部 Recently 分组 | 现有分类不动，最上加 Recently 分组（VS Code 模式） | 同一命令出现两次，视觉冗余；垂直高度多占 1/3 |
+| B. 仅组内 MRU | 分组顺序不变，组内按 MRU 排（Sublime 模式） | 默认高亮项命中率有限（用户得先按方向键到对应分组） |
+| **C. 分组 + 组内双层 MRU（采用）** | 分组之间、组内都按 frecency 排，未用过的回退原 sortOrder | — |
+
+方案 C 的代价是分类位置漂移，缓解手段是分组 heading 一直可见，用户靠 heading 文字识别而不是位置。完全未用过的项回退原 sortOrder，新用户首次体验等同当前设计。
+
+## 数据契约
+
+### shared/contracts/command-palette-mru.ts
+
+```ts
+import { z } from "zod";
+
+export const mruEntrySchema = z.object({
+  actionId: z.string().min(1),
+  useCount: z.number().int().nonnegative(),
+  lastUsedAt: z.number().int(), // epoch ms
+});
+
+export const mruStateSchema = z.object({
+  version: z.literal(1),
+  entries: z.array(mruEntrySchema).max(200),
+});
+
+export type MruEntry = z.infer<typeof mruEntrySchema>;
+export type MruState = z.infer<typeof mruStateSchema>;
+```
+
+`version` 字段为后续 schema 升级预留。`entries.max(200)` 是兜底上限，触顶时按 frecency 升序逐出最弱的 entry。
+
+### IPC 契约
+
+```ts
+interface CommandPaletteMruAPI {
+  read(): Promise<MruState>;
+  recordUse(actionId: string): void;
+  clear(): Promise<void>;
+  /** 订阅 `pier:command-palette-mru:changed` 广播, 返回解绑函数 */
+  onChange(handler: (state: MruState) => void): () => void;
+}
+```
+
+挂在 `window.pier.commandPaletteMru` 命名空间。`recordUse` 用 send（fire-and-forget），`read` 和 `clear` 用 invoke。`onChange` 由 preload 包装：`ipcRenderer.on("pier:command-palette-mru:changed", listener)` + 返回 `ipcRenderer.off` 的解绑闭包。main 在每次 record / clear 落盘后通过 `BrowserWindow.getAllWindows().forEach(w => w.webContents.send(...))` 广播给所有窗口。
+
+### 通道设计
+
+| 通道 | 传输 | 频率 |
+| --- | --- | --- |
+| `pier:command-palette-mru:read` | invoke/handle | 启动一次/窗口 |
+| `pier:command-palette-mru:record` | send/on | 中（每次 action 执行）|
+| `pier:command-palette-mru:clear` | invoke/handle | 极低 |
+| `pier:command-palette-mru:changed` | webContents.send → renderer | 中（每次写入后广播）|
+
+## 持久化分层
+
+独立文件 `userData/command-palette-mru.json`，**不**复用 preferences.json。理由：写入频率高（每次 action 执行）、schema 独立演化、损坏不牵连主偏好。
+
+复用 [main/state/preferences.ts](../../../src/main/state/preferences.ts) 的写入 pattern：`proper-lockfile` 锁 + `write-file-atomic`。
+
+```
+src/
+  shared/contracts/command-palette-mru.ts   schema + 类型
+  main/
+    state/command-palette-mru.ts            读 / 写 / record / clear
+    ipc/command-palette-mru.ts              IPC handlers + 多窗口广播
+  preload/index.ts                          挂 window.pier.commandPaletteMru
+  renderer/
+    stores/command-palette-mru.store.ts     zustand store, 订阅 onChange
+```
+
+main 进程持有当前 state 的内存副本，`recordUse` 同步更新内存并异步落盘 + 广播。renderer 启动时拉一次 read，之后只依赖 onChange 推送。
+
+## 算法
+
+### frecency 公式
+
+```ts
+const HALF_LIFE_DAYS = 14;
+const MS_PER_DAY = 86_400_000;
+
+function frecency(entry: MruEntry, now: number): number {
+  const ageDays = (now - entry.lastUsedAt) / MS_PER_DAY;
+  const decay = Math.pow(0.5, ageDays / HALF_LIFE_DAYS);
+  return entry.useCount * decay;
+}
+```
+
+半衰期 14 天：两周不用，权重折半。参数硬编码，先观察体感再决定是否暴露成可调。
+
+### 排序规则
+
+```ts
+function actionRank(action: Action, frecencyMap: ReadonlyMap<string, number>):
+  | { tier: "frecency"; score: number }
+  | { tier: "fallback"; sortOrder: number } {
+  const score = frecencyMap.get(action.id);
+  return score != null
+    ? { tier: "frecency", score }
+    : { tier: "fallback", sortOrder: action.metadata?.sortOrder ?? 0 };
+}
+
+function groupRank(actions: readonly Action[], frecencyMap: ReadonlyMap<string, number>):
+  | { tier: "frecency"; maxScore: number }
+  | { tier: "fallback"; order: number } {
+  let maxScore = -Infinity;
+  for (const a of actions) {
+    const s = frecencyMap.get(a.id);
+    if (s != null && s > maxScore) maxScore = s;
+  }
+  if (maxScore > -Infinity) return { tier: "frecency", maxScore };
+  const category = actions[0]?.category ?? "";
+  return { tier: "fallback", order: CATEGORY_META[category]?.order ?? UNKNOWN_ORDER };
+}
+```
+
+排序时 frecency tier 一律排在 fallback tier 前面；同 tier 内按 score 降序 / order 升序。
+
+### 与 cmdk 搜索的关系
+
+**有搜索时不叠 frecency，把排序完全交给 cmdk 的 fuzzy score。**理由：cmdk score 已经按 query 匹配度从高到低排，叠 frecency 会让"我刚搜了一个新词、它却被推到第二位"，体感诡异。VS Code 同样处理。
+
+实现上 `groupActions` 在 query 非空时不重排，只在 query 为空时按上述 rank 排序。判断 query 是否为空：本地 `query` state 不为空字符串。
+
+## UI 改造
+
+### 修改 [groupActions](../../../src/renderer/components/common/command-palette.tsx)
+
+```ts
+function groupActions(
+  actions: readonly Action[],
+  frecencyMap: ReadonlyMap<string, number>,
+  query: string,
+): ActionGroup[] {
+  const groups = collectByCategory(actions);
+  if (query.length > 0) {
+    // 让 cmdk 接管, 维持当前 CATEGORY_META.order 顺序即可
+    return groups.sort(byCategoryMetaOrder);
+  }
+  // 组内按 actionRank 排
+  for (const g of groups) g.actions.sort(byActionRank(frecencyMap));
+  // 组间按 groupRank 排
+  return groups.sort(byGroupRank(frecencyMap));
+}
+```
+
+### 新增 store
+
+`stores/command-palette-mru.store.ts`：
+
+```ts
+interface CommandPaletteMruStore {
+  frecencyMap: ReadonlyMap<string, number>;
+  /** 触发一次本地更新 + IPC fire-and-forget */
+  recordUse(actionId: string): void;
+  /** 清空 */
+  clear(): Promise<void>;
+}
+```
+
+启动时 bootstrap 调一次 `window.pier.commandPaletteMru.read()`，订阅 `onChange` 持续同步。`frecencyMap` 在 store 内**仅在 entries 引用变化时**重算（`useCount × decay`），renderer 端不写 useCount/lastUsedAt 原值；不在每次 render 时按"现在时间"实时重算，避免无谓的渲染抖动——decay 是相对值，命令面板打开瞬间算一次就够。
+
+### 触发记录的时机
+
+仅在 [handleExecuteAction](../../../src/renderer/components/common/command-palette.tsx) handler **成功完成**后调 `recordUse`：
+
+```ts
+const handleExecuteAction = async (action: Action) => {
+  if (action.enabled?.() === false) return;
+  const before = useCommandPaletteController.getState().requestId;
+  try {
+    await action.handler();
+    if (!action.metadata?.excludeFromMru) {
+      useCommandPaletteMru.getState().recordUse(action.id);
+    }
+    // ... 现有关闭逻辑
+  } catch (err) {
+    // 不记录失败的 action
+    console.error(...);
+  }
+};
+```
+
+- handler throw → 不记
+- `enabled?.() === false` → 不记（不进入 handler 调用）
+- `metadata.excludeFromMru === true` → 不记（专供 clear action 自身豁免，详见下文）
+- quick-pick 内层 `onAccept` → 不记（只记顶层进入命令面板的 action，内层选项有自己的 domain 语义）
+
+### Action 类型扩展
+
+`ActionMetadata` 新增可选字段：
+
+```ts
+interface ActionMetadata {
+  // 既有字段
+  iconComponent?: LucideIcon;
+  keywords?: readonly string[];
+  sortOrder?: number;
+  // 新增
+  /** true = 执行后不计入命令面板 MRU。仅给 clearRecent 这类元命令用 */
+  excludeFromMru?: boolean;
+}
+```
+
+### 新增 clear action
+
+注册一个 `pier.commandPalette.clearRecent` 命令，category 归 `Settings`，i18n：
+
+- `zh-CN`: "清空命令面板使用记录"
+- `en`: "Clear command palette history"
+
+handler 调 `window.pier.commandPaletteMru.clear()` 并 toast 提示。surface 设 `["command-palette"]`，让它本身也出现在命令面板里。`metadata.excludeFromMru = true` 让它清空后不会把自己写回 MRU（否则下一次打开命令面板就会看到 clearRecent 排在顶端，违反"清空"语义）。
+
+## 错误处理
+
+| 场景 | 行为 |
+| --- | --- |
+| `userData/command-palette-mru.json` 不存在 | read 返回 `{ version: 1, entries: [] }` |
+| JSON 损坏 / schema 校验失败 | 起空状态，记 warning 日志，**不**自动备份（用户主动清空即可重置）|
+| IPC 调用失败（main 进程异常）| `recordUse` 仍然先本地更新 store entries（保证本会话内排序有反馈），再 fire IPC；若 IPC 静默失败，落盘缺失这一次的记录，下次窗口启动 read 时会和真实落盘对齐——会丢一次 record 但不会卡 UI |
+| 并发写入（多窗口同时 recordUse）| main 进程单实例持有内存副本 + lockfile，串行化合并 |
+| entries 触顶 200 | 写入前按 frecency 升序排，逐出尾部最弱的 entry，再插入新 entry |
+
+## 测试
+
+### 单元测试
+
+- `frecency()`: 0 天 → useCount；14 天 → useCount/2；28 天 → useCount/4
+- `actionRank()`: frecency tier 在 fallback tier 前；同 tier 按 score / sortOrder 排
+- `groupRank()`: 组取 max(score)；空组（无 frecency）落 fallback
+- `groupActions()`:
+  - query 空 → 双层 MRU 排
+  - query 非空 → 维持 CATEGORY_META.order, 不重排组内
+  - 全是新用户（empty frecencyMap）→ 等同当前实现
+
+### 集成测试（Vitest + IPC mock）
+
+- recordUse → read 应包含新 entry，useCount = 1
+- 重复 recordUse 同一 id → useCount 递增，lastUsedAt 更新
+- entries 已满 200 → 触发逐出最弱 entry
+- onChange 广播 → 多个 renderer 实例都收到
+
+### E2E（Playwright）
+
+- 打开命令面板 → 执行 "Switch Theme" → 关闭 → 重开 → "Switch Theme" 在最上面
+- clear → 重开 → 顺序回归到当前 CATEGORY_META.order
+
+## 不做
+
+- **搜索时的 frecency 加权**：交给 cmdk fuzzy score。
+- **frecency 参数 UI 化**：半衰期 14 天和 cap 200 都是死值，后续观察体感再决定。
+- **跨设备同步**：命令面板 MRU 状态仅本地，与 preferences.json 的处理一致。
+- **批量配置 excludeFromMru**：目前只有 clearRecent 一个 action 需要豁免，不做配置系统、不做 UI；后续若再有第二个 case 也只是手填 metadata。
+- **quick-pick 内层选项的独立 MRU**：内层是 domain 概念（主题、字体等），不属于命令面板自身排序，由各自 quick-pick provider 决定要不要记。
+
+## 风险
+
+| 风险 | 缓解 |
+| --- | --- |
+| 老用户启用后顺序大变，造成困惑 | clear 入口在命令面板里就能执行，发布说明里提一句 |
+| frecency 公式参数不合适，体感诡异 | 半衰期写在常量，后续灰度调；现阶段先观察 |
+| store 重算 frecencyMap 频繁，渲染抖动 | 仅在 entries 引用变更时重算（store 持有 entries 引用做浅比较）|
+| 多窗口同时写 | main 单实例 + lockfile + onChange 广播兜底一致性 |

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -8,6 +8,7 @@ import {
   nativeImage,
 } from "electron";
 import { installCsp } from "./csp.ts";
+import { registerCommandPaletteMruIpc } from "./ipc/command-palette-mru.ts";
 import { registerPreferencesIpc } from "./ipc/preferences.ts";
 import { registerTerminalIpc } from "./ipc/terminal.ts";
 import { registerThemeIpc } from "./ipc/theme.ts";
@@ -170,6 +171,7 @@ app.whenReady().then(() => {
   registerTerminalIpc(ipcMain);
   registerThemeIpc(ipcMain);
   registerWorkspaceIpc(ipcMain);
+  registerCommandPaletteMruIpc(ipcMain);
 
   // 首窗口 id 固定 "main".
   windowManager.create({ id: "main" });

--- a/src/main/ipc/command-palette-mru.ts
+++ b/src/main/ipc/command-palette-mru.ts
@@ -23,6 +23,7 @@ const CHANNEL_CLEAR = "pier:command-palette-mru:clear";
 const CHANNEL_CHANGED = "pier:command-palette-mru:changed";
 
 let memo: MruState | null = null;
+let memoPromise: Promise<MruState> | null = null;
 let queue: Promise<unknown> = Promise.resolve();
 
 function enqueue<T>(work: () => Promise<T>): Promise<T> {
@@ -32,12 +33,22 @@ function enqueue<T>(work: () => Promise<T>): Promise<T> {
   return next;
 }
 
-async function ensureLoaded(): Promise<MruState> {
+function ensureLoaded(): Promise<MruState> {
   if (memo) {
-    return memo;
+    return Promise.resolve(memo);
   }
-  memo = await readMruState();
-  return memo;
+  if (memoPromise) {
+    return memoPromise;
+  }
+  memoPromise = readMruState()
+    .then((s) => {
+      memo = s;
+      return s;
+    })
+    .finally(() => {
+      memoPromise = null;
+    });
+  return memoPromise;
 }
 
 function broadcast(state: MruState): void {
@@ -52,30 +63,40 @@ export function registerCommandPaletteMruIpc(ipcMain: IpcMain): void {
   ipcMain.handle(CHANNEL_READ, async () => ensureLoaded());
 
   ipcMain.on(CHANNEL_RECORD, (_event, actionId: string) => {
-    if (typeof actionId !== "string" || actionId.length === 0) {
+    // #6: 拒绝异常长的 actionId, 避免 disk-fill 攻击面.
+    if (
+      typeof actionId !== "string" ||
+      actionId.length === 0 ||
+      actionId.length > 128
+    ) {
       return;
     }
     enqueue(async () => {
-      const current = await ensureLoaded();
-      const next = recordUse(current, actionId, Date.now());
-      memo = next;
+      const prev = await ensureLoaded();
+      const next = recordUse(prev, actionId, Date.now());
       try {
         await writeMruState(next);
       } catch (err) {
-        console.error("[command-palette-mru] 落盘失败:", err);
+        console.error("[command-palette-mru] record 落盘失败, memo 不变:", err);
+        // #1: 落盘失败不更新 memo, 不 broadcast. 渲染器本地乐观状态在下次 read / broadcast 修复.
+        return;
       }
+      memo = next;
       broadcast(next);
     });
   });
 
   ipcMain.handle(CHANNEL_CLEAR, async () =>
     enqueue(async () => {
-      memo = EMPTY_MRU_STATE;
+      await ensureLoaded(); // 让磁盘读完成, 避免后续 read 与本 clear 抢
       try {
         await writeMruState(EMPTY_MRU_STATE);
       } catch (err) {
         console.error("[command-palette-mru] 清空落盘失败:", err);
+        // #2: 让 invoke 抛错, 渲染器 catch 后能本地兜底.
+        throw err;
       }
+      memo = EMPTY_MRU_STATE;
       broadcast(EMPTY_MRU_STATE);
       return EMPTY_MRU_STATE;
     })

--- a/src/main/ipc/command-palette-mru.ts
+++ b/src/main/ipc/command-palette-mru.ts
@@ -1,0 +1,83 @@
+/**
+ * IPC 桥接 + 多窗口广播.
+ * - read: invoke, 返回当前 state (首次会从磁盘读)
+ * - record: send (fire-and-forget), 内存写 + 异步落盘 + 广播
+ * - clear: invoke, 重置 + 落盘 + 广播
+ *
+ * 串行化: 用一个 promise 链让 record/clear 顺序执行, 避免 lockfile 抢占.
+ */
+import {
+  EMPTY_MRU_STATE,
+  type MruState,
+} from "@shared/contracts/command-palette-mru.ts";
+import { BrowserWindow, type IpcMain } from "electron";
+import {
+  readMruState,
+  recordUse,
+  writeMruState,
+} from "../state/command-palette-mru.ts";
+
+const CHANNEL_READ = "pier:command-palette-mru:read";
+const CHANNEL_RECORD = "pier:command-palette-mru:record";
+const CHANNEL_CLEAR = "pier:command-palette-mru:clear";
+const CHANNEL_CHANGED = "pier:command-palette-mru:changed";
+
+let memo: MruState | null = null;
+let queue: Promise<unknown> = Promise.resolve();
+
+function enqueue<T>(work: () => Promise<T>): Promise<T> {
+  const next = queue.then(work, work);
+  // 吞掉错误避免毒化 queue, 但保留链
+  queue = next.catch(() => undefined);
+  return next;
+}
+
+async function ensureLoaded(): Promise<MruState> {
+  if (memo) {
+    return memo;
+  }
+  memo = await readMruState();
+  return memo;
+}
+
+function broadcast(state: MruState): void {
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (!win.isDestroyed()) {
+      win.webContents.send(CHANNEL_CHANGED, state);
+    }
+  }
+}
+
+export function registerCommandPaletteMruIpc(ipcMain: IpcMain): void {
+  ipcMain.handle(CHANNEL_READ, async () => ensureLoaded());
+
+  ipcMain.on(CHANNEL_RECORD, (_event, actionId: string) => {
+    if (typeof actionId !== "string" || actionId.length === 0) {
+      return;
+    }
+    enqueue(async () => {
+      const current = await ensureLoaded();
+      const next = recordUse(current, actionId, Date.now());
+      memo = next;
+      try {
+        await writeMruState(next);
+      } catch (err) {
+        console.error("[command-palette-mru] 落盘失败:", err);
+      }
+      broadcast(next);
+    });
+  });
+
+  ipcMain.handle(CHANNEL_CLEAR, async () =>
+    enqueue(async () => {
+      memo = EMPTY_MRU_STATE;
+      try {
+        await writeMruState(EMPTY_MRU_STATE);
+      } catch (err) {
+        console.error("[command-palette-mru] 清空落盘失败:", err);
+      }
+      broadcast(EMPTY_MRU_STATE);
+      return EMPTY_MRU_STATE;
+    })
+  );
+}

--- a/src/main/state/command-palette-mru.ts
+++ b/src/main/state/command-palette-mru.ts
@@ -1,0 +1,122 @@
+/**
+ * 命令面板 MRU 持久化层. 纯函数 (recordUse, evictWeakest) 暴露给单测;
+ * IO 函数 (readMruState, writeMruState) 走 lockfile + atomic write.
+ *
+ * IO pattern 抄自 src/main/state/preferences.ts.
+ */
+import { existsSync } from "node:fs";
+import { mkdir, readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import {
+  EMPTY_MRU_STATE,
+  MRU_MAX_ENTRIES,
+  type MruEntry,
+  type MruState,
+  mruStateSchema,
+} from "@shared/contracts/command-palette-mru.ts";
+import { app } from "electron";
+import lockfile from "proper-lockfile";
+import writeFileAtomic from "write-file-atomic";
+
+const HALF_LIFE_DAYS = 14;
+const MS_PER_DAY = 86_400_000;
+
+function frecency(entry: MruEntry, now: number): number {
+  const ageDays = (now - entry.lastUsedAt) / MS_PER_DAY;
+  return entry.useCount * 0.5 ** (ageDays / HALF_LIFE_DAYS);
+}
+
+export function evictWeakest(
+  entries: readonly MruEntry[],
+  now: number
+): MruEntry[] {
+  const first = entries[0];
+  if (!first) {
+    return [];
+  }
+  let weakestIdx = 0;
+  let weakestScore = frecency(first, now);
+  for (let i = 1; i < entries.length; i++) {
+    const current = entries[i];
+    if (!current) {
+      continue;
+    }
+    const s = frecency(current, now);
+    if (s < weakestScore) {
+      weakestScore = s;
+      weakestIdx = i;
+    }
+  }
+  return entries.filter((_, i) => i !== weakestIdx);
+}
+
+export function recordUse(
+  state: MruState,
+  actionId: string,
+  now: number
+): MruState {
+  const idx = state.entries.findIndex((e) => e.actionId === actionId);
+  const existing = idx >= 0 ? state.entries[idx] : undefined;
+  if (existing) {
+    const updated: MruEntry = {
+      actionId: existing.actionId,
+      useCount: existing.useCount + 1,
+      lastUsedAt: now,
+    };
+    const entries = state.entries.slice();
+    entries[idx] = updated;
+    return { ...state, entries };
+  }
+  const incoming: MruEntry = { actionId, useCount: 1, lastUsedAt: now };
+  const base =
+    state.entries.length >= MRU_MAX_ENTRIES
+      ? evictWeakest(state.entries, now)
+      : state.entries;
+  return { ...state, entries: [...base, incoming] };
+}
+
+function resolveFilePath(): string {
+  return join(app.getPath("userData"), "command-palette-mru.json");
+}
+
+async function ensureDir(filePath: string): Promise<void> {
+  await mkdir(dirname(filePath), { recursive: true });
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    const { stat } = await import("node:fs/promises");
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function readMruState(): Promise<MruState> {
+  const path = resolveFilePath();
+  if (!existsSync(path)) {
+    return EMPTY_MRU_STATE;
+  }
+  try {
+    const raw = await readFile(path, "utf-8");
+    return mruStateSchema.parse(JSON.parse(raw));
+  } catch (err) {
+    console.warn("[command-palette-mru] schema 校验失败, 回到空状态:", err);
+    return EMPTY_MRU_STATE;
+  }
+}
+
+export async function writeMruState(state: MruState): Promise<void> {
+  const path = resolveFilePath();
+  await ensureDir(path);
+  let release: (() => Promise<void>) | undefined;
+  try {
+    if (await fileExists(path)) {
+      release = await lockfile.lock(path);
+    }
+    await writeFileAtomic(path, `${JSON.stringify(state, null, 2)}\n`);
+  } finally {
+    await release?.();
+  }
+}

--- a/src/main/state/command-palette-mru.ts
+++ b/src/main/state/command-palette-mru.ts
@@ -76,16 +76,6 @@ async function ensureDir(filePath: string): Promise<void> {
   await mkdir(dirname(filePath), { recursive: true });
 }
 
-async function fileExists(path: string): Promise<boolean> {
-  try {
-    const { stat } = await import("node:fs/promises");
-    await stat(path);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
 export async function readMruState(): Promise<MruState> {
   const path = resolveFilePath();
   if (!existsSync(path)) {
@@ -103,13 +93,17 @@ export async function readMruState(): Promise<MruState> {
 export async function writeMruState(state: MruState): Promise<void> {
   const path = resolveFilePath();
   await ensureDir(path);
-  let release: (() => Promise<void>) | undefined;
+  // 首次写: 文件还不存在时 lockfile.lock 会拒, 所以先 touch 一个空状态再加锁覆盖.
+  if (!existsSync(path)) {
+    await writeFileAtomic(
+      path,
+      `${JSON.stringify(EMPTY_MRU_STATE, null, 2)}\n`
+    );
+  }
+  const release = await lockfile.lock(path);
   try {
-    if (await fileExists(path)) {
-      release = await lockfile.lock(path);
-    }
     await writeFileAtomic(path, `${JSON.stringify(state, null, 2)}\n`);
   } finally {
-    await release?.();
+    await release();
   }
 }

--- a/src/main/state/command-palette-mru.ts
+++ b/src/main/state/command-palette-mru.ts
@@ -9,6 +9,7 @@ import { mkdir, readFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import {
   EMPTY_MRU_STATE,
+  frecency,
   MRU_MAX_ENTRIES,
   type MruEntry,
   type MruState,
@@ -17,14 +18,6 @@ import {
 import { app } from "electron";
 import lockfile from "proper-lockfile";
 import writeFileAtomic from "write-file-atomic";
-
-const HALF_LIFE_DAYS = 14;
-const MS_PER_DAY = 86_400_000;
-
-function frecency(entry: MruEntry, now: number): number {
-  const ageDays = (now - entry.lastUsedAt) / MS_PER_DAY;
-  return entry.useCount * 0.5 ** (ageDays / HALF_LIFE_DAYS);
-}
 
 export function evictWeakest(
   entries: readonly MruEntry[],

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,3 +1,4 @@
+import type { MruState } from "@shared/contracts/command-palette-mru.ts";
 import type { TerminalAPI } from "@shared/contracts/terminal.ts";
 import { contextBridge, ipcRenderer } from "electron";
 
@@ -44,6 +45,14 @@ export interface PierWorkspaceAPI {
   saveLayout: (layout: unknown) => Promise<void>;
 }
 
+export interface PierCommandPaletteMruAPI {
+  clear: () => Promise<MruState>;
+  /** 订阅 changed 广播, 返回解绑函数 */
+  onChange: (handler: (state: MruState) => void) => () => void;
+  read: () => Promise<MruState>;
+  recordUse: (actionId: string) => void;
+}
+
 /**
  * Keyboard chord forward: swift NSEvent monitor 捕获 Cmd+key → main IPC →
  * 这里 dispatch 到 renderer 侧的 listener (shell-keybindings).
@@ -57,6 +66,7 @@ export interface PierKeybindingAPI {
 export interface PierWindowAPI {
   closeCurrentWindow: () => Promise<void>;
   closeWindow: (windowId: string) => Promise<void>;
+  commandPaletteMru: PierCommandPaletteMruAPI;
   createWindow: () => Promise<{ windowId: string }>;
   focusWindow: (windowId: string) => Promise<void>;
   keybinding: PierKeybindingAPI;
@@ -101,6 +111,22 @@ const workspaceApi: PierWorkspaceAPI = {
     ipcRenderer.invoke("pier:workspace:save-layout", layout),
 };
 
+const commandPaletteMruApi: PierCommandPaletteMruAPI = {
+  read: () => ipcRenderer.invoke("pier:command-palette-mru:read"),
+  recordUse: (actionId) =>
+    ipcRenderer.send("pier:command-palette-mru:record", actionId),
+  clear: () => ipcRenderer.invoke("pier:command-palette-mru:clear"),
+  onChange: (handler) => {
+    const listener = (_event: unknown, state: MruState) => {
+      handler(state);
+    };
+    ipcRenderer.on("pier:command-palette-mru:changed", listener);
+    return () => {
+      ipcRenderer.off("pier:command-palette-mru:changed", listener);
+    };
+  },
+};
+
 const keybindingApi: PierKeybindingAPI = {
   onForward: (cb) => {
     const listener = (
@@ -120,6 +146,7 @@ const api: PierWindowAPI = {
   closeCurrentWindow: () => ipcRenderer.invoke("pier://window:close-current"),
   closeWindow: (windowId) =>
     ipcRenderer.invoke("pier://window:close", windowId),
+  commandPaletteMru: commandPaletteMruApi,
   createWindow: () => ipcRenderer.invoke("pier://window:create"),
   focusWindow: (windowId) =>
     ipcRenderer.invoke("pier://window:focus", windowId),

--- a/src/renderer/components/common/command-palette.tsx
+++ b/src/renderer/components/common/command-palette.tsx
@@ -30,49 +30,54 @@ import { useT } from "@/i18n/use-t.ts";
 import { actionRegistry } from "@/lib/actions/registry.ts";
 import type { Action } from "@/lib/actions/types.ts";
 import { useCommandPaletteController } from "@/lib/command-palette/controller.ts";
+import {
+  CATEGORY_META,
+  compareActions,
+  compareGroups,
+  UNKNOWN_ORDER,
+} from "@/lib/command-palette/frecency.ts";
 import type { QuickPick, QuickPickItem } from "@/lib/command-palette/types.ts";
 import { formatChord } from "@/lib/keybindings/formatter.ts";
 import { keybindingRegistry } from "@/lib/keybindings/registry.ts";
 import { useKeybindingScope } from "@/stores/keybinding-scope.store.ts";
 import { popOverlay, pushOverlay } from "@/stores/terminal-overlay.store.ts";
 
-interface CategoryMeta {
-  /** 用作 i18n key: commandPalette.category.${labelKey} */
-  labelKey: string;
-  order: number;
-}
-
-// 新增分类时这里加一行 + i18n 加 commandPalette.category.<key>。未注册的分类
-// 兜底排在末尾, label 直接用 raw category 字符串。
-const CATEGORY_META: Record<string, CategoryMeta> = {
-  View: { order: 0, labelKey: "view" },
-  Workspace: { order: 1, labelKey: "workspace" },
-  Panel: { order: 2, labelKey: "panel" },
-  Window: { order: 3, labelKey: "window" },
-  Settings: { order: 4, labelKey: "settings" },
-};
-
-const UNKNOWN_ORDER = Object.keys(CATEGORY_META).length;
-
-function categoryRank(category: string): number {
-  return CATEGORY_META[category]?.order ?? UNKNOWN_ORDER;
-}
-
 interface ActionGroup {
   actions: Action[];
   category: string;
 }
 
-function groupActions(actions: readonly Action[]): ActionGroup[] {
+export function groupActionsForPalette(
+  actions: readonly Action[],
+  frecencyMap: ReadonlyMap<string, number>,
+  query: string
+): ActionGroup[] {
   const map = new Map<string, Action[]>();
   for (const action of actions) {
     const list = map.get(action.category) ?? [];
     list.push(action);
     map.set(action.category, list);
   }
-  return Array.from(map.entries())
-    .map(([category, list]) => ({ category, actions: list }))
-    .sort((a, b) => categoryRank(a.category) - categoryRank(b.category));
+  const groups = Array.from(map.entries()).map(([category, list]) => ({
+    category,
+    actions: list,
+  }));
+
+  if (query.length > 0) {
+    // 有搜索时不重排组内, 让 cmdk fuzzy score 接管
+    return groups.sort(
+      (a, b) =>
+        (CATEGORY_META[a.category]?.order ?? UNKNOWN_ORDER) -
+        (CATEGORY_META[b.category]?.order ?? UNKNOWN_ORDER)
+    );
+  }
+
+  for (const g of groups) {
+    g.actions.sort((a, b) => compareActions(a, b, frecencyMap));
+  }
+  return groups.sort((ga, gb) =>
+    compareGroups(ga.actions, gb.actions, frecencyMap)
+  );
 }
 
 function useActions(): readonly Action[] {
@@ -116,11 +121,11 @@ export function CommandPalette() {
   const t = useT();
   const controller = useCommandPaletteController();
   const actions = useActions();
-  const groups = groupActions(actions);
   const keybindingLabels = useKeybindingLabels();
 
   // 本地 UI 态: 与 controller 保持同步, 但 cmdk 需要 controlled value/query 引用稳定。
   const [query, setQuery] = useState("");
+  const groups = groupActionsForPalette(actions, new Map(), query);
   const [selectedValue, setSelectedValue] = useState("");
   const lastRequestIdRef = useRef(-1);
   // null = 未 accept; 非 null = 已 accept (值是 item id)。

--- a/src/renderer/components/common/command-palette.tsx
+++ b/src/renderer/components/common/command-palette.tsx
@@ -72,6 +72,7 @@ export function groupActionsForPalette(
     );
   }
 
+  // 入参可能已被 actionRegistry.list 按 sortOrder 预排; 这里再排一次保证函数自洽, 不依赖上游顺序.
   for (const g of groups) {
     g.actions.sort((a, b) => compareActions(a, b, frecencyMap));
   }

--- a/src/renderer/components/common/command-palette.tsx
+++ b/src/renderer/components/common/command-palette.tsx
@@ -39,6 +39,7 @@ import {
 import type { QuickPick, QuickPickItem } from "@/lib/command-palette/types.ts";
 import { formatChord } from "@/lib/keybindings/formatter.ts";
 import { keybindingRegistry } from "@/lib/keybindings/registry.ts";
+import { useCommandPaletteMru } from "@/stores/command-palette-mru.store.ts";
 import { useKeybindingScope } from "@/stores/keybinding-scope.store.ts";
 import { popOverlay, pushOverlay } from "@/stores/terminal-overlay.store.ts";
 
@@ -123,10 +124,11 @@ export function CommandPalette() {
   const controller = useCommandPaletteController();
   const actions = useActions();
   const keybindingLabels = useKeybindingLabels();
+  const frecencyMap = useCommandPaletteMru((s) => s.frecencyMap);
 
   // 本地 UI 态: 与 controller 保持同步, 但 cmdk 需要 controlled value/query 引用稳定。
   const [query, setQuery] = useState("");
-  const groups = groupActionsForPalette(actions, new Map(), query);
+  const groups = groupActionsForPalette(actions, frecencyMap, query);
   const [selectedValue, setSelectedValue] = useState("");
   const lastRequestIdRef = useRef(-1);
   // null = 未 accept; 非 null = 已 accept (值是 item id)。
@@ -268,6 +270,9 @@ export function CommandPalette() {
     const before = useCommandPaletteController.getState().requestId;
     try {
       await action.handler();
+      if (!action.metadata?.excludeFromMru) {
+        useCommandPaletteMru.getState().recordUse(action.id);
+      }
       const after = useCommandPaletteController.getState();
       // handler 没开 quick-pick (requestId 没变) 且仍在 commands 模式: 关闭面板。
       if (after.requestId === before && after.mode === "commands") {

--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -77,6 +77,7 @@ export const en = {
       selectStyle: "Select Style",
       selectLanguage: "Select Display Language",
       resetLayout: "Reset Layout",
+      clearRecent: "Clear command palette history",
     },
   },
 } as const;

--- a/src/renderer/i18n/locales/zh-cn.ts
+++ b/src/renderer/i18n/locales/zh-cn.ts
@@ -77,6 +77,7 @@ export const zhCN = {
       selectStyle: "选择风格",
       selectLanguage: "选择显示语言",
       resetLayout: "重置布局",
+      clearRecent: "清空命令面板使用记录",
     },
   },
 } as const;

--- a/src/renderer/lib/actions/command-palette-mru-action.ts
+++ b/src/renderer/lib/actions/command-palette-mru-action.ts
@@ -1,0 +1,31 @@
+/**
+ * "清空命令面板使用记录" 元命令.
+ *
+ * 自身设 excludeFromMru = true, 避免清空后立刻把自己写回 MRU 顶部
+ * (体感上违反 "清空" 语义).
+ */
+import i18next from "i18next";
+import { Eraser } from "lucide-react";
+import { actionRegistry } from "@/lib/actions/registry.ts";
+import { useCommandPaletteMru } from "@/stores/command-palette-mru.store.ts";
+
+export function registerCommandPaletteMruAction(): () => void {
+  return actionRegistry.register({
+    id: "pier.commandPalette.clearRecent",
+    category: "Settings",
+    title: () => i18next.t("commandPalette.action.clearRecent"),
+    surfaces: ["command-palette"],
+    metadata: {
+      iconComponent: Eraser,
+      sortOrder: 30,
+      excludeFromMru: true,
+      keywords: ["clear", "reset", "history", "清空", "重置", "历史"],
+    },
+    handler: () => {
+      useCommandPaletteMru
+        .getState()
+        .clear()
+        .catch(() => undefined);
+    },
+  });
+}

--- a/src/renderer/lib/actions/command-palette-mru-action.ts
+++ b/src/renderer/lib/actions/command-palette-mru-action.ts
@@ -25,7 +25,9 @@ export function registerCommandPaletteMruAction(): () => void {
       useCommandPaletteMru
         .getState()
         .clear()
-        .catch(() => undefined);
+        .catch((err: unknown) => {
+          console.error("[command-palette-mru] clear 失败:", err);
+        });
     },
   });
 }

--- a/src/renderer/lib/actions/types.ts
+++ b/src/renderer/lib/actions/types.ts
@@ -5,6 +5,8 @@
 import type { LucideIcon } from "lucide-react";
 
 export interface ActionMetadata {
+  /** true = 执行后不计入命令面板 MRU。仅给 clearRecent 这类元命令用 */
+  excludeFromMru?: boolean;
   iconComponent?: LucideIcon;
   keywords?: readonly string[];
   sortOrder?: number;

--- a/src/renderer/lib/command-palette/frecency.ts
+++ b/src/renderer/lib/command-palette/frecency.ts
@@ -1,0 +1,121 @@
+/**
+ * 命令面板 MRU 排序算法.
+ *
+ *   frecency = useCount × 0.5^(ageDays / HALF_LIFE_DAYS)
+ *
+ * 半衰期 14 天: 两周不用, 权重折半. 参数硬编码, 后续观察体感再调.
+ */
+import type { MruEntry } from "@shared/contracts/command-palette-mru.ts";
+import type { Action } from "@/lib/actions/types.ts";
+
+const HALF_LIFE_DAYS = 14;
+const MS_PER_DAY = 86_400_000;
+
+export const CATEGORY_META: Record<
+  string,
+  { labelKey: string; order: number }
+> = {
+  View: { order: 0, labelKey: "view" },
+  Workspace: { order: 1, labelKey: "workspace" },
+  Panel: { order: 2, labelKey: "panel" },
+  Window: { order: 3, labelKey: "window" },
+  Settings: { order: 4, labelKey: "settings" },
+};
+
+export const UNKNOWN_ORDER = Object.keys(CATEGORY_META).length;
+
+export function buildFrecencyMap(
+  entries: readonly MruEntry[],
+  now: number
+): ReadonlyMap<string, number> {
+  const map = new Map<string, number>();
+  for (const entry of entries) {
+    const ageDays = (now - entry.lastUsedAt) / MS_PER_DAY;
+    map.set(entry.actionId, entry.useCount * 0.5 ** (ageDays / HALF_LIFE_DAYS));
+  }
+  return map;
+}
+
+export type ActionRank =
+  | { tier: "frecency"; score: number }
+  | { tier: "fallback"; sortOrder: number };
+
+export function actionRank(
+  action: Action,
+  frecencyMap: ReadonlyMap<string, number>
+): ActionRank {
+  const score = frecencyMap.get(action.id);
+  return score == null
+    ? { tier: "fallback", sortOrder: action.metadata?.sortOrder ?? 0 }
+    : { tier: "frecency", score };
+}
+
+export type GroupRank =
+  | { tier: "frecency"; maxScore: number }
+  | { tier: "fallback"; order: number };
+
+export function groupRank(
+  actions: readonly Action[],
+  frecencyMap: ReadonlyMap<string, number>
+): GroupRank {
+  let maxScore = Number.NEGATIVE_INFINITY;
+  for (const a of actions) {
+    const s = frecencyMap.get(a.id);
+    if (s != null && s > maxScore) {
+      maxScore = s;
+    }
+  }
+  if (maxScore > Number.NEGATIVE_INFINITY) {
+    return { tier: "frecency", maxScore };
+  }
+  const category = actions[0]?.category ?? "";
+  return {
+    tier: "fallback",
+    order: CATEGORY_META[category]?.order ?? UNKNOWN_ORDER,
+  };
+}
+
+export function compareActions(
+  a: Action,
+  b: Action,
+  frecencyMap: ReadonlyMap<string, number>
+): number {
+  const ra = actionRank(a, frecencyMap);
+  const rb = actionRank(b, frecencyMap);
+  // frecency tier 在前
+  if (ra.tier === "frecency" && rb.tier === "fallback") {
+    return -1;
+  }
+  if (ra.tier === "fallback" && rb.tier === "frecency") {
+    return 1;
+  }
+  if (ra.tier === "frecency" && rb.tier === "frecency") {
+    return rb.score - ra.score; // 高分在前
+  }
+  if (ra.tier === "fallback" && rb.tier === "fallback") {
+    return ra.sortOrder - rb.sortOrder; // 小 sortOrder 在前
+  }
+  return 0;
+}
+
+export function compareGroups(
+  ga: readonly Action[],
+  gb: readonly Action[],
+  frecencyMap: ReadonlyMap<string, number>
+): number {
+  const ra = groupRank(ga, frecencyMap);
+  const rb = groupRank(gb, frecencyMap);
+  if (ra.tier === "frecency" && rb.tier === "fallback") {
+    return -1;
+  }
+  if (ra.tier === "fallback" && rb.tier === "frecency") {
+    return 1;
+  }
+  if (ra.tier === "frecency" && rb.tier === "frecency") {
+    return rb.maxScore - ra.maxScore;
+  }
+  if (ra.tier === "fallback" && rb.tier === "fallback") {
+    return ra.order - rb.order;
+  }
+  return 0;
+}

--- a/src/renderer/lib/command-palette/frecency.ts
+++ b/src/renderer/lib/command-palette/frecency.ts
@@ -5,11 +5,12 @@
  *
  * 半衰期 14 天: 两周不用, 权重折半. 参数硬编码, 后续观察体感再调.
  */
-import type { MruEntry } from "@shared/contracts/command-palette-mru.ts";
+import {
+  HALF_LIFE_DAYS,
+  type MruEntry,
+  MS_PER_DAY,
+} from "@shared/contracts/command-palette-mru.ts";
 import type { Action } from "@/lib/actions/types.ts";
-
-const HALF_LIFE_DAYS = 14;
-const MS_PER_DAY = 86_400_000;
 
 export const CATEGORY_META: Record<
   string,

--- a/src/renderer/lib/command-palette/frecency.ts
+++ b/src/renderer/lib/command-palette/frecency.ts
@@ -6,9 +6,8 @@
  * 半衰期 14 天: 两周不用, 权重折半. 参数硬编码, 后续观察体感再调.
  */
 import {
-  HALF_LIFE_DAYS,
+  frecency,
   type MruEntry,
-  MS_PER_DAY,
 } from "@shared/contracts/command-palette-mru.ts";
 import type { Action } from "@/lib/actions/types.ts";
 
@@ -31,8 +30,7 @@ export function buildFrecencyMap(
 ): ReadonlyMap<string, number> {
   const map = new Map<string, number>();
   for (const entry of entries) {
-    const ageDays = (now - entry.lastUsedAt) / MS_PER_DAY;
-    map.set(entry.actionId, entry.useCount * 0.5 ** (ageDays / HALF_LIFE_DAYS));
+    map.set(entry.actionId, frecency(entry, now));
   }
   return map;
 }

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -4,6 +4,7 @@ import { App } from "./App.tsx";
 import "./app/globals.css";
 import { initI18n } from "./i18n/index.ts";
 import { registerCommandPaletteAction } from "./lib/actions/command-palette-action.ts";
+import { registerCommandPaletteMruAction } from "./lib/actions/command-palette-mru-action.ts";
 import { registerConfigActions } from "./lib/actions/config-actions.ts";
 import { registerPanelActions } from "./lib/actions/panel-actions.ts";
 import { registerSettingsActions } from "./lib/actions/settings-actions.ts";
@@ -35,6 +36,7 @@ async function bootstrap() {
   registerCommandPaletteAction();
   registerPanelActions();
   registerSettingsActions();
+  registerCommandPaletteMruAction();
   keybindingRegistry.registerDefaults(DEFAULT_KEYMAP);
 
   const rootEl = document.getElementById("root");

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -9,6 +9,7 @@ import { registerPanelActions } from "./lib/actions/panel-actions.ts";
 import { registerSettingsActions } from "./lib/actions/settings-actions.ts";
 import { DEFAULT_KEYMAP } from "./lib/keybindings/defaults.ts";
 import { keybindingRegistry } from "./lib/keybindings/registry.ts";
+import { initCommandPaletteMru } from "./stores/command-palette-mru.store.ts";
 import { initFont } from "./stores/font.store.ts";
 import { initLocale } from "./stores/locale.store.ts";
 import { installDragWatcher } from "./stores/terminal-overlay.store.ts";
@@ -28,6 +29,7 @@ async function bootstrap() {
 
   window.pier?.terminal?.setup?.()?.catch(() => undefined);
   installDragWatcher();
+  initCommandPaletteMru().catch(() => undefined);
 
   registerConfigActions();
   registerCommandPaletteAction();

--- a/src/renderer/stores/command-palette-mru.store.ts
+++ b/src/renderer/stores/command-palette-mru.store.ts
@@ -46,6 +46,27 @@ function applyLocal(
   return [...prev, { actionId, useCount: 1, lastUsedAt: now }];
 }
 
+function entriesEqual(a: readonly MruEntry[], b: readonly MruEntry[]): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  for (let i = 0; i < a.length; i++) {
+    const x = a[i];
+    const y = b[i];
+    if (!(x && y)) {
+      return false;
+    }
+    if (
+      x.actionId !== y.actionId ||
+      x.useCount !== y.useCount ||
+      x.lastUsedAt !== y.lastUsedAt
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
 export const useCommandPaletteMru = create<CommandPaletteMruStore>(
   (set, get) => ({
     entries: EMPTY_MRU_STATE.entries,
@@ -85,6 +106,9 @@ export async function initCommandPaletteMru(): Promise<void> {
     console.error("[command-palette-mru] init read 失败:", err);
   }
   api.onChange((state: MruState) => {
+    if (entriesEqual(state.entries, useCommandPaletteMru.getState().entries)) {
+      return;
+    }
     useCommandPaletteMru.setState({
       entries: state.entries,
       frecencyMap: recompute(state.entries),

--- a/src/renderer/stores/command-palette-mru.store.ts
+++ b/src/renderer/stores/command-palette-mru.store.ts
@@ -1,0 +1,93 @@
+/**
+ * 命令面板 MRU store. 详见 specs/2026-06-23-command-palette-mru-design.md.
+ *
+ * - init: read + 订阅 onChange (main 端 record/clear 都会广播)
+ * - recordUse: 本地立即更新 + fire-and-forget IPC
+ * - frecencyMap 仅 entries 引用变化时重算
+ */
+import {
+  EMPTY_MRU_STATE,
+  type MruEntry,
+  type MruState,
+} from "@shared/contracts/command-palette-mru.ts";
+import { create } from "zustand";
+import { buildFrecencyMap } from "@/lib/command-palette/frecency.ts";
+
+interface CommandPaletteMruStore {
+  clear(): Promise<void>;
+  entries: readonly MruEntry[];
+  frecencyMap: ReadonlyMap<string, number>;
+  recordUse(actionId: string): void;
+}
+
+function recompute(entries: readonly MruEntry[]): ReadonlyMap<string, number> {
+  return buildFrecencyMap(entries, Date.now());
+}
+
+function applyLocal(
+  prev: readonly MruEntry[],
+  actionId: string,
+  now: number
+): readonly MruEntry[] {
+  const idx = prev.findIndex((e) => e.actionId === actionId);
+  if (idx >= 0) {
+    const existing = prev[idx];
+    if (existing) {
+      const updated: MruEntry = {
+        ...existing,
+        useCount: existing.useCount + 1,
+        lastUsedAt: now,
+      };
+      const next = prev.slice();
+      next[idx] = updated;
+      return next;
+    }
+  }
+  return [...prev, { actionId, useCount: 1, lastUsedAt: now }];
+}
+
+export const useCommandPaletteMru = create<CommandPaletteMruStore>(
+  (set, get) => ({
+    entries: EMPTY_MRU_STATE.entries,
+    frecencyMap: new Map(),
+
+    recordUse: (actionId) => {
+      const nextEntries = applyLocal(get().entries, actionId, Date.now());
+      set({ entries: nextEntries, frecencyMap: recompute(nextEntries) });
+      window.pier?.commandPaletteMru?.recordUse?.(actionId);
+    },
+
+    clear: async () => {
+      try {
+        await window.pier?.commandPaletteMru?.clear?.();
+        // 广播回来会通过 onChange 重置, 这里不直接 set 避免双写
+      } catch (err) {
+        console.error("[command-palette-mru] clear 失败:", err);
+        // 仍然本地清空保持 UI 一致
+        set({ entries: [], frecencyMap: new Map() });
+      }
+    },
+  })
+);
+
+export async function initCommandPaletteMru(): Promise<void> {
+  const api = window.pier?.commandPaletteMru;
+  if (!api) {
+    return;
+  }
+  try {
+    const state = await api.read();
+    useCommandPaletteMru.setState({
+      entries: state.entries,
+      frecencyMap: recompute(state.entries),
+    });
+  } catch (err) {
+    console.error("[command-palette-mru] init read 失败:", err);
+  }
+  api.onChange((state: MruState) => {
+    useCommandPaletteMru.setState({
+      entries: state.entries,
+      frecencyMap: recompute(state.entries),
+    });
+  });
+}

--- a/src/renderer/stores/command-palette-mru.store.ts
+++ b/src/renderer/stores/command-palette-mru.store.ts
@@ -96,15 +96,8 @@ export async function initCommandPaletteMru(): Promise<void> {
   if (!api) {
     return;
   }
-  try {
-    const state = await api.read();
-    useCommandPaletteMru.setState({
-      entries: state.entries,
-      frecencyMap: recompute(state.entries),
-    });
-  } catch (err) {
-    console.error("[command-palette-mru] init read 失败:", err);
-  }
+
+  // 先订阅 onChange, 否则 await read 期间到来的广播会丢失
   api.onChange((state: MruState) => {
     if (entriesEqual(state.entries, useCommandPaletteMru.getState().entries)) {
       return;
@@ -114,4 +107,14 @@ export async function initCommandPaletteMru(): Promise<void> {
       frecencyMap: recompute(state.entries),
     });
   });
+
+  try {
+    const state = await api.read();
+    useCommandPaletteMru.setState({
+      entries: state.entries,
+      frecencyMap: recompute(state.entries),
+    });
+  } catch (err) {
+    console.error("[command-palette-mru] init read 失败:", err);
+  }
 }

--- a/src/renderer/stores/command-palette-mru.store.ts
+++ b/src/renderer/stores/command-palette-mru.store.ts
@@ -7,6 +7,8 @@
  */
 import {
   EMPTY_MRU_STATE,
+  frecency,
+  MRU_MAX_ENTRIES,
   type MruEntry,
   type MruState,
 } from "@shared/contracts/command-palette-mru.ts";
@@ -43,7 +45,26 @@ function applyLocal(
       return next;
     }
   }
-  return [...prev, { actionId, useCount: 1, lastUsedAt: now }];
+  const incoming: MruEntry = { actionId, useCount: 1, lastUsedAt: now };
+  if (prev.length < MRU_MAX_ENTRIES) {
+    return [...prev, incoming];
+  }
+  // 已满: 按 frecency 淘汰最弱, 与 main evictWeakest 同语义, 保证渲染器瞬时状态也守 schema max(200).
+  let weakestIdx = 0;
+  const head = prev[0];
+  let weakestScore = head ? frecency(head, now) : 0;
+  for (let i = 1; i < prev.length; i++) {
+    const e = prev[i];
+    if (!e) {
+      continue;
+    }
+    const s = frecency(e, now);
+    if (s < weakestScore) {
+      weakestScore = s;
+      weakestIdx = i;
+    }
+  }
+  return [...prev.filter((_, i) => i !== weakestIdx), incoming];
 }
 
 function entriesEqual(a: readonly MruEntry[], b: readonly MruEntry[]): boolean {
@@ -79,12 +100,21 @@ export const useCommandPaletteMru = create<CommandPaletteMruStore>(
     },
 
     clear: async () => {
+      const api = window.pier?.commandPaletteMru;
+      // #3: preload 缺失 → 本地兜底, 不让 await undefined 静默成功.
+      if (!api) {
+        set({ entries: [], frecencyMap: new Map() });
+        return;
+      }
       try {
-        await window.pier?.commandPaletteMru?.clear?.();
-        // 广播回来会通过 onChange 重置, 这里不直接 set 避免双写
+        // #10: 用 IPC 返回值兜底, 不再仅依赖 broadcast 触发 onChange.
+        const next = await api.clear();
+        set({
+          entries: next.entries,
+          frecencyMap: recompute(next.entries),
+        });
       } catch (err) {
         console.error("[command-palette-mru] clear 失败:", err);
-        // 仍然本地清空保持 UI 一致
         set({ entries: [], frecencyMap: new Map() });
       }
     },
@@ -97,8 +127,11 @@ export async function initCommandPaletteMru(): Promise<void> {
     return;
   }
 
+  let onChangeApplied = false;
+
   // 先订阅 onChange, 否则 await read 期间到来的广播会丢失
   api.onChange((state: MruState) => {
+    onChangeApplied = true;
     if (entriesEqual(state.entries, useCommandPaletteMru.getState().entries)) {
       return;
     }
@@ -110,6 +143,10 @@ export async function initCommandPaletteMru(): Promise<void> {
 
   try {
     const state = await api.read();
+    if (onChangeApplied) {
+      // read 等待期间已有更新到达, 它的快照可能比当前状态旧, 跳过覆盖.
+      return;
+    }
     useCommandPaletteMru.setState({
       entries: state.entries,
       frecencyMap: recompute(state.entries),

--- a/src/shared/contracts/command-palette-mru.ts
+++ b/src/shared/contracts/command-palette-mru.ts
@@ -1,0 +1,21 @@
+/**
+ * 命令面板 MRU 持久化 schema. 详见 docs/superpowers/specs/2026-06-23-command-palette-mru-design.md
+ */
+import { z } from "zod";
+
+export const mruEntrySchema = z.object({
+  actionId: z.string().min(1),
+  useCount: z.number().int().nonnegative(),
+  lastUsedAt: z.number().int(),
+});
+
+export const mruStateSchema = z.object({
+  version: z.literal(1),
+  entries: z.array(mruEntrySchema).max(200),
+});
+
+export type MruEntry = z.infer<typeof mruEntrySchema>;
+export type MruState = z.infer<typeof mruStateSchema>;
+
+export const EMPTY_MRU_STATE: MruState = { version: 1, entries: [] };
+export const MRU_MAX_ENTRIES = 200;

--- a/src/shared/contracts/command-palette-mru.ts
+++ b/src/shared/contracts/command-palette-mru.ts
@@ -19,3 +19,15 @@ export type MruState = z.infer<typeof mruStateSchema>;
 
 export const EMPTY_MRU_STATE: MruState = { version: 1, entries: [] };
 export const MRU_MAX_ENTRIES = 200;
+
+/** 半衰期 14 天: 两周不用, 权重折半. main state evictWeakest 和 renderer
+ * frecency.ts 双端共用, 调这里就两边都生效. */
+export const HALF_LIFE_DAYS = 14;
+export const MS_PER_DAY = 86_400_000;
+
+/** frecency = useCount × 0.5^(ageDays / HALF_LIFE_DAYS).
+ * 同时在 main state.evictWeakest 和 renderer buildFrecencyMap 使用. */
+export function frecency(entry: MruEntry, now: number): number {
+  const ageDays = (now - entry.lastUsedAt) / MS_PER_DAY;
+  return entry.useCount * 0.5 ** (ageDays / HALF_LIFE_DAYS);
+}

--- a/tests/e2e/command-palette.spec.ts
+++ b/tests/e2e/command-palette.spec.ts
@@ -101,7 +101,7 @@ test.describe("Command Palette e2e", () => {
         .click();
       await win.waitForTimeout(500);
 
-      // 4. 重开命令面板, "打开设置" 不应在第一位 (CATEGORY_META.View=0 排前)
+      // 4. 重开命令面板, "打开设置" 不应在第一位 (Settings.order=4 在最后, View/Workspace/Panel/Window 都比它靠前)
       await win.keyboard.press("Meta+Shift+KeyP");
       await win.waitForTimeout(800);
       await expect(win.locator("[cmdk-item]").first()).not.toContainText(

--- a/tests/e2e/command-palette.spec.ts
+++ b/tests/e2e/command-palette.spec.ts
@@ -1,3 +1,5 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { _electron as electron, expect, test } from "@playwright/test";
 
@@ -37,5 +39,77 @@ test.describe("Command Palette e2e", () => {
     await expect(items.filter({ hasText: "选择显示语言" })).toBeVisible();
 
     await app.close();
+  });
+
+  test("MRU 顶置最近执行的 action", async () => {
+    const userDataDir = mkdtempSync(join(tmpdir(), "pier-mru-e2e-"));
+    const app = await electron.launch({
+      args: [OUT_MAIN, `--user-data-dir=${userDataDir}`],
+    });
+    try {
+      const win = await app.firstWindow();
+      await win.waitForLoadState("domcontentloaded");
+
+      // 1. 打开命令面板, 执行 "打开设置" (handler 不开 quick-pick)
+      await win.keyboard.press("Meta+Shift+KeyP");
+      await win.waitForTimeout(800);
+      await win.locator("[cmdk-item]").filter({ hasText: "打开设置" }).click();
+      // 设置弹窗会打开, Esc 关掉
+      await win.keyboard.press("Escape");
+      await win.waitForTimeout(300);
+
+      // 2. 重开命令面板
+      await win.keyboard.press("Meta+Shift+KeyP");
+      await win.waitForTimeout(800);
+
+      // 3. 第一个 cmdk-item 应是 "打开设置"
+      const firstItem = win.locator("[cmdk-item]").first();
+      await expect(firstItem).toContainText("打开设置");
+    } finally {
+      await app.close();
+      rmSync(userDataDir, { recursive: true, force: true });
+    }
+  });
+
+  test("清空命令面板使用记录后恢复默认顺序", async () => {
+    const userDataDir = mkdtempSync(join(tmpdir(), "pier-mru-e2e-"));
+    const app = await electron.launch({
+      args: [OUT_MAIN, `--user-data-dir=${userDataDir}`],
+    });
+    try {
+      const win = await app.firstWindow();
+      await win.waitForLoadState("domcontentloaded");
+
+      // 1. 执行 "打开设置" 让它进 MRU
+      await win.keyboard.press("Meta+Shift+KeyP");
+      await win.waitForTimeout(800);
+      await win.locator("[cmdk-item]").filter({ hasText: "打开设置" }).click();
+      await win.keyboard.press("Escape");
+      await win.waitForTimeout(300);
+
+      // 2. 验证它确实顶置 (sanity check)
+      await win.keyboard.press("Meta+Shift+KeyP");
+      await win.waitForTimeout(800);
+      await expect(win.locator("[cmdk-item]").first()).toContainText(
+        "打开设置"
+      );
+
+      // 3. 触发清空
+      await win
+        .locator("[cmdk-item]")
+        .filter({ hasText: "清空命令面板使用记录" })
+        .click();
+      await win.waitForTimeout(500);
+
+      // 4. 重开命令面板, "打开设置" 不应在第一位 (CATEGORY_META.View=0 排前)
+      await win.keyboard.press("Meta+Shift+KeyP");
+      await win.waitForTimeout(800);
+      await expect(win.locator("[cmdk-item]").first()).not.toContainText(
+        "打开设置"
+      );
+    } finally {
+      await app.close();
+      rmSync(userDataDir, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/unit/command-palette-frecency.test.ts
+++ b/tests/unit/command-palette-frecency.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from "vitest";
 import {
   actionRank,
   buildFrecencyMap,
+  compareActions,
+  compareGroups,
   groupRank,
 } from "@/lib/command-palette/frecency.ts";
 
@@ -99,5 +101,55 @@ describe("groupRank", () => {
     if (r.tier === "fallback") {
       expect(r.order).toBe(4);
     }
+  });
+});
+
+describe("compareActions", () => {
+  const mkA = (id: string, sortOrder?: number) => ({
+    id,
+    category: "View",
+    title: () => id,
+    handler: () => undefined,
+    ...(sortOrder == null ? {} : { metadata: { sortOrder } }),
+  });
+
+  it("frecency tier 排在 fallback tier 前面", () => {
+    const map = new Map([["a", 1]]);
+    expect(compareActions(mkA("a"), mkA("b", 0), map)).toBeLessThan(0);
+    expect(compareActions(mkA("b", 0), mkA("a"), map)).toBeGreaterThan(0);
+  });
+
+  it("两个 frecency: 高分在前", () => {
+    const map = new Map([
+      ["a", 5],
+      ["b", 10],
+    ]);
+    expect(compareActions(mkA("b"), mkA("a"), map)).toBeLessThan(0);
+  });
+
+  it("两个 fallback: 小 sortOrder 在前", () => {
+    expect(compareActions(mkA("a", 1), mkA("b", 5), new Map())).toBeLessThan(0);
+  });
+});
+
+describe("compareGroups", () => {
+  const mkA = (id: string, category: string) => ({
+    id,
+    category,
+    title: () => id,
+    handler: () => undefined,
+  });
+
+  it("frecency 组排在 fallback 组前面", () => {
+    const ga = [mkA("a", "Panel")];
+    const gb = [mkA("b", "View")];
+    const map = new Map([["a", 1]]);
+    expect(compareGroups(ga, gb, map)).toBeLessThan(0);
+  });
+
+  it("两个 fallback 组: 按 CATEGORY_META.order 排 (View=0 在前, Settings=4 在后)", () => {
+    const view = [mkA("v", "View")];
+    const settings = [mkA("s", "Settings")];
+    expect(compareGroups(view, settings, new Map())).toBeLessThan(0);
   });
 });

--- a/tests/unit/command-palette-frecency.test.ts
+++ b/tests/unit/command-palette-frecency.test.ts
@@ -1,0 +1,103 @@
+import type { MruEntry } from "@shared/contracts/command-palette-mru.ts";
+import { describe, expect, it } from "vitest";
+import {
+  actionRank,
+  buildFrecencyMap,
+  groupRank,
+} from "@/lib/command-palette/frecency.ts";
+
+const day = 86_400_000;
+
+describe("buildFrecencyMap", () => {
+  it("0 天: frecency = useCount", () => {
+    const now = 1000 * day;
+    const entries: MruEntry[] = [
+      { actionId: "x", useCount: 4, lastUsedAt: now },
+    ];
+    const map = buildFrecencyMap(entries, now);
+    expect(map.get("x")).toBeCloseTo(4);
+  });
+
+  it("14 天 (一个半衰期): frecency = useCount/2", () => {
+    const now = 1000 * day;
+    const entries: MruEntry[] = [
+      { actionId: "x", useCount: 4, lastUsedAt: now - 14 * day },
+    ];
+    expect(buildFrecencyMap(entries, now).get("x")).toBeCloseTo(2);
+  });
+
+  it("28 天 (两个半衰期): frecency = useCount/4", () => {
+    const now = 1000 * day;
+    const entries: MruEntry[] = [
+      { actionId: "x", useCount: 4, lastUsedAt: now - 28 * day },
+    ];
+    expect(buildFrecencyMap(entries, now).get("x")).toBeCloseTo(1);
+  });
+});
+
+describe("actionRank", () => {
+  const baseAction = (id: string, sortOrder?: number) => ({
+    id,
+    category: "View",
+    title: () => id,
+    handler: () => undefined,
+    ...(sortOrder == null ? {} : { metadata: { sortOrder } }),
+  });
+
+  it("有 frecency → tier=frecency", () => {
+    const map = new Map([["a", 5]]);
+    const r = actionRank(baseAction("a"), map);
+    expect(r.tier).toBe("frecency");
+    if (r.tier === "frecency") {
+      expect(r.score).toBe(5);
+    }
+  });
+
+  it("无 frecency → tier=fallback + sortOrder", () => {
+    const map = new Map<string, number>();
+    const r = actionRank(baseAction("a", 7), map);
+    expect(r.tier).toBe("fallback");
+    if (r.tier === "fallback") {
+      expect(r.sortOrder).toBe(7);
+    }
+  });
+
+  it("无 frecency 且无 sortOrder → fallback + 0", () => {
+    const r = actionRank(baseAction("a"), new Map());
+    if (r.tier === "fallback") {
+      expect(r.sortOrder).toBe(0);
+    }
+  });
+});
+
+describe("groupRank", () => {
+  const baseAction = (id: string, category: string) => ({
+    id,
+    category,
+    title: () => id,
+    handler: () => undefined,
+  });
+
+  it("组内任一 action 有 frecency → tier=frecency + maxScore", () => {
+    const actions = [baseAction("a", "View"), baseAction("b", "View")];
+    const map = new Map([
+      ["a", 3],
+      ["b", 7],
+    ]);
+    const r = groupRank(actions, map);
+    expect(r.tier).toBe("frecency");
+    if (r.tier === "frecency") {
+      expect(r.maxScore).toBe(7);
+    }
+  });
+
+  it("组内全无 frecency → tier=fallback + CATEGORY_META.order", () => {
+    const actions = [baseAction("a", "Settings")];
+    const r = groupRank(actions, new Map());
+    expect(r.tier).toBe("fallback");
+    // Settings.order = 4 (见 command-palette.tsx CATEGORY_META)
+    if (r.tier === "fallback") {
+      expect(r.order).toBe(4);
+    }
+  });
+});

--- a/tests/unit/command-palette-group-actions.test.ts
+++ b/tests/unit/command-palette-group-actions.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { groupActionsForPalette } from "@/components/common/command-palette.tsx";
+import type { Action } from "@/lib/actions/types.ts";
+
+const mk = (id: string, category: string, sortOrder?: number): Action => ({
+  id,
+  category,
+  title: () => id,
+  handler: () => undefined,
+  surfaces: ["command-palette"],
+  ...(sortOrder == null ? {} : { metadata: { sortOrder } }),
+});
+
+describe("groupActionsForPalette", () => {
+  it("query 非空 → 按 CATEGORY_META.order 排, 组内保持入参顺序", () => {
+    const actions = [
+      mk("s1", "Settings", 10),
+      mk("v1", "View", 5),
+      mk("v2", "View", 1),
+    ];
+    const groups = groupActionsForPalette(actions, new Map(), "foo");
+    expect(groups.map((g) => g.category)).toEqual(["View", "Settings"]);
+    expect(groups[0]?.actions.map((a) => a.id)).toEqual(["v1", "v2"]);
+  });
+
+  it("query 空 + 全无 frecency → 等同 CATEGORY_META.order + sortOrder", () => {
+    const actions = [
+      mk("v1", "View", 5),
+      mk("v2", "View", 1),
+      mk("s1", "Settings", 10),
+    ];
+    const groups = groupActionsForPalette(actions, new Map(), "");
+    expect(groups.map((g) => g.category)).toEqual(["View", "Settings"]);
+    expect(groups[0]?.actions.map((a) => a.id)).toEqual(["v2", "v1"]);
+  });
+
+  it("query 空 + 有 frecency → 组间按 max(score) 排, 组内按 score 排", () => {
+    const actions = [
+      mk("v1", "View"),
+      mk("v2", "View"),
+      mk("s1", "Settings"),
+      mk("s2", "Settings"),
+    ];
+    const map = new Map([
+      ["v1", 3],
+      ["s1", 10],
+      ["s2", 7],
+    ]);
+    const groups = groupActionsForPalette(actions, map, "");
+    expect(groups[0]?.category).toBe("Settings");
+    expect(groups[0]?.actions.map((a) => a.id)).toEqual(["s1", "s2"]);
+    expect(groups[1]?.category).toBe("View");
+    expect(groups[1]?.actions.map((a) => a.id)).toEqual(["v1", "v2"]);
+  });
+
+  it("frecency tier 整组排在 fallback tier 整组之前", () => {
+    const actions = [mk("v1", "View", 5), mk("p1", "Panel")];
+    const map = new Map([["p1", 1]]);
+    const groups = groupActionsForPalette(actions, map, "");
+    expect(groups.map((g) => g.category)).toEqual(["Panel", "View"]);
+  });
+});

--- a/tests/unit/command-palette-mru-schema.test.ts
+++ b/tests/unit/command-palette-mru-schema.test.ts
@@ -1,0 +1,42 @@
+import {
+  mruEntrySchema,
+  mruStateSchema,
+} from "@shared/contracts/command-palette-mru.ts";
+import { describe, expect, it } from "vitest";
+
+describe("command-palette-mru schema", () => {
+  it("接受最小合法 entry", () => {
+    const parsed = mruEntrySchema.parse({
+      actionId: "pier.x",
+      useCount: 1,
+      lastUsedAt: 1_700_000_000_000,
+    });
+    expect(parsed.actionId).toBe("pier.x");
+  });
+
+  it("拒绝空 actionId", () => {
+    expect(() =>
+      mruEntrySchema.parse({ actionId: "", useCount: 0, lastUsedAt: 0 })
+    ).toThrow();
+  });
+
+  it("拒绝负 useCount", () => {
+    expect(() =>
+      mruEntrySchema.parse({ actionId: "x", useCount: -1, lastUsedAt: 0 })
+    ).toThrow();
+  });
+
+  it("默认 state 通过校验", () => {
+    const parsed = mruStateSchema.parse({ version: 1, entries: [] });
+    expect(parsed.entries).toEqual([]);
+  });
+
+  it("拒绝超过 200 条 entries", () => {
+    const entries = Array.from({ length: 201 }, (_, i) => ({
+      actionId: `a${i}`,
+      useCount: 1,
+      lastUsedAt: 0,
+    }));
+    expect(() => mruStateSchema.parse({ version: 1, entries })).toThrow();
+  });
+});

--- a/tests/unit/command-palette-mru-state.test.ts
+++ b/tests/unit/command-palette-mru-state.test.ts
@@ -1,0 +1,70 @@
+import { evictWeakest, recordUse } from "@main/state/command-palette-mru.ts";
+import {
+  EMPTY_MRU_STATE,
+  type MruState,
+} from "@shared/contracts/command-palette-mru.ts";
+import { describe, expect, it } from "vitest";
+
+const day = 86_400_000;
+
+describe("recordUse", () => {
+  it("新 actionId → append entry, useCount=1", () => {
+    const next = recordUse(EMPTY_MRU_STATE, "pier.x", 1000);
+    expect(next.entries).toEqual([
+      { actionId: "pier.x", useCount: 1, lastUsedAt: 1000 },
+    ]);
+  });
+
+  it("已存在 actionId → useCount++ + lastUsedAt 刷新", () => {
+    const base: MruState = {
+      version: 1,
+      entries: [{ actionId: "pier.x", useCount: 3, lastUsedAt: 1000 }],
+    };
+    const next = recordUse(base, "pier.x", 2000);
+    expect(next.entries).toEqual([
+      { actionId: "pier.x", useCount: 4, lastUsedAt: 2000 },
+    ]);
+  });
+
+  it("不破坏旧引用 (immutable)", () => {
+    const base: MruState = {
+      version: 1,
+      entries: [{ actionId: "pier.x", useCount: 1, lastUsedAt: 0 }],
+    };
+    recordUse(base, "pier.x", 2000);
+    expect(base.entries[0]?.useCount).toBe(1);
+  });
+});
+
+describe("evictWeakest (满 200 时使用)", () => {
+  it("frecency 最低的被剔除", () => {
+    const now = 100 * day;
+    const entries = [
+      // useCount=10, age=0 → frecency=10
+      { actionId: "hot", useCount: 10, lastUsedAt: now },
+      // useCount=1, age=100d → frecency≈0.0073, 最低
+      { actionId: "cold", useCount: 1, lastUsedAt: 0 },
+      // useCount=2, age=14d → frecency=1
+      { actionId: "warm", useCount: 2, lastUsedAt: now - 14 * day },
+    ];
+    const survivors = evictWeakest(entries, now);
+    expect(survivors.map((e) => e.actionId).sort()).toEqual(["hot", "warm"]);
+  });
+});
+
+describe("recordUse + cap 200", () => {
+  it("满 200 时新插入触发逐出 weakest", () => {
+    const now = 100 * day;
+    const entries = Array.from({ length: 200 }, (_, i) => ({
+      actionId: `a${i}`,
+      // a0 是最弱的: useCount=1, age=200d
+      useCount: i === 0 ? 1 : 5,
+      lastUsedAt: i === 0 ? 0 : now - 7 * day,
+    }));
+    const base: MruState = { version: 1, entries };
+    const next = recordUse(base, "fresh", now);
+    expect(next.entries).toHaveLength(200);
+    expect(next.entries.some((e) => e.actionId === "fresh")).toBe(true);
+    expect(next.entries.some((e) => e.actionId === "a0")).toBe(false);
+  });
+});


### PR DESCRIPTION
## 概述

给命令面板加上"最近使用优先级"双层排序：分组顺序和组内顺序都按 frecency（频次 × 近期度）排，最常用的命令出现在最上面、所在分组也提到最前。完全没用过的分组和命令回退到现有的 `CATEGORY_META.order` 与 `metadata.sortOrder`，保证新用户首次打开看到的就是当前设计意图的顺序。

目的不是当下命中率，而是为后续命令池扩张（Git / AI / Terminal 等新 surface 接入）做承重，避免"分类多、每类条目多"之后用户每次都得手动滚屏找。

## 设计文档

- Spec: [docs/superpowers/specs/2026-06-23-command-palette-mru-design.md](docs/superpowers/specs/2026-06-23-command-palette-mru-design.md)
- Plan (12 task): [docs/superpowers/plans/2026-06-23-command-palette-mru.md](docs/superpowers/plans/2026-06-23-command-palette-mru.md)

## 排序规则

- **frecency 公式**: `useCount × 0.5^(ageDays / 14)` — 半衰期 14 天
- **排序**:
  - 分组之间: max(frecency) 高的在前; 全无 frecency → fallback 到 `CATEGORY_META.order`
  - 组内: action.frecency 高的在前; 全无 → fallback 到 `sortOrder`
- **搜索时**: query 非空时不重排, 让 cmdk fuzzy score 接管
- **触发记录**: handler 成功 resolve 后, 且 `metadata.excludeFromMru !== true`

## 持久化

- 独立文件 \`userData/command-palette-mru.json\` (不挤进 preferences.json)
- main state 模块: lockfile + write-file-atomic, 首次写先 touch 空状态再加锁
- 多窗口同步: main 经 \`pier:command-palette-mru:changed\` 广播给所有 BrowserWindow
- renderer 端 zustand store: 启动 read + 订阅 onChange + recordUse 本地乐观更新
- 内存副本 + queue 串行化 + ensureLoaded in-flight promise 避免并发 race

## 新增 \"清空命令面板使用记录\" 元命令

- id: \`pier.commandPalette.clearRecent\`, 归 Settings 分类
- \`metadata.excludeFromMru: true\` 防止清空后自己回到顶部
- i18n: zh-CN \"清空命令面板使用记录\" / en \"Clear command palette history\"

## 主要变更

| 层 | 文件 | 说明 |
| --- | --- | --- |
| 契约 | \`src/shared/contracts/command-palette-mru.ts\` | zod schema + frecency 公式 (双端共用) |
| main state | \`src/main/state/command-palette-mru.ts\` | 持久化 + recordUse / evictWeakest 纯函数 |
| main IPC | \`src/main/ipc/command-palette-mru.ts\` | read / record / clear + 多窗口广播 |
| preload | \`src/preload/index.ts\` | \`window.pier.commandPaletteMru\` |
| renderer 算法 | \`src/renderer/lib/command-palette/frecency.ts\` | buildFrecencyMap / actionRank / groupRank / compare* + CATEGORY_META |
| renderer store | \`src/renderer/stores/command-palette-mru.store.ts\` | zustand + bootstrap init |
| renderer UI | \`src/renderer/components/common/command-palette.tsx\` | groupActionsForPalette + 触发 recordUse |
| Actions | \`src/renderer/lib/actions/command-palette-mru-action.ts\` | clearRecent 元命令 |
| 类型 | \`src/renderer/lib/actions/types.ts\` | \`ActionMetadata.excludeFromMru?\` |
| i18n | \`src/renderer/i18n/locales/{zh-cn,en}.ts\` | \`commandPalette.action.clearRecent\` |

## Test plan

- [x] 单测 41/41 pass (\`pnpm test:unit\`): schema / state / frecency / groupActions / compare*
- [x] E2E 3/3 pass (\`pnpm test:e2e\`): 既有命令面板用例 + MRU 顶置 + clear 恢复默认顺序
- [x] \`pnpm check\` 全绿 (typecheck + lint + depcruise + file-size)
- [ ] 手工验证 (reviewer 拉下后):
  - 打开命令面板, 执行某个 action 几次, 关闭重开 → 该 action 在分组顶部, 分组提到最前
  - 触发 \"清空命令面板使用记录\" → 顺序回到默认 (View → Workspace → Panel → Window → Settings)
  - 多窗口同时打开, 一个窗口 record → 另一窗口下次打开顺序也更新
  - 退出后查看 \`~/Library/Application Support/Pier-dev/userData/command-palette-mru.json\` 内容正确

## Review 闭环

实施过程跑了 12 个 plan task + 全程 spec compliance review + code quality review, 全部通过。最终又做一次 ultra max-effort 多 angle review (10 finder + verify + sweep), 找到 15 个 finding:

- ✅ 11 个修了 (CONFIRMED 持久化/并发/契约 bug + 复用清理): commits \`13c25e3\` / \`eecce62\` / \`98236c3\`
- 📝 1 个是 spec 明确设计选择 (#5: quick-pick 顶层 action 在 handler resolve 时记 MRU, 即使内层 Esc, 与 \"打开 picker 即用过\" 语义一致)
- 🔮 2 个是 altitude follow-up (#14 excludeFromMru 改 category 层抽象; #15 CATEGORY_META 改 category 自注册), 留作未来重构

## 不做 / 后续

- 搜索时的 frecency 加权 (交给 cmdk)
- frecency 参数 UI 化 (半衰期 14 天 / cap 200 都死值, 后续观察体感再调)
- 跨设备同步 (本地状态, 与 preferences.json 一致)
- toast 反馈 (Pier 暂无项目级 toast 系统; 当前 clear 失败仅 console.error, 后续接入后可升级)

🤖 Generated with [Claude Code](https://claude.com/claude-code)