### PR TITLE
Persist terminal working directory across reloads

### DIFF
--- a/native/Sources/GhosttyBridge/GhosttyBridge.swift
+++ b/native/Sources/GhosttyBridge/GhosttyBridge.swift
@@ -549,7 +549,8 @@ final class GhosttyBridgeImpl {
         panelId: String,
         viewport: NSRect,
         fontFamily: String,
-        fontSize: Float
+        fontSize: Float,
+        workingDirectory: String?
     ) -> Bool {
         guard let contentView = parent.contentView else { return false }
 
@@ -587,7 +588,10 @@ final class GhosttyBridgeImpl {
         let frame = computeFrame(in: contentView, viewport: viewport)
 
         let terminalView = TerminalView(frame: .zero)
-        terminalView.configuration = TerminalSurfaceOptions(backend: .exec)
+        terminalView.configuration = TerminalSurfaceOptions(
+            backend: .exec,
+            workingDirectory: workingDirectory
+        )
         terminalView.controller = controller(for: parent)
 
         // 把创建期字体写进 controller 的 TerminalConfiguration. 走 setTerminalConfiguration
@@ -934,19 +938,22 @@ public func ghosttyBridgeCreateTerminal(
     _ panelIdPtr: UnsafePointer<CChar>,
     _ x: Double, _ y: Double, _ w: Double, _ h: Double,
     _ fontFamilyPtr: UnsafePointer<CChar>,
-    _ fontSize: Float
+    _ fontSize: Float,
+    _ workingDirectoryPtr: UnsafePointer<CChar>?
 ) -> Bool {
     MainActor.assumeIsolated {
         let window = Unmanaged<NSWindow>.fromOpaque(nsWindowPtr).takeUnretainedValue()
         let panelId = String(cString: panelIdPtr)
         let fontFamily = String(cString: fontFamilyPtr)
+        let workingDirectory = workingDirectoryPtr.map { String(cString: $0) }
         let viewport = NSRect(x: x, y: y, width: w, height: h)
         return GhosttyBridgeImpl.shared.createTerminal(
             parent: window,
             panelId: panelId,
             viewport: viewport,
             fontFamily: fontFamily,
-            fontSize: fontSize
+            fontSize: fontSize,
+            workingDirectory: workingDirectory
         )
     }
 }

--- a/native/src/addon.mm
+++ b/native/src/addon.mm
@@ -9,7 +9,8 @@ extern "C" {
     void ghostty_bridge_set_overlay_active(void* nsWindow, bool active);
     bool ghostty_bridge_create_terminal(void* nsWindow, const char* panelId,
                                          double x, double y, double w, double h,
-                                         const char* fontFamily, float fontSize);
+                                         const char* fontFamily, float fontSize,
+                                         const char* workingDirectory);
     void ghostty_bridge_set_font_config(void* nsWindow, const char* fontFamily, float fontSize);
     void ghostty_bridge_set_frame(const char* panelId,
                                    double x, double y, double w, double h);
@@ -98,10 +99,17 @@ static Napi::Value JsCreateTerminal(const Napi::CallbackInfo& info) {
     double h = frame.Get("height").As<Napi::Number>().DoubleValue();
     std::string fontFamily = info[3].As<Napi::String>().Utf8Value();
     float fontSize = info[4].As<Napi::Number>().FloatValue();
+    const char* cwdPtr = nullptr;
+    std::string cwdHolder;
+    if (info.Length() > 5 && info[5].IsString()) {
+        cwdHolder = info[5].As<Napi::String>().Utf8Value();
+        if (!cwdHolder.empty()) cwdPtr = cwdHolder.c_str();
+    }
     bool ok = ghostty_bridge_create_terminal(
         (__bridge void*)win, panelId.c_str(),
         x, y, w, h,
-        fontFamily.c_str(), fontSize
+        fontFamily.c_str(), fontSize,
+        cwdPtr
     );
     return Napi::Boolean::New(info.Env(), ok);
 }

--- a/src/main/ipc/terminal-native-addon.ts
+++ b/src/main/ipc/terminal-native-addon.ts
@@ -1,0 +1,94 @@
+import type {
+  TerminalColors,
+  TerminalFrame,
+} from "@shared/contracts/terminal.ts";
+
+export interface NativeAddon {
+  /**
+   * 应用 Pier 主题派生的终端配色到指定 window 下的 Ghostty controller.
+   * Ghostty 库 controller.setTheme(...) 内部 reconfigure 并立即生效, shell 进程
+   * 不重启. 每个 BrowserWindow 一个 controller, 该 window 下所有 terminal panel
+   * 共享, 调一次即可.
+   */
+  applyTerminalTheme(parentHandle: Buffer, colors: TerminalColors): void;
+  closeAllTerminals(parentHandle: Buffer): void;
+  closeTerminal(panelId: string): void;
+  createTerminal(
+    parentHandle: Buffer,
+    panelId: string,
+    frame: TerminalFrame,
+    fontFamily: string,
+    fontSize: number,
+    cwd: string | undefined
+  ): boolean;
+  /** Window 真正销毁时调用一次: closeAll + 卸 EventRouter + 卸 NSEvent monitor */
+  detachWindow(parentHandle: Buffer): void;
+  focusTerminal(panelId: string): void;
+  hideTerminal(panelId: string): void;
+  /**
+   * 孤儿清理:关掉该 window 下不在 activeIds 集合的 terminal NSView. C 方案
+   * reload 零销毁路径上, renderer 重建后报告"我现在还需要这些 panelId",
+   * swift 把不在集合里的清掉. 空数组 = 全清 (等价 closeAllTerminals).
+   */
+  reconcileTerminals(parentHandle: Buffer, activeIds: string[]): void;
+  /**
+   * 注册 keyboard forward callback. swift NSEvent monitor 检测 Cmd+key 后调用,
+   * 传 (browserWindowId, modifierFlags, chars). browserWindowId 是 setupWindow
+   * 传入的 BrowserWindow.id, 用于多窗口路由. 传 null 解绑.
+   */
+  setActivePanelKind(
+    parentHandle: Buffer,
+    kindRaw: number,
+    panelId: string | null
+  ): void;
+  setFrame(panelId: string, frame: TerminalFrame): void;
+  setKeyboardForwardCallback(
+    cb:
+      | ((
+          browserWindowId: number,
+          modifierFlags: number,
+          chars: string
+        ) => void)
+      | null
+  ): void;
+  setMouseForwardCallback(
+    cb:
+      | ((
+          browserWindowId: number,
+          panelId: string,
+          x: number,
+          y: number
+        ) => void)
+      | null
+  ): void;
+  setOverlayActive(parentHandle: Buffer, active: boolean): void;
+  /**
+   * 注册 PWD forward callback. swift TerminalSurfacePwdDelegate 收到 OSC 7 后调用,
+   * 传 (browserWindowId, panelId, cwd). 用 windowId 路由到对应 BrowserWindow 的
+   * renderer (多窗口下避免广播污染). 传 null 解绑.
+   */
+  setPwdForwardCallback(
+    cb: ((browserWindowId: number, panelId: string, cwd: string) => void) | null
+  ): void;
+  setTerminalFocusRequestCallback(
+    cb: ((browserWindowId: number, panelId: string) => void) | null
+  ): void;
+  /** 热更新 window 下所有 terminal 的字体. controller per window, 内部走 Ghostty TerminalController.setTerminalConfiguration. */
+  setTerminalFont(
+    parentHandle: Buffer,
+    fontFamily: string,
+    fontSize: number
+  ): void;
+  /**
+   * 注册 Title forward callback. swift TerminalSurfaceTitleDelegate 收到 OSC 0/2 后调用,
+   * 传 (browserWindowId, panelId, title). TUI 应用 (claude / vim / aider) 自定义 title
+   * 通道. 与 PWD 路由方式相同, 按 windowId 精准送到对应 BrowserWindow renderer.
+   */
+  setTitleForwardCallback(
+    cb:
+      | ((browserWindowId: number, panelId: string, title: string) => void)
+      | null
+  ): void;
+  setupWindow(parentHandle: Buffer, browserWindowId: number): boolean;
+  showTerminal(panelId: string): void;
+}

--- a/src/main/ipc/terminal.ts
+++ b/src/main/ipc/terminal.ts
@@ -10,95 +10,13 @@ import {
   isToggleDevToolsNativeChord,
   toggleDetachedDevTools,
 } from "../devtools.ts";
-
-interface NativeAddon {
-  /**
-   * 应用 Pier 主题派生的终端配色到指定 window 下的 Ghostty controller.
-   * Ghostty 库 controller.setTheme(...) 内部 reconfigure 并立即生效, shell 进程
-   * 不重启. 每个 BrowserWindow 一个 controller, 该 window 下所有 terminal panel
-   * 共享, 调一次即可.
-   */
-  applyTerminalTheme(parentHandle: Buffer, colors: TerminalColors): void;
-  closeAllTerminals(parentHandle: Buffer): void;
-  closeTerminal(panelId: string): void;
-  createTerminal(
-    parentHandle: Buffer,
-    panelId: string,
-    frame: TerminalFrame,
-    fontFamily: string,
-    fontSize: number
-  ): boolean;
-  /** Window 真正销毁时调用一次: closeAll + 卸 EventRouter + 卸 NSEvent monitor */
-  detachWindow(parentHandle: Buffer): void;
-  focusTerminal(panelId: string): void;
-  hideTerminal(panelId: string): void;
-  /**
-   * 孤儿清理:关掉该 window 下不在 activeIds 集合的 terminal NSView. C 方案
-   * reload 零销毁路径上, renderer 重建后报告"我现在还需要这些 panelId",
-   * swift 把不在集合里的清掉. 空数组 = 全清 (等价 closeAllTerminals).
-   */
-  reconcileTerminals(parentHandle: Buffer, activeIds: string[]): void;
-  /**
-   * 注册 keyboard forward callback. swift NSEvent monitor 检测 Cmd+key 后调用,
-   * 传 (browserWindowId, modifierFlags, chars). browserWindowId 是 setupWindow
-   * 传入的 BrowserWindow.id, 用于多窗口路由. 传 null 解绑.
-   */
-  setActivePanelKind(
-    parentHandle: Buffer,
-    kindRaw: number,
-    panelId: string | null
-  ): void;
-  setFrame(panelId: string, frame: TerminalFrame): void;
-  setKeyboardForwardCallback(
-    cb:
-      | ((
-          browserWindowId: number,
-          modifierFlags: number,
-          chars: string
-        ) => void)
-      | null
-  ): void;
-  setMouseForwardCallback(
-    cb:
-      | ((
-          browserWindowId: number,
-          panelId: string,
-          x: number,
-          y: number
-        ) => void)
-      | null
-  ): void;
-  setOverlayActive(parentHandle: Buffer, active: boolean): void;
-  /**
-   * 注册 PWD forward callback. swift TerminalSurfacePwdDelegate 收到 OSC 7 后调用,
-   * 传 (browserWindowId, panelId, cwd). 用 windowId 路由到对应 BrowserWindow 的
-   * renderer (多窗口下避免广播污染). 传 null 解绑.
-   */
-  setPwdForwardCallback(
-    cb: ((browserWindowId: number, panelId: string, cwd: string) => void) | null
-  ): void;
-  setTerminalFocusRequestCallback(
-    cb: ((browserWindowId: number, panelId: string) => void) | null
-  ): void;
-  /** 热更新 window 下所有 terminal 的字体. controller per window, 内部走 Ghostty TerminalController.setTerminalConfiguration. */
-  setTerminalFont(
-    parentHandle: Buffer,
-    fontFamily: string,
-    fontSize: number
-  ): void;
-  /**
-   * 注册 Title forward callback. swift TerminalSurfaceTitleDelegate 收到 OSC 0/2 后调用,
-   * 传 (browserWindowId, panelId, title). TUI 应用 (claude / vim / aider) 自定义 title
-   * 通道. 与 PWD 路由方式相同, 按 windowId 精准送到对应 BrowserWindow renderer.
-   */
-  setTitleForwardCallback(
-    cb:
-      | ((browserWindowId: number, panelId: string, title: string) => void)
-      | null
-  ): void;
-  setupWindow(parentHandle: Buffer, browserWindowId: number): boolean;
-  showTerminal(panelId: string): void;
-}
+import {
+  readTerminalPanelSession,
+  removeTerminalPanelSession,
+  updateTerminalPanelCwd,
+} from "../state/terminal-session-state.ts";
+import { findBrowserWindowId } from "../windows/window-identity.ts";
+import type { NativeAddon } from "./terminal-native-addon.ts";
 
 /** 暴露给 window-manager 在 renderer reload/crash 时调用清理. */
 export function getTerminalAddon(): NativeAddon | null {
@@ -120,6 +38,10 @@ function rememberActivePanelFocus(
   panelId: string | null
 ): void {
   activePanelFocusByWindowId.set(win.id, { kind, panelId });
+}
+
+function stableWindowIdFor(win: BrowserWindow): string {
+  return findBrowserWindowId(win) ?? `browser-${win.id}`;
 }
 
 export function restoreActivePanelFocus(win: BrowserWindow): void {
@@ -256,6 +178,13 @@ export function registerTerminalIpc(ipcMain: IpcMain): void {
     );
   });
   addon?.setPwdForwardCallback((id, panelId, cwd) => {
+    const targetWindow = BrowserWindow.fromId(id);
+    if (targetWindow && !targetWindow.isDestroyed()) {
+      const windowId = stableWindowIdFor(targetWindow);
+      updateTerminalPanelCwd(windowId, panelId, cwd).catch((err) => {
+        console.error("[pier-cwd-persist] failed:", err);
+      });
+    }
     forwardToWindow(
       id,
       "pier:terminal:cwd-change",
@@ -293,33 +222,40 @@ export function registerTerminalIpc(ipcMain: IpcMain): void {
     }
   });
 
-  ipcMain.handle("pier:terminal:create", (event, args: CreateTerminalArgs) => {
-    if (!addon) {
-      return { ok: false, error: loadError ?? "native addon not loaded" };
+  ipcMain.handle(
+    "pier:terminal:create",
+    async (event, args: CreateTerminalArgs) => {
+      if (!addon) {
+        return { ok: false, error: loadError ?? "native addon not loaded" };
+      }
+      const win = BrowserWindow.fromWebContents(event.sender);
+      if (!win) {
+        return { ok: false, error: "window not found" };
+      }
+      try {
+        const handle = win.getNativeWindowHandle();
+        const windowId = stableWindowIdFor(win);
+        const saved = await readTerminalPanelSession(windowId, args.panelId);
+        const cwd = args.cwd ?? saved?.cwd;
+        const ok = addon.createTerminal(
+          handle,
+          args.panelId,
+          args.frame,
+          args.font.family,
+          args.font.size,
+          cwd
+        );
+        return ok
+          ? { ok: true }
+          : { ok: false, error: "createTerminal returned false" };
+      } catch (e) {
+        return {
+          ok: false,
+          error: e instanceof Error ? e.message : String(e),
+        };
+      }
     }
-    const win = BrowserWindow.fromWebContents(event.sender);
-    if (!win) {
-      return { ok: false, error: "window not found" };
-    }
-    try {
-      const handle = win.getNativeWindowHandle();
-      const ok = addon.createTerminal(
-        handle,
-        args.panelId,
-        args.frame,
-        args.font.family,
-        args.font.size
-      );
-      return ok
-        ? { ok: true }
-        : { ok: false, error: "createTerminal returned false" };
-    } catch (e) {
-      return {
-        ok: false,
-        error: e instanceof Error ? e.message : String(e),
-      };
-    }
-  });
+  );
 
   // Renderer → addon 单参数透传 (fire-and-forget): renderer.ipcRenderer.send 单向
   // 触发 addon 同名 method. addon 可能未加载 (非 darwin / native load 失败), 用
@@ -334,14 +270,20 @@ export function registerTerminalIpc(ipcMain: IpcMain): void {
       channel: "pier:terminal:hide",
       call: (panelId: string) => addon?.hideTerminal(panelId),
     },
-    {
-      channel: "pier:terminal:close",
-      call: (panelId: string) => addon?.closeTerminal(panelId),
-    },
   ] as const;
   for (const { channel, call } of panelIdRelays) {
     ipcMain.on(channel, (_event, panelId: string) => call(panelId));
   }
+  ipcMain.on("pier:terminal:close", (event, panelId: string) => {
+    const win = BrowserWindow.fromWebContents(event.sender);
+    if (win) {
+      const windowId = stableWindowIdFor(win);
+      removeTerminalPanelSession(windowId, panelId).catch((err) => {
+        console.error("[pier-cwd-remove] failed:", err);
+      });
+    }
+    addon?.closeTerminal(panelId);
+  });
   ipcMain.on("pier:terminal:focus", (event, panelId: string) => {
     const win = BrowserWindow.fromWebContents(event.sender);
     if (win) {

--- a/src/main/state/terminal-session-state.ts
+++ b/src/main/state/terminal-session-state.ts
@@ -1,0 +1,147 @@
+/**
+ * Terminal session state persistence.
+ *
+ * This is intentionally smaller than a full session restore system: it only
+ * remembers the last cwd per stable Pier window id + terminal panel id, so a
+ * relaunched app can create a fresh shell in the same directory.
+ */
+import { existsSync } from "node:fs";
+import { mkdir, readFile } from "node:fs/promises";
+import { dirname, isAbsolute, join } from "node:path";
+import { app } from "electron";
+import lockfile from "proper-lockfile";
+import writeFileAtomic from "write-file-atomic";
+import { z } from "zod";
+
+const terminalPanelSessionSchema = z.object({
+  cwd: z.string(),
+  updatedAt: z.string(),
+});
+
+const terminalWindowSessionSchema = z.object({
+  panels: z.record(z.string(), terminalPanelSessionSchema),
+});
+
+const terminalSessionStateSchema = z.object({
+  version: z.literal(1),
+  windows: z.record(z.string(), terminalWindowSessionSchema),
+});
+
+export type TerminalPanelSession = z.infer<typeof terminalPanelSessionSchema>;
+type TerminalSessionState = z.infer<typeof terminalSessionStateSchema>;
+
+const EMPTY_TERMINAL_SESSION_STATE: TerminalSessionState = {
+  version: 1,
+  windows: {},
+};
+
+function resolveFilePath(): string {
+  return join(app.getPath("userData"), "terminal-session-state.json");
+}
+
+async function ensureDir(filePath: string): Promise<void> {
+  await mkdir(dirname(filePath), { recursive: true });
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    const { stat } = await import("node:fs/promises");
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readState(): Promise<TerminalSessionState> {
+  const path = resolveFilePath();
+  if (!existsSync(path)) {
+    return EMPTY_TERMINAL_SESSION_STATE;
+  }
+  try {
+    const raw = await readFile(path, "utf-8");
+    return terminalSessionStateSchema.parse(JSON.parse(raw));
+  } catch (err) {
+    console.warn(
+      "[terminal-session-state] parse failed, using empty state:",
+      err
+    );
+    return EMPTY_TERMINAL_SESSION_STATE;
+  }
+}
+
+async function writeState(state: TerminalSessionState): Promise<void> {
+  const path = resolveFilePath();
+  await ensureDir(path);
+  if (!(await fileExists(path))) {
+    await writeFileAtomic(
+      path,
+      `${JSON.stringify(EMPTY_TERMINAL_SESSION_STATE, null, 2)}\n`
+    );
+  }
+  const release = await lockfile.lock(path);
+  try {
+    await writeFileAtomic(path, `${JSON.stringify(state, null, 2)}\n`);
+  } finally {
+    await release();
+  }
+}
+
+function isNonEmptyId(value: string): boolean {
+  return value.trim().length > 0;
+}
+
+function isRestorableCwd(cwd: string): boolean {
+  return cwd.trim() === cwd && cwd.length > 0 && isAbsolute(cwd);
+}
+
+export async function readTerminalPanelSession(
+  windowId: string,
+  panelId: string
+): Promise<TerminalPanelSession | null> {
+  if (!(isNonEmptyId(windowId) && isNonEmptyId(panelId))) {
+    return null;
+  }
+  const state = await readState();
+  return state.windows[windowId]?.panels[panelId] ?? null;
+}
+
+export async function updateTerminalPanelCwd(
+  windowId: string,
+  panelId: string,
+  cwd: string
+): Promise<void> {
+  if (!(isNonEmptyId(windowId) && isNonEmptyId(panelId))) {
+    return;
+  }
+  if (!isRestorableCwd(cwd)) {
+    return;
+  }
+  const state = await readState();
+  const windowState = state.windows[windowId] ?? { panels: {} };
+  state.windows[windowId] = windowState;
+  windowState.panels[panelId] = {
+    cwd,
+    updatedAt: new Date().toISOString(),
+  };
+  await writeState(state);
+}
+
+export async function removeTerminalPanelSession(
+  windowId: string,
+  panelId: string
+): Promise<void> {
+  if (!(isNonEmptyId(windowId) && isNonEmptyId(panelId))) {
+    return;
+  }
+  const state = await readState();
+  const windowState = state.windows[windowId];
+  if (!windowState?.panels[panelId]) {
+    return;
+  }
+  delete windowState.panels[panelId];
+  if (Object.keys(windowState.panels).length === 0) {
+    delete state.windows[windowId];
+  }
+  await writeState(state);
+}

--- a/src/main/windows/window-identity.ts
+++ b/src/main/windows/window-identity.ts
@@ -1,0 +1,18 @@
+import type { BrowserWindow } from "electron";
+
+const browserWindowIds = new WeakMap<BrowserWindow, string>();
+
+export function rememberBrowserWindowId(
+  window: BrowserWindow,
+  id: string
+): void {
+  browserWindowIds.set(window, id);
+}
+
+export function forgetBrowserWindowId(window: BrowserWindow): void {
+  browserWindowIds.delete(window);
+}
+
+export function findBrowserWindowId(window: BrowserWindow): string | null {
+  return browserWindowIds.get(window) ?? null;
+}

--- a/src/main/windows/window-manager.ts
+++ b/src/main/windows/window-manager.ts
@@ -21,6 +21,11 @@ import {
   restoreActivePanelFocus,
 } from "../ipc/terminal.ts";
 import { WindowIdAllocator } from "./window-id-allocator.ts";
+import {
+  findBrowserWindowId,
+  forgetBrowserWindowId,
+  rememberBrowserWindowId,
+} from "./window-identity.ts";
 
 const WINDOW_ID_REGEX = /^(main|w-\d+)$/;
 
@@ -121,6 +126,7 @@ class WindowManager {
     }
 
     const window = new BrowserWindow(winOpts);
+    rememberBrowserWindowId(window, id);
 
     window.on("ready-to-show", () => window.show());
     window.on("blur", () => {
@@ -209,6 +215,7 @@ class WindowManager {
       for (const cb of this.onCloseCallbacks) {
         cb(id);
       }
+      forgetBrowserWindowId(window);
       this.windows.delete(id);
       this.allocator.release(id);
     });
@@ -262,12 +269,7 @@ class WindowManager {
 
   /** 通过 BrowserWindow 实例反查内部 string id. */
   findInternalIdByBrowserWindow(bw: BrowserWindow): string | null {
-    for (const [id, w] of this.windows) {
-      if (w === bw) {
-        return id;
-      }
-    }
-    return null;
+    return findBrowserWindowId(bw);
   }
 }
 

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -43,12 +43,9 @@ async function bootstrap() {
   const rootEl = document.getElementById("root");
   if (rootEl) {
     // 不包 StrictMode:Pier 终端 panel 是 web React tree + Ghostty native NSView
-    // 协同, useEffect cleanup 调 terminal.close IPC 销毁 NSView. StrictMode 在
-    // dev 模式让组件双 mount/unmount, 会产生 close 多于 create 的孤儿调用,
-    // 把 reload 后复用的 NSView 真销毁, 反而引入 dev-only 视觉/PTY 状态丢失.
-    // 生产 build 没 StrictMode, C 方案的 createTerminal 复用 + reconcile 已经
-    // 让 reload 零闪 + PTY 跨 reload 保留;关掉 dev StrictMode 让两个环境行为
-    // 一致, 不影响其它 dev 检查能力 (Pier 没有依赖 StrictMode 暴露的具体反例).
+    // 协同, native terminal session 生命周期由 workspace 显式 close/reconcile
+    // 管理. dev StrictMode 的诊断性 remount 对 native surface 没有业务含义,
+    // 这里保持 dev/prod 行为一致, 避免给 reload 复用路径引入额外扰动.
     createRoot(rootEl).render(<App />);
   }
 }

--- a/src/renderer/panel-kits/terminal/terminal-panel.tsx
+++ b/src/renderer/panel-kits/terminal/terminal-panel.tsx
@@ -210,7 +210,6 @@ export function TerminalPanel(props: IDockviewPanelProps) {
       for (const s of subscriptions) {
         s.dispose();
       }
-      window.pier.terminal.close(panelId);
     };
   }, [api, panelId]);
 

--- a/src/renderer/stores/workspace.store.ts
+++ b/src/renderer/stores/workspace.store.ts
@@ -104,10 +104,9 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       });
       return;
     }
-    // 主动先发 native terminal close IPC, 再 removePanel — 不依赖 React unmount
-    // 时序. dockview removePanel 会同步 dispose React tree, useEffect cleanup 也会
-    // 调 terminal.close (idempotent, swift close 二次调用 no-op), 这里只是确保
-    // close IPC 一定先于 dockview 内部 panel state 销毁 fire.
+    // 主动先发 native terminal close IPC, 再 removePanel — native session 生命周期
+    // 只绑定显式 workspace close 操作, 不绑定 React unmount. 这样 Electron reload
+    // 卸载 renderer tree 时不会误杀可复用的 Ghostty surface / PTY.
     //
     // 用 panel.view.contentComponent 而非 panel.params?.component:
     // contentComponent 是 dockview 注册组件的 stable readonly string (panel-registry

--- a/src/shared/contracts/terminal.ts
+++ b/src/shared/contracts/terminal.ts
@@ -16,6 +16,7 @@ export interface TerminalFont {
 }
 
 export interface CreateTerminalArgs {
+  cwd?: string | undefined;
   font: TerminalFont;
   frame: TerminalFrame;
   panelId: string;

--- a/tests/component/terminal-panel-lifecycle.test.tsx
+++ b/tests/component/terminal-panel-lifecycle.test.tsx
@@ -1,0 +1,95 @@
+import { render, waitFor } from "@testing-library/react";
+import type { IDockviewPanelProps } from "dockview-react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TerminalPanel } from "@/panel-kits/terminal/terminal-panel.tsx";
+
+class TestResizeObserver {
+  observe() {
+    // Test no-op.
+  }
+  disconnect() {
+    // Test no-op.
+  }
+}
+
+function createPanelProps(): IDockviewPanelProps {
+  return {
+    api: {
+      id: "terminal-1",
+      onDidActiveChange: vi.fn(() => ({ dispose: vi.fn() })),
+      onDidVisibilityChange: vi.fn(() => ({ dispose: vi.fn() })),
+      setTitle: vi.fn(),
+    },
+    containerApi: {},
+  } as unknown as IDockviewPanelProps;
+}
+
+describe("TerminalPanel lifecycle", () => {
+  const originalGetBoundingClientRect =
+    HTMLElement.prototype.getBoundingClientRect;
+
+  beforeEach(() => {
+    vi.stubGlobal("ResizeObserver", TestResizeObserver);
+    vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) =>
+      window.setTimeout(() => cb(performance.now()), 0)
+    );
+    vi.stubGlobal("cancelAnimationFrame", (id: number) =>
+      window.clearTimeout(id)
+    );
+
+    HTMLElement.prototype.getBoundingClientRect = function () {
+      if (this.classList.contains("terminal-anchor")) {
+        return {
+          bottom: 320,
+          height: 300,
+          left: 10,
+          right: 410,
+          top: 20,
+          width: 400,
+          x: 10,
+          y: 20,
+          toJSON: () => null,
+        } as DOMRect;
+      }
+      return originalGetBoundingClientRect.call(this);
+    };
+
+    Object.defineProperty(window, "pier", {
+      configurable: true,
+      value: {
+        terminal: {
+          close: vi.fn(),
+          create: vi.fn(async () => ({ ok: true })),
+          focus: vi.fn(),
+          hide: vi.fn(),
+          onContextMenuRequest: vi.fn(() => vi.fn()),
+          onCwdChange: vi.fn(() => vi.fn()),
+          onTitleChange: vi.fn(() => vi.fn()),
+          setFont: vi.fn(),
+          setFrame: vi.fn(),
+          show: vi.fn(),
+        },
+      },
+    });
+  });
+
+  afterEach(() => {
+    HTMLElement.prototype.getBoundingClientRect = originalGetBoundingClientRect;
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("keeps the native terminal alive when React unmounts during renderer reload", async () => {
+    const { unmount } = render(<TerminalPanel {...createPanelProps()} />);
+
+    await waitFor(() => {
+      expect(window.pier.terminal.create).toHaveBeenCalledWith(
+        expect.objectContaining({ panelId: "terminal-1" })
+      );
+    });
+
+    unmount();
+
+    expect(window.pier.terminal.close).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/main/terminal-focus.test.ts
+++ b/tests/unit/main/terminal-focus.test.ts
@@ -9,12 +9,13 @@ describe("terminal focus restoration", () => {
   async function setupTerminalFocusHarness(
     opts: { ipcWindowFocused?: boolean } = {}
   ) {
+    const invokeHandlers = new Map<string, (...args: unknown[]) => unknown>();
     const handlers = new Map<string, (...args: unknown[]) => unknown>();
     const fakeAddon = {
       applyTerminalTheme: vi.fn(),
       closeAllTerminals: vi.fn(),
       closeTerminal: vi.fn(),
-      createTerminal: vi.fn(),
+      createTerminal: vi.fn(() => true),
       detachWindow: vi.fn(),
       focusTerminal: vi.fn(),
       hideTerminal: vi.fn(),
@@ -48,7 +49,11 @@ describe("terminal focus restoration", () => {
     const ipcWindow = createFakeWindow(opts.ipcWindowFocused ?? true);
     const restoreWindow = createFakeWindow();
     const fakeIpcMain = {
-      handle: vi.fn(),
+      handle: vi.fn(
+        (channel: string, handler: (...args: unknown[]) => unknown) => {
+          invokeHandlers.set(channel, handler);
+        }
+      ),
       on: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
         handlers.set(channel, handler);
       }),
@@ -66,6 +71,16 @@ describe("terminal focus restoration", () => {
         createRequire: vi.fn(() => vi.fn(() => fakeAddon)),
       },
     }));
+    vi.doMock("@main/state/terminal-session-state.ts", () => ({
+      readTerminalPanelSession: vi.fn(async () => ({
+        cwd: "/Users/xyz/ABC/pier",
+        updatedAt: "2026-06-24T00:00:00.000Z",
+      })),
+      updateTerminalPanelCwd: vi.fn(async () => undefined),
+    }));
+    vi.doMock("@main/windows/window-identity.ts", () => ({
+      findBrowserWindowId: vi.fn(() => "main"),
+    }));
 
     const { registerTerminalIpc, restoreActivePanelFocus } = await import(
       "@main/ipc/terminal.ts"
@@ -75,6 +90,7 @@ describe("terminal focus restoration", () => {
     return {
       fakeAddon,
       handlers,
+      invokeHandlers,
       ipcWindow,
       restoreActivePanelFocus,
       restoreWindow,
@@ -156,6 +172,30 @@ describe("terminal focus restoration", () => {
     expect(ipcWindow.webContents.send).toHaveBeenCalledWith(
       "pier:terminal:focus-request",
       { panelId: "panel-2" }
+    );
+  });
+
+  it("passes the saved cwd when creating a new native terminal", async () => {
+    const { fakeAddon, invokeHandlers, ipcWindow } =
+      await setupTerminalFocusHarness();
+
+    const result = await invokeHandlers.get("pier:terminal:create")?.(
+      { sender: ipcWindow.webContents },
+      {
+        font: { family: "Menlo", size: 13 },
+        frame: { x: 1, y: 2, width: 300, height: 200 },
+        panelId: "terminal-1",
+      }
+    );
+
+    expect(result).toEqual({ ok: true });
+    expect(fakeAddon.createTerminal).toHaveBeenCalledWith(
+      Buffer.from("window"),
+      "terminal-1",
+      { x: 1, y: 2, width: 300, height: 200 },
+      "Menlo",
+      13,
+      "/Users/xyz/ABC/pier"
     );
   });
 

--- a/tests/unit/main/terminal-session-state.test.ts
+++ b/tests/unit/main/terminal-session-state.test.ts
@@ -1,0 +1,59 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("terminal session state", () => {
+  let userDataDir: string;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    userDataDir = await mkdtemp(join(tmpdir(), "pier-terminal-session-"));
+    vi.doMock("electron", () => ({
+      app: {
+        getPath: vi.fn((name: string) => {
+          if (name !== "userData") {
+            throw new Error(`unexpected app path: ${name}`);
+          }
+          return userDataDir;
+        }),
+      },
+    }));
+  });
+
+  afterEach(async () => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+    await rm(userDataDir, { force: true, recursive: true });
+  });
+
+  it("persists and reads the last cwd by window and panel", async () => {
+    const { readTerminalPanelSession, updateTerminalPanelCwd } = await import(
+      "@main/state/terminal-session-state.ts"
+    );
+
+    await updateTerminalPanelCwd("main", "terminal-1", "/Users/xyz/ABC/pier");
+
+    await expect(
+      readTerminalPanelSession("main", "terminal-1")
+    ).resolves.toMatchObject({
+      cwd: "/Users/xyz/ABC/pier",
+    });
+    await expect(
+      readTerminalPanelSession("w-2", "terminal-1")
+    ).resolves.toBeNull();
+  });
+
+  it("ignores blank and relative cwd updates", async () => {
+    const { readTerminalPanelSession, updateTerminalPanelCwd } = await import(
+      "@main/state/terminal-session-state.ts"
+    );
+
+    await updateTerminalPanelCwd("main", "terminal-1", "");
+    await updateTerminalPanelCwd("main", "terminal-1", "relative/path");
+
+    await expect(
+      readTerminalPanelSession("main", "terminal-1")
+    ).resolves.toBeNull();
+  });
+});

--- a/tests/unit/renderer/stores/workspace-store-terminal-close.test.ts
+++ b/tests/unit/renderer/stores/workspace-store-terminal-close.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useWorkspaceStore } from "@/stores/workspace.store.ts";
+
+function terminalPanel(id: string) {
+  return {
+    id,
+    title: "Terminal",
+    view: { contentComponent: "terminal" },
+  };
+}
+
+describe("workspace terminal close lifecycle", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    Object.defineProperty(window, "pier", {
+      configurable: true,
+      value: {
+        terminal: { close: vi.fn() },
+      },
+    });
+    useWorkspaceStore.getState().setApi(null);
+  });
+
+  it("closes the native terminal when a terminal panel is explicitly closed", () => {
+    const panel = terminalPanel("terminal-1");
+    const api = {
+      activePanel: panel,
+      panels: [panel, { ...terminalPanel("terminal-2"), id: "welcome-1" }],
+      removePanel: vi.fn(),
+      totalPanels: 2,
+    };
+
+    useWorkspaceStore.getState().setApi(api as never);
+
+    useWorkspaceStore.getState().closePanel("terminal-1");
+
+    expect(window.pier.terminal.close).toHaveBeenCalledWith("terminal-1");
+    expect(api.removePanel).toHaveBeenCalledWith(panel);
+  });
+});


### PR DESCRIPTION
## Summary
- Persist the last valid terminal `cwd` per stable window and panel, then reuse it when creating a terminal after reload.
- Pass `cwd` through the native bridge into Ghostty so new shells start in the restored directory.
- Decouple terminal teardown from React unmount and keep cleanup tied to explicit workspace close/reconcile flows.
- Add window identity tracking plus lifecycle tests for reload and cwd restore behavior.

## Testing
- Added component coverage to verify React unmount during renderer reload does not call native terminal close.
- Added unit coverage to verify terminal creation uses the saved `cwd` when available.
- Not run (not requested)