### PR TITLE
Refine terminal window lifecycle and native chrome integration

### DIFF
--- a/native/Package.swift
+++ b/native/Package.swift
@@ -29,7 +29,10 @@ let package = Package(
         ),
         .testTarget(
             name: "GhosttyBridgeTests",
-            dependencies: ["GhosttyBridge"]
+            dependencies: [
+                "GhosttyBridge",
+                .product(name: "GhosttyTerminal", package: "libghostty-spm"),
+            ]
         ),
     ]
 )

--- a/native/Package.swift
+++ b/native/Package.swift
@@ -27,5 +27,9 @@ let package = Package(
                 .unsafeFlags(["-Xfrontend", "-enable-objc-interop"]),
             ]
         ),
+        .testTarget(
+            name: "GhosttyBridgeTests",
+            dependencies: ["GhosttyBridge"]
+        ),
     ]
 )

--- a/native/Sources/GhosttyBridge/GhosttyBridge.swift
+++ b/native/Sources/GhosttyBridge/GhosttyBridge.swift
@@ -340,7 +340,7 @@ final class TerminalEventDelegate: TerminalSurfacePwdDelegate,
 // MARK: - Terminal record
 
 private struct Terminal {
-    let containerView: NSView
+    let containerView: TerminalContainerView
     let terminalView: TerminalView
     let parentWindow: NSWindow
     /// EventDelegate adapter (strong-hold — terminalView.delegate 是 weak).
@@ -378,9 +378,32 @@ struct TerminalLiveResizePredictor {
     }
 }
 
-private struct TerminalLayoutSnapshot {
-    let contentSize: NSSize
-    let nativeFrame: NSRect
+struct TerminalLayoutState {
+    private(set) var authoritativeContentSize: NSSize
+    private(set) var authoritativeFrame: NSRect
+    private(set) var presentedFrame: NSRect
+
+    init(authoritativeContentSize: NSSize, authoritativeFrame: NSRect) {
+        self.authoritativeContentSize = authoritativeContentSize
+        self.authoritativeFrame = authoritativeFrame
+        self.presentedFrame = authoritativeFrame
+    }
+
+    mutating func predictProvisionalFrame(newContentSize: NSSize) -> NSRect {
+        let frame = TerminalLiveResizePredictor.predict(
+            lastFrame: authoritativeFrame,
+            oldContentSize: authoritativeContentSize,
+            newContentSize: newContentSize
+        )
+        presentedFrame = frame
+        return frame
+    }
+
+    mutating func rememberAuthoritativeLayout(contentSize: NSSize, frame: NSRect) {
+        authoritativeContentSize = contentSize
+        authoritativeFrame = frame
+        presentedFrame = frame
+    }
 }
 
 // MARK: - Bridge implementation
@@ -397,7 +420,7 @@ final class GhosttyBridgeImpl {
     private var eventRouters: [ObjectIdentifier: EventRouterView] = [:]  // per-window
     private var terminalBackgrounds: [ObjectIdentifier: NSColor] = [:]
     private var terminalForegrounds: [ObjectIdentifier: NSColor] = [:]
-    private var terminalLayouts: [String: TerminalLayoutSnapshot] = [:]
+    private var terminalLayouts: [String: TerminalLayoutState] = [:]
     private var liveResizeContentSizes: [ObjectIdentifier: NSSize] = [:]
     private var liveResizeObservers: [ObjectIdentifier: NSObjectProtocol] = [:]
     /// per-window TerminalController. window close 时通过 detachWindow 释放 — 避免
@@ -458,9 +481,17 @@ final class GhosttyBridgeImpl {
         contentView: NSView,
         nativeFrame: NSRect
     ) {
-        terminalLayouts[panelId] = TerminalLayoutSnapshot(
-            contentSize: contentView.bounds.size,
-            nativeFrame: nativeFrame
+        if var existing = terminalLayouts[panelId] {
+            existing.rememberAuthoritativeLayout(
+                contentSize: contentView.bounds.size,
+                frame: nativeFrame
+            )
+            terminalLayouts[panelId] = existing
+            return
+        }
+        terminalLayouts[panelId] = TerminalLayoutState(
+            authoritativeContentSize: contentView.bounds.size,
+            authoritativeFrame: nativeFrame
         )
     }
 
@@ -491,16 +522,10 @@ final class GhosttyBridgeImpl {
         liveResizeContentSizes[windowId] = newSize
 
         for (panelId, term) in terminals where term.parentWindow === parent {
-            guard let snapshot = terminalLayouts[panelId] else { continue }
-            let frame = TerminalLiveResizePredictor.predict(
-                lastFrame: snapshot.nativeFrame,
-                oldContentSize: oldSize,
-                newContentSize: newSize
-            )
-            CATransaction.begin()
-            CATransaction.setDisableActions(true)
-            term.containerView.frame = frame
-            CATransaction.commit()
+            guard var state = terminalLayouts[panelId] else { continue }
+            let frame = state.predictProvisionalFrame(newContentSize: newSize)
+            terminalLayouts[panelId] = state
+            term.containerView.applyHostFrame(frame)
 
             eventRouters[windowId]?.targets[panelId] = EventRouterView.Target(
                 rect: Self.terminalTargetRect(for: frame),
@@ -737,10 +762,7 @@ final class GhosttyBridgeImpl {
         if let existing = terminals[panelId] {
             if existing.parentWindow === parent {
                 let frame = computeFrame(in: contentView, viewport: viewport)
-                CATransaction.begin()
-                CATransaction.setDisableActions(true)
-                existing.containerView.frame = frame
-                CATransaction.commit()
+                existing.containerView.applyHostFrame(frame)
                 rememberLayout(
                     panelId: panelId,
                     contentView: contentView,
@@ -813,6 +835,7 @@ final class GhosttyBridgeImpl {
         // 正确: .below relativeTo nil → 插入 subviews[0], 在 ViewsCompositorSuperview
         //   之下 (visually 最底), web 层可叠加在 terminal 之上.
         contentView.addSubview(container, positioned: .below, relativeTo: nil)
+        container.applyHostFrame(frame)
 
         terminals[panelId] = Terminal(
             containerView: container,
@@ -851,10 +874,7 @@ final class GhosttyBridgeImpl {
         guard let term = terminals[panelId],
               let contentView = term.parentWindow.contentView else { return }
         let frame = computeFrame(in: contentView, viewport: viewport)
-        CATransaction.begin()
-        CATransaction.setDisableActions(true)
-        term.containerView.frame = frame
-        CATransaction.commit()
+        term.containerView.applyHostFrame(frame)
         rememberLayout(
             panelId: panelId,
             contentView: contentView,
@@ -873,12 +893,16 @@ final class GhosttyBridgeImpl {
         guard let term = terminals[panelId] else { return }
         activePanelId = panelId
 
-        CATransaction.begin()
-        CATransaction.setDisableActions(true)
         if let contentView = term.parentWindow.contentView {
             // 确保终端在所有 web 渲染层之下 (见 createTerminal 注释)
             contentView.addSubview(term.containerView, positioned: .below, relativeTo: nil)
         }
+
+        let frame = terminalLayouts[panelId]?.presentedFrame ?? term.containerView.frame
+        term.containerView.applyHostFrame(frame)
+
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
         term.containerView.alphaValue = 1
         term.containerView.isHidden = false
         CATransaction.commit()
@@ -1030,18 +1054,14 @@ final class GhosttyBridgeImpl {
             let windowId = ObjectIdentifier(window)
             terminalBackgrounds[windowId] = backgroundColor
             for term in terminals.values where term.parentWindow === window {
-                if let container = term.containerView as? TerminalContainerView {
-                    container.backgroundColor = backgroundColor
-                }
+                term.containerView.backgroundColor = backgroundColor
             }
         }
         if let foregroundColor = Self.terminalColor(from: foreground) {
             let windowId = ObjectIdentifier(window)
             terminalForegrounds[windowId] = foregroundColor
             for term in terminals.values where term.parentWindow === window {
-                if let container = term.containerView as? TerminalContainerView {
-                    container.scrollbarColor = foregroundColor
-                }
+                term.containerView.scrollbarColor = foregroundColor
             }
         }
     }

--- a/native/Sources/GhosttyBridge/GhosttyBridge.swift
+++ b/native/Sources/GhosttyBridge/GhosttyBridge.swift
@@ -349,6 +349,40 @@ private struct Terminal {
     let eventDelegate: TerminalEventDelegate
 }
 
+struct TerminalLiveResizePredictor {
+    private static let edgeTolerance: CGFloat = 1
+    private static let edgeBleed: CGFloat = 2
+
+    static func predict(
+        lastFrame: NSRect,
+        oldContentSize: NSSize,
+        newContentSize: NSSize
+    ) -> NSRect {
+        let deltaWidth = newContentSize.width - oldContentSize.width
+        let deltaHeight = newContentSize.height - oldContentSize.height
+        let touchesRight = abs(lastFrame.maxX - oldContentSize.width) <= edgeTolerance
+        let touchesBottom = lastFrame.minY <= edgeTolerance
+        let touchesTop = abs(lastFrame.maxY - oldContentSize.height) <= edgeTolerance
+
+        var next = lastFrame
+        if touchesRight {
+            next.size.width = max(lastFrame.width + deltaWidth + edgeBleed, 0)
+        }
+        if touchesBottom {
+            next.origin.y = -edgeBleed
+            next.size.height = max(lastFrame.height + deltaHeight + edgeBleed, 0)
+        } else if touchesTop {
+            next.origin.y = lastFrame.minY + deltaHeight
+        }
+        return next
+    }
+}
+
+private struct TerminalLayoutSnapshot {
+    let contentSize: NSSize
+    let nativeFrame: NSRect
+}
+
 // MARK: - Bridge implementation
 
 @MainActor
@@ -363,6 +397,9 @@ final class GhosttyBridgeImpl {
     private var eventRouters: [ObjectIdentifier: EventRouterView] = [:]  // per-window
     private var terminalBackgrounds: [ObjectIdentifier: NSColor] = [:]
     private var terminalForegrounds: [ObjectIdentifier: NSColor] = [:]
+    private var terminalLayouts: [String: TerminalLayoutSnapshot] = [:]
+    private var liveResizeContentSizes: [ObjectIdentifier: NSSize] = [:]
+    private var liveResizeObservers: [ObjectIdentifier: NSObjectProtocol] = [:]
     /// per-window TerminalController. window close 时通过 detachWindow 释放 — 避免
     /// 旧 controller 内 session/PTY 列表跨 window 累积 (singleton 不会随 window
     /// 销毁而清理).
@@ -414,6 +451,62 @@ final class GhosttyBridgeImpl {
         }
         controllers[windowId] = c
         return c
+    }
+
+    private func rememberLayout(
+        panelId: String,
+        contentView: NSView,
+        nativeFrame: NSRect
+    ) {
+        terminalLayouts[panelId] = TerminalLayoutSnapshot(
+            contentSize: contentView.bounds.size,
+            nativeFrame: nativeFrame
+        )
+    }
+
+    private func installLiveResizeObserver(parent: NSWindow, contentView: NSView) {
+        let windowId = ObjectIdentifier(parent)
+        guard liveResizeObservers[windowId] == nil else { return }
+        contentView.postsBoundsChangedNotifications = true
+        liveResizeContentSizes[windowId] = contentView.bounds.size
+        let token = NotificationCenter.default.addObserver(
+            forName: NSView.boundsDidChangeNotification,
+            object: contentView,
+            queue: .main
+        ) { [weak parent] _ in
+            guard let parent else { return }
+            Task { @MainActor in
+                GhosttyBridgeImpl.shared.handleContentViewLiveResize(parent: parent)
+            }
+        }
+        liveResizeObservers[windowId] = token
+    }
+
+    private func handleContentViewLiveResize(parent: NSWindow) {
+        guard let contentView = parent.contentView else { return }
+        let windowId = ObjectIdentifier(parent)
+        let oldSize = liveResizeContentSizes[windowId] ?? contentView.bounds.size
+        let newSize = contentView.bounds.size
+        guard oldSize != newSize else { return }
+        liveResizeContentSizes[windowId] = newSize
+
+        for (panelId, term) in terminals where term.parentWindow === parent {
+            guard let snapshot = terminalLayouts[panelId] else { continue }
+            let frame = TerminalLiveResizePredictor.predict(
+                lastFrame: snapshot.nativeFrame,
+                oldContentSize: oldSize,
+                newContentSize: newSize
+            )
+            CATransaction.begin()
+            CATransaction.setDisableActions(true)
+            term.containerView.frame = frame
+            CATransaction.commit()
+
+            eventRouters[windowId]?.targets[panelId] = EventRouterView.Target(
+                rect: Self.terminalTargetRect(for: frame),
+                view: term.containerView
+            )
+        }
     }
 
     nonisolated static func configureDefaultTerminalAppearance(
@@ -505,6 +598,7 @@ final class GhosttyBridgeImpl {
         contentView.addSubview(router, positioned: .above, relativeTo: nil)
         router.attachInputRouting(window: parent, browserWindowId: browserWindowId)
         eventRouters[windowId] = router
+        installLiveResizeObserver(parent: parent, contentView: contentView)
 
         // 初始化 per-window keyboard state (PanelKind 默认 .web — 安全, 不抢 firstResponder)
         windowStates[windowId] = WindowKeyboardState()
@@ -647,6 +741,11 @@ final class GhosttyBridgeImpl {
                 CATransaction.setDisableActions(true)
                 existing.containerView.frame = frame
                 CATransaction.commit()
+                rememberLayout(
+                    panelId: panelId,
+                    contentView: contentView,
+                    nativeFrame: frame
+                )
 
                 applyFontToController(parent: parent, family: fontFamily, size: fontSize)
 
@@ -721,6 +820,11 @@ final class GhosttyBridgeImpl {
             parentWindow: parent,
             eventDelegate: eventDelegate
         )
+        rememberLayout(
+            panelId: panelId,
+            contentView: contentView,
+            nativeFrame: frame
+        )
 
         // 更新 EventRouter targets (inset 留出 sash 事件通道)
         let windowId = ObjectIdentifier(parent)
@@ -751,6 +855,11 @@ final class GhosttyBridgeImpl {
         CATransaction.setDisableActions(true)
         term.containerView.frame = frame
         CATransaction.commit()
+        rememberLayout(
+            panelId: panelId,
+            contentView: contentView,
+            nativeFrame: frame
+        )
 
         // 同步 EventRouter targets (inset 留出 sash 事件通道)
         let windowId = ObjectIdentifier(term.parentWindow)
@@ -852,6 +961,7 @@ final class GhosttyBridgeImpl {
         for (panelId, term) in toClose {
             term.containerView.removeFromSuperview()
             terminals.removeValue(forKey: panelId)
+            terminalLayouts.removeValue(forKey: panelId)
         }
         if let activeId = activePanelId, terminals[activeId] == nil {
             activePanelId = nil
@@ -874,6 +984,10 @@ final class GhosttyBridgeImpl {
             router.removeFromSuperview()
             eventRouters.removeValue(forKey: windowId)
         }
+        if let token = liveResizeObservers.removeValue(forKey: windowId) {
+            NotificationCenter.default.removeObserver(token)
+        }
+        liveResizeContentSizes.removeValue(forKey: windowId)
         // 释放该 window 的 TerminalController — 内部 session/PTY 列表跨 window 累积
         // 是潜在内存泄漏, swift ARC 让无引用 controller 自动 dealloc.
         controllers.removeValue(forKey: windowId)

--- a/native/Sources/GhosttyBridge/TerminalScrollContainer.swift
+++ b/native/Sources/GhosttyBridge/TerminalScrollContainer.swift
@@ -108,6 +108,19 @@ final class TerminalContainerView: NSView, TerminalScrollbarStateSink {
 
     override func layout() {
         super.layout()
+        synchronizeChildFrames()
+    }
+
+    func applyHostFrame(_ hostFrame: NSRect) {
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        frame = hostFrame
+        synchronizeChildFrames()
+        terminalView.flushHostResizeFrame()
+        CATransaction.commit()
+    }
+
+    private func synchronizeChildFrames() {
         let frames = TerminalContainerLayout.frames(in: bounds)
         terminalView.frame = frames.terminal
         scrollbarView.frame = frames.scrollbar

--- a/native/Tests/GhosttyBridgeTests/TerminalHostResizeTests.swift
+++ b/native/Tests/GhosttyBridgeTests/TerminalHostResizeTests.swift
@@ -1,0 +1,33 @@
+import AppKit
+@testable import GhosttyBridge
+import GhosttyTerminal
+import XCTest
+
+@MainActor
+final class TerminalHostResizeTests: XCTestCase {
+    func testFlushHostResizeFrameIsSafeWithoutAttachedSurface() {
+        let terminalView = TerminalView(frame: NSRect(x: 0, y: 0, width: 320, height: 200))
+
+        XCTAssertNoThrow(terminalView.flushHostResizeFrame())
+    }
+
+    func testApplyHostFrameSynchronizesContainerAndChildFramesImmediately() {
+        let terminalView = TerminalView(frame: .zero)
+        let container = TerminalContainerView(
+            frame: NSRect(x: 0, y: 0, width: 100, height: 80),
+            terminalView: terminalView,
+            panelId: "terminal-1",
+            browserWindowId: 42
+        )
+
+        let hostFrame = NSRect(x: 12, y: 18, width: 480, height: 320)
+        container.applyHostFrame(hostFrame)
+
+        XCTAssertEqual(container.frame, hostFrame)
+        XCTAssertEqual(terminalView.frame, NSRect(x: 0, y: 0, width: 480, height: 320))
+        XCTAssertEqual(
+            container.subviews[1].frame,
+            NSRect(x: 466, y: 0, width: 14, height: 320)
+        )
+    }
+}

--- a/native/Tests/GhosttyBridgeTests/TerminalLiveResizePredictionTests.swift
+++ b/native/Tests/GhosttyBridgeTests/TerminalLiveResizePredictionTests.swift
@@ -33,4 +33,30 @@ final class TerminalLiveResizePredictionTests: XCTestCase {
 
         XCTAssertEqual(predicted, frame)
     }
+
+    func testLiveResizePredictionDoesNotAdvanceAuthoritativeLayout() {
+        var state = TerminalLayoutState(
+            authoritativeContentSize: NSSize(width: 800, height: 600),
+            authoritativeFrame: NSRect(x: 500, y: 0, width: 300, height: 600)
+        )
+
+        let predicted = state.predictProvisionalFrame(
+            newContentSize: NSSize(width: 900, height: 700)
+        )
+
+        XCTAssertEqual(predicted, NSRect(x: 500, y: -2, width: 402, height: 702))
+        XCTAssertEqual(state.authoritativeContentSize, NSSize(width: 800, height: 600))
+        XCTAssertEqual(state.authoritativeFrame, NSRect(x: 500, y: 0, width: 300, height: 600))
+        XCTAssertEqual(state.presentedFrame, predicted)
+
+        let finalFrame = NSRect(x: 500, y: 0, width: 400, height: 700)
+        state.rememberAuthoritativeLayout(
+            contentSize: NSSize(width: 900, height: 700),
+            frame: finalFrame
+        )
+
+        XCTAssertEqual(state.authoritativeContentSize, NSSize(width: 900, height: 700))
+        XCTAssertEqual(state.authoritativeFrame, finalFrame)
+        XCTAssertEqual(state.presentedFrame, finalFrame)
+    }
 }

--- a/native/Tests/GhosttyBridgeTests/TerminalLiveResizePredictionTests.swift
+++ b/native/Tests/GhosttyBridgeTests/TerminalLiveResizePredictionTests.swift
@@ -1,0 +1,36 @@
+import AppKit
+@testable import GhosttyBridge
+import XCTest
+
+final class TerminalLiveResizePredictionTests: XCTestCase {
+    func testExpandsRightAndBottomEdgesWithBleed() {
+        let predicted = TerminalLiveResizePredictor.predict(
+            lastFrame: NSRect(x: 500, y: 0, width: 300, height: 600),
+            oldContentSize: NSSize(width: 800, height: 600),
+            newContentSize: NSSize(width: 900, height: 700)
+        )
+
+        XCTAssertEqual(predicted, NSRect(x: 500, y: -2, width: 402, height: 702))
+    }
+
+    func testKeepsTopAnchoredPanelsAgainstTheTopEdge() {
+        let predicted = TerminalLiveResizePredictor.predict(
+            lastFrame: NSRect(x: 0, y: 300, width: 400, height: 300),
+            oldContentSize: NSSize(width: 800, height: 600),
+            newContentSize: NSSize(width: 800, height: 700)
+        )
+
+        XCTAssertEqual(predicted, NSRect(x: 0, y: 400, width: 400, height: 300))
+    }
+
+    func testLeavesInteriorPanelsUntouched() {
+        let frame = NSRect(x: 100, y: 100, width: 300, height: 200)
+        let predicted = TerminalLiveResizePredictor.predict(
+            lastFrame: frame,
+            oldContentSize: NSSize(width: 800, height: 600),
+            newContentSize: NSSize(width: 900, height: 700)
+        )
+
+        XCTAssertEqual(predicted, frame)
+    }
+}

--- a/native/Vendor/libghostty-spm/Sources/GhosttyTerminal/Platform/AppKit/AppTerminalView+Lifecycle.swift
+++ b/native/Vendor/libghostty-spm/Sources/GhosttyTerminal/Platform/AppKit/AppTerminalView+Lifecycle.swift
@@ -168,6 +168,11 @@
             core.fitToSize()
         }
 
+        public func flushHostResizeFrame() {
+            updateMetalLayerMetrics()
+            core.resizeAndRenderSynchronously()
+        }
+
         func updateMetalLayerMetrics() {
             guard bounds.width > 0, bounds.height > 0 else { return }
             let scale = core.scaleFactor()

--- a/native/Vendor/libghostty-spm/Sources/GhosttyTerminal/Surface/TerminalSurfaceCoordinator.swift
+++ b/native/Vendor/libghostty-spm/Sources/GhosttyTerminal/Surface/TerminalSurfaceCoordinator.swift
@@ -227,6 +227,11 @@ final class TerminalSurfaceCoordinator {
         }
     }
 
+    func resizeAndRenderSynchronously() {
+        synchronizeMetrics()
+        renderImmediately()
+    }
+
     func setDisplayVisible(_ visible: Bool) {
         guard isDisplayVisible != visible else {
             surface?.setOcclusion(effectiveSurfaceVisible)

--- a/src/main/app-core/app-core.ts
+++ b/src/main/app-core/app-core.ts
@@ -1,11 +1,12 @@
 import type { MruState } from "@shared/contracts/command-palette-mru.ts";
 import { RENDERER_COMMAND_CHANNEL } from "@shared/contracts/renderer-command-channels.ts";
-import { app, BrowserWindow } from "electron";
+import { app } from "electron";
 import { createCommandPaletteMruService } from "../services/command-palette-service.ts";
 import { createPreferencesService } from "../services/preferences-service.ts";
 import { createRendererCommandService } from "../services/renderer-command-service.ts";
 import { createWindowService } from "../services/window-service.ts";
 import { createWorkspaceService } from "../services/workspace-service.ts";
+import type { AppWindow } from "../windows/app-window.ts";
 import { windowManager } from "../windows/window-manager.ts";
 import {
   createClientRegistry,
@@ -26,14 +27,14 @@ export interface PierAppCore {
 }
 
 function broadcastMruState(state: MruState): void {
-  for (const win of BrowserWindow.getAllWindows()) {
+  for (const win of windowManager.getAll()) {
     if (!win.isDestroyed()) {
       win.webContents.send("pier:command-palette-mru:changed", state);
     }
   }
 }
 
-function focusRendererTarget(win: BrowserWindow): void {
+function focusRendererTarget(win: AppWindow): void {
   if (win.isMinimized()) {
     win.restore();
   }
@@ -61,7 +62,7 @@ function sendRendererCommand(
     return true;
   }
   const focused =
-    BrowserWindow.getFocusedWindow() ??
+    windowManager.getFocused() ??
     windowManager.getAll().find((win) => !win.isDestroyed()) ??
     null;
   if (!focused || focused.isDestroyed()) {

--- a/src/main/devtools.ts
+++ b/src/main/devtools.ts
@@ -1,8 +1,8 @@
 import {
   app,
-  type BrowserWindow,
   type Input,
   type MenuItemConstructorOptions,
+  type WebContents,
 } from "electron";
 
 export const DETACHED_DEVTOOLS_ACCELERATOR = "CommandOrControl+Alt+I";
@@ -12,18 +12,18 @@ const NS_FLAG_CONTROL = 0x4_00_00;
 const NS_FLAG_OPTION = 0x8_00_00;
 const NS_FLAG_COMMAND = 0x10_00_00;
 
+type DevToolsWebContentsLike = Pick<
+  WebContents,
+  "closeDevTools" | "isDestroyed" | "isDevToolsOpened" | "on" | "openDevTools"
+>;
+
 interface DevToolsWindowLike {
-  isDestroyed?: () => boolean;
-  webContents: {
-    closeDevTools: () => void;
-    isDestroyed: () => boolean;
-    isDevToolsOpened: () => boolean;
-    openDevTools: (options: {
-      activate: boolean;
-      mode: "detach";
-      title: string;
-    }) => void;
-  };
+  focus: () => void;
+  isDestroyed: () => boolean;
+  isMinimized: () => boolean;
+  moveTop: () => void;
+  restore: () => void;
+  webContents: DevToolsWebContentsLike;
 }
 
 function hasFlag(flags: number, flag: number): boolean {
@@ -67,7 +67,7 @@ export function isToggleDevToolsNativeChord(
 }
 
 export function toggleDetachedDevTools(win: DevToolsWindowLike): void {
-  if (win.isDestroyed?.() === true || win.webContents.isDestroyed()) {
+  if (win.isDestroyed() || win.webContents.isDestroyed()) {
     return;
   }
 
@@ -99,7 +99,7 @@ export function createDetachedDevToolsMenuItem(
 }
 
 export function installDetachedDevToolsHandlers(
-  win: BrowserWindow,
+  win: DevToolsWindowLike,
   restoreFocus: () => void
 ): void {
   win.webContents.on("before-input-event", (event, input) => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,7 +1,6 @@
 import { join } from "node:path";
 import {
   app,
-  BrowserWindow,
   ipcMain,
   Menu,
   type MenuItemConstructorOptions,
@@ -118,11 +117,7 @@ function buildAppMenu(): Menu {
       { role: "reload" },
       { role: "forceReload" },
       ...(isDev
-        ? [
-            createDetachedDevToolsMenuItem(() =>
-              BrowserWindow.getFocusedWindow()
-            ),
-          ]
+        ? [createDetachedDevToolsMenuItem(() => windowManager.getFocused())]
         : []),
       { type: "separator" },
       { role: "resetZoom" },
@@ -205,7 +200,7 @@ app.whenReady().then(() => {
   windowManager.create({ id: "main" });
 
   app.on("activate", () => {
-    if (BrowserWindow.getAllWindows().length === 0) {
+    if (windowManager.getAll().length === 0) {
       windowManager.create({ id: "main" });
     }
   });
@@ -218,7 +213,9 @@ app.on("window-all-closed", () => {
 });
 
 app.on("before-quit", () => {
+  windowManager.destroyAllForQuit();
   localControl?.close().catch(() => {
     // ignore: app 正在退出
   });
+  localControl = null;
 });

--- a/src/main/ipc/menu.ts
+++ b/src/main/ipc/menu.ts
@@ -1,6 +1,6 @@
 /**
  * pier:menu:popup IPC — renderer 通过 contextBridge 提交 MenuTemplate, main 在
- * BrowserWindow 上弹原生菜单. resolve 返回用户选中的 actionId (action 项) 或 null
+ * app window 上弹原生菜单. resolve 返回用户选中的 actionId (action 项) 或 null
  * (Esc / 点击外部 / role 项).
  *
  * 安全: 任何 schema 不合法的 template 立即 reject, 不调 Menu.popup; role 仅允许
@@ -17,13 +17,14 @@ import type {
   MenuItem as PierMenuItem,
 } from "@shared/contracts/menu.ts";
 import {
-  BrowserWindow,
+  type BaseWindow,
   type IpcMain,
   Menu,
   type MenuItem,
   type MenuItemConstructorOptions,
 } from "electron";
 import { MenuTemplateSchema } from "../menu/template-schema.ts";
+import { windowManager } from "../windows/window-manager.ts";
 
 function toMenuItem(
   item: PierMenuItem,
@@ -73,7 +74,7 @@ export function registerMenuIpc(ipcMain: IpcMain): void {
         return Promise.resolve({ actionId: null });
       }
 
-      const win = BrowserWindow.fromWebContents(event.sender);
+      const win = windowManager.fromWebContents(event.sender);
       if (!win) {
         return Promise.resolve({ actionId: null });
       }
@@ -99,8 +100,8 @@ export function registerMenuIpc(ipcMain: IpcMain): void {
         menu.once("menu-will-close", () => {
           setImmediate(() => resolve({ actionId: pickedId }));
         });
-        const popupOpts: { window: BrowserWindow; x?: number; y?: number } = {
-          window: win,
+        const popupOpts: { window: BaseWindow; x?: number; y?: number } = {
+          window: win.host,
         };
         // 必须 isFinite 否则 NaN/Infinity 通过 typeof 守卫, Math.round(NaN)=NaN 传给
         // Menu.popup 行为未定义 (部分平台让 popup 永不弹出, menu-will-close 不 fire,

--- a/src/main/ipc/preferences.ts
+++ b/src/main/ipc/preferences.ts
@@ -1,6 +1,7 @@
-import { BrowserWindow, type IpcMain } from "electron";
+import type { IpcMain } from "electron";
 import { appCore } from "../app-core/app-core.ts";
 import type { ProjectPreferences } from "../state/preferences.ts";
+import { windowManager } from "../windows/window-manager.ts";
 
 export function registerPreferencesIpc(ipcMain: IpcMain): void {
   ipcMain.handle("pier:preferences:read", async () =>
@@ -16,7 +17,7 @@ export function registerPreferencesIpc(ipcMain: IpcMain): void {
       // locale.store 暂未接 listener — 跨窗口字体/语言切换需要重启目标窗口才
       // 生效. sender 自己已在 setTheme/setStylePreset await 后立即应用, 不走
       // listener 路径避免重复 set.
-      for (const win of BrowserWindow.getAllWindows()) {
+      for (const win of windowManager.getAll()) {
         if (win.webContents.id === event.sender.id) {
           continue;
         }

--- a/src/main/ipc/terminal.ts
+++ b/src/main/ipc/terminal.ts
@@ -5,7 +5,7 @@ import type {
   TerminalFont,
   TerminalFrame,
 } from "@shared/contracts/terminal.ts";
-import { BrowserWindow, type IpcMain } from "electron";
+import type { IpcMain, WebContents } from "electron";
 import {
   isToggleDevToolsNativeChord,
   toggleDetachedDevTools,
@@ -15,7 +15,12 @@ import {
   removeTerminalPanelSession,
   updateTerminalPanelCwd,
 } from "../state/terminal-session-state.ts";
-import { findBrowserWindowId } from "../windows/window-identity.ts";
+import type { AppWindow } from "../windows/app-window.ts";
+import {
+  findAppWindowByElectronId,
+  findAppWindowByWebContents,
+  findInternalWindowId,
+} from "../windows/window-identity.ts";
 import type { NativeAddon } from "./terminal-native-addon.ts";
 
 /** 暴露给 window-manager 在 renderer reload/crash 时调用清理. */
@@ -33,18 +38,18 @@ interface ActivePanelFocusState {
 const activePanelFocusByWindowId = new Map<number, ActivePanelFocusState>();
 
 function rememberActivePanelFocus(
-  win: BrowserWindow,
+  win: AppWindow,
   kind: "terminal" | "web",
   panelId: string | null
 ): void {
   activePanelFocusByWindowId.set(win.id, { kind, panelId });
 }
 
-function stableWindowIdFor(win: BrowserWindow): string {
-  return findBrowserWindowId(win) ?? `browser-${win.id}`;
+function stableWindowIdFor(win: AppWindow): string {
+  return findInternalWindowId(win) ?? `window-${win.id}`;
 }
 
-export function restoreActivePanelFocus(win: BrowserWindow): void {
+export function restoreActivePanelFocus(win: AppWindow): void {
   if (win.isDestroyed()) {
     return;
   }
@@ -68,7 +73,7 @@ export function restoreActivePanelFocus(win: BrowserWindow): void {
   }
 }
 
-export function blurActivePanelFocus(win: BrowserWindow): void {
+export function blurActivePanelFocus(win: AppWindow): void {
   if (win.isDestroyed()) {
     return;
   }
@@ -99,10 +104,10 @@ function loadNativeAddon(): {
 }
 
 /**
- * Forward swift-originated event to a specific BrowserWindow's renderer.
+ * Forward swift-originated event to a specific app window renderer.
  *
  * 所有 swift→main→renderer forward 共用这一条路由 (keyboard / mouse / pwd / title):
- * 1. 按 browserWindowId 精准定位 BrowserWindow — swift NSEvent monitor / delegate
+ * 1. 按 Electron window id 精准定位 app window — swift NSEvent monitor / delegate
  *    跨线程, callback 执行时 focused window 可能已切换, 不能用 getFocusedWindow.
  * 2. 守 isDestroyed (window/webContents 在 swift 触发 → main JS dispatch 间可能销毁).
  * 3. send 抛任何错误 (window 关闭瞬间) 都 catch + log + 继续 — 不影响其他 channel.
@@ -114,7 +119,7 @@ function forwardToWindow<P>(
   errorLabel: string
 ): void {
   try {
-    const targetWindow = BrowserWindow.fromId(browserWindowId);
+    const targetWindow = findAppWindowByElectronId(browserWindowId);
     if (!targetWindow || targetWindow.isDestroyed()) {
       return;
     }
@@ -128,14 +133,18 @@ function forwardToWindow<P>(
   }
 }
 
+function windowFromWebContents(webContents: WebContents): AppWindow | null {
+  return findAppWindowByWebContents(webContents);
+}
+
 export function registerTerminalIpc(ipcMain: IpcMain): void {
   const { addon, error: loadError } = loadNativeAddon();
   cachedAddon = addon;
 
   // 四条 swift → renderer forward channel, 全部走 forwardToWindow helper.
-  // 不能用 BrowserWindow.getFocusedWindow():swift 触发时 (NSEvent monitor / OSC
+  // 不能用 focused window:swift 触发时 (NSEvent monitor / OSC
   // parser delegate) 跨线程, focused window 不一定是事件源 window — 必须用 setupWindow
-  // 时记录的 BrowserWindow.id 精准路由.
+  // 时记录的 Electron window id 精准路由.
   //
   // - keyboard:Cmd+key 全局快捷键 (terminal 透明 + web overlay 架构下唯一可靠通道,
   //   不能依赖 wk.keyDown forward 或 firstResponder chain — Electron 42 ViewsCompositor-
@@ -144,7 +153,7 @@ export function registerTerminalIpc(ipcMain: IpcMain): void {
   // - pwd:OSC 7 → 真实 cwd → descriptor.path / descriptor.short basename.
   // - title:OSC 0/2 → TUI 应用 (claude / vim) 自定义 title → descriptor.long.
   addon?.setKeyboardForwardCallback((id, modifierFlags, chars) => {
-    const targetWindow = BrowserWindow.fromId(id);
+    const targetWindow = findAppWindowByElectronId(id);
     if (
       targetWindow &&
       !targetWindow.isDestroyed() &&
@@ -178,7 +187,7 @@ export function registerTerminalIpc(ipcMain: IpcMain): void {
     );
   });
   addon?.setPwdForwardCallback((id, panelId, cwd) => {
-    const targetWindow = BrowserWindow.fromId(id);
+    const targetWindow = findAppWindowByElectronId(id);
     if (targetWindow && !targetWindow.isDestroyed()) {
       const windowId = stableWindowIdFor(targetWindow);
       updateTerminalPanelCwd(windowId, panelId, cwd).catch((err) => {
@@ -205,15 +214,13 @@ export function registerTerminalIpc(ipcMain: IpcMain): void {
     if (!addon) {
       return { ok: false, error: loadError ?? "native addon not loaded" };
     }
-    const win = BrowserWindow.fromWebContents(event.sender);
+    const win = windowFromWebContents(event.sender);
     if (!win) {
       return { ok: false, error: "window not found" };
     }
     try {
-      // Electron API: 窗口背景透明 (CSS 控制哪些区域透视, 非终端区域自行画不透明背景)
-      win.setBackgroundColor("#00000000");
       const handle = win.getNativeWindowHandle();
-      // 把 BrowserWindow.id 传给 swift, 让 forward callback 能按 window 路由 (多窗口
+      // 把 Electron window id 传给 swift, 让 forward callback 能按 window 路由 (多窗口
       // 下避免 getFocusedWindow 误把 background window 的 keystroke 路由到 focused)
       const ok = addon.setupWindow(handle, win.id);
       return ok ? { ok: true } : { ok: false, error: "setupWindow failed" };
@@ -228,7 +235,7 @@ export function registerTerminalIpc(ipcMain: IpcMain): void {
       if (!addon) {
         return { ok: false, error: loadError ?? "native addon not loaded" };
       }
-      const win = BrowserWindow.fromWebContents(event.sender);
+      const win = windowFromWebContents(event.sender);
       if (!win) {
         return { ok: false, error: "window not found" };
       }
@@ -275,7 +282,7 @@ export function registerTerminalIpc(ipcMain: IpcMain): void {
     ipcMain.on(channel, (_event, panelId: string) => call(panelId));
   }
   ipcMain.on("pier:terminal:close", (event, panelId: string) => {
-    const win = BrowserWindow.fromWebContents(event.sender);
+    const win = windowFromWebContents(event.sender);
     if (win) {
       const windowId = stableWindowIdFor(win);
       removeTerminalPanelSession(windowId, panelId).catch((err) => {
@@ -285,7 +292,7 @@ export function registerTerminalIpc(ipcMain: IpcMain): void {
     addon?.closeTerminal(panelId);
   });
   ipcMain.on("pier:terminal:focus", (event, panelId: string) => {
-    const win = BrowserWindow.fromWebContents(event.sender);
+    const win = windowFromWebContents(event.sender);
     if (win) {
       rememberActivePanelFocus(win, "terminal", panelId);
       if (!win.isFocused()) {
@@ -311,7 +318,7 @@ export function registerTerminalIpc(ipcMain: IpcMain): void {
     if (!addon) {
       return;
     }
-    const win = BrowserWindow.fromWebContents(event.sender);
+    const win = windowFromWebContents(event.sender);
     if (!win) {
       return;
     }
@@ -326,7 +333,7 @@ export function registerTerminalIpc(ipcMain: IpcMain): void {
     if (!addon) {
       return;
     }
-    const win = BrowserWindow.fromWebContents(event.sender);
+    const win = windowFromWebContents(event.sender);
     if (!win) {
       return;
     }
@@ -347,7 +354,7 @@ export function registerTerminalIpc(ipcMain: IpcMain): void {
     if (!addon) {
       return;
     }
-    const win = BrowserWindow.fromWebContents(event.sender);
+    const win = windowFromWebContents(event.sender);
     if (!win) {
       return;
     }
@@ -367,7 +374,7 @@ export function registerTerminalIpc(ipcMain: IpcMain): void {
       if (!addon) {
         return;
       }
-      const win = BrowserWindow.fromWebContents(event.sender);
+      const win = windowFromWebContents(event.sender);
       if (!win) {
         return;
       }
@@ -386,7 +393,7 @@ export function registerTerminalIpc(ipcMain: IpcMain): void {
   ipcMain.on(
     "pier:terminal:set-active-panel-kind",
     (event, kind: "terminal" | "web", panelId: string | null) => {
-      const win = BrowserWindow.fromWebContents(event.sender);
+      const win = windowFromWebContents(event.sender);
       if (!win) {
         return;
       }

--- a/src/main/ipc/theme.ts
+++ b/src/main/ipc/theme.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, type IpcMain, nativeTheme } from "electron";
+import { type IpcMain, nativeTheme } from "electron";
 import { windowManager } from "../windows/window-manager.ts";
 
 const NATIVE_CHROME_PALETTE = {
@@ -19,17 +19,14 @@ export function registerThemeIpc(ipcMain: IpcMain): void {
       const color = chromeColor ?? NATIVE_CHROME_PALETTE[resolved];
 
       if (isMac) {
-        // macOS: 平时 BrowserWindow 必须保持 #00000000 透明让 terminal NSView 透出,
-        // 不能直接 setBackgroundColor(chromeColor) — 否则 Chromium 合成时窗口底色
-        // 盖住下层 terminal NSView. 改为只记录给 window-manager 的 reload chrome
-        // 缓存, did-start-loading 临时切到 chromeColor 覆盖 reload 期间非终端区域
-        // 的"透到桌面"闪烁, did-finish-load 立刻切回透明.
-        for (const win of BrowserWindow.getAllWindows()) {
-          windowManager.setReloadChromeColor(win, color);
+        // macOS: opaque BaseWindow 只作为兜底 backing; renderer 透明区域仍通过
+        // transparent WebContentsView 透出 native terminal NSView.
+        for (const win of windowManager.getAll()) {
+          windowManager.setNativeChromeColor(win, color);
         }
         return;
       }
-      for (const win of BrowserWindow.getAllWindows()) {
+      for (const win of windowManager.getAll()) {
         win.setBackgroundColor(color);
       }
     }

--- a/src/main/ipc/window.ts
+++ b/src/main/ipc/window.ts
@@ -6,7 +6,7 @@
  */
 
 import { PIER } from "@shared/ipc-channels.ts";
-import { BrowserWindow, type IpcMain } from "electron";
+import type { IpcMain } from "electron";
 import { appCore } from "../app-core/app-core.ts";
 import { windowManager } from "../windows/window-manager.ts";
 
@@ -24,11 +24,11 @@ export function registerWindowIpc(ipcMain: IpcMain): void {
   });
 
   ipcMain.handle(PIER.WINDOW_CLOSE_CURRENT, (event) => {
-    const win = BrowserWindow.fromWebContents(event.sender);
+    const win = windowManager.fromWebContents(event.sender);
     if (!win) {
       return;
     }
-    const internalId = windowManager.findInternalIdByBrowserWindow(win);
+    const internalId = windowManager.findInternalIdByWindow(win);
     if (internalId) {
       windowManager.close(internalId);
     }

--- a/src/main/state/terminal-session-state.ts
+++ b/src/main/state/terminal-session-state.ts
@@ -9,7 +9,7 @@ import { existsSync } from "node:fs";
 import { mkdir, readFile } from "node:fs/promises";
 import { dirname, isAbsolute, join } from "node:path";
 import { app } from "electron";
-import lockfile from "proper-lockfile";
+import lockfile, { type LockOptions } from "proper-lockfile";
 import writeFileAtomic from "write-file-atomic";
 import { z } from "zod";
 
@@ -30,10 +30,23 @@ const terminalSessionStateSchema = z.object({
 export type TerminalPanelSession = z.infer<typeof terminalPanelSessionSchema>;
 type TerminalSessionState = z.infer<typeof terminalSessionStateSchema>;
 
-const EMPTY_TERMINAL_SESSION_STATE: TerminalSessionState = {
-  version: 1,
-  windows: {},
+const LOCK_OPTIONS: LockOptions = {
+  retries: {
+    factor: 1,
+    maxTimeout: 100,
+    minTimeout: 20,
+    retries: 5,
+  },
 };
+
+let stateMutationQueue: Promise<void> = Promise.resolve();
+
+function createEmptyState(): TerminalSessionState {
+  return {
+    version: 1,
+    windows: {},
+  };
+}
 
 function resolveFilePath(): string {
   return join(app.getPath("userData"), "terminal-session-state.json");
@@ -53,10 +66,9 @@ async function fileExists(path: string): Promise<boolean> {
   }
 }
 
-async function readState(): Promise<TerminalSessionState> {
-  const path = resolveFilePath();
+async function readStateFromPath(path: string): Promise<TerminalSessionState> {
   if (!existsSync(path)) {
-    return EMPTY_TERMINAL_SESSION_STATE;
+    return createEmptyState();
   }
   try {
     const raw = await readFile(path, "utf-8");
@@ -66,25 +78,50 @@ async function readState(): Promise<TerminalSessionState> {
       "[terminal-session-state] parse failed, using empty state:",
       err
     );
-    return EMPTY_TERMINAL_SESSION_STATE;
+    return createEmptyState();
   }
 }
 
-async function writeState(state: TerminalSessionState): Promise<void> {
+function readState(): Promise<TerminalSessionState> {
   const path = resolveFilePath();
+  return readStateFromPath(path);
+}
+
+async function ensureStateFile(path: string): Promise<void> {
   await ensureDir(path);
   if (!(await fileExists(path))) {
     await writeFileAtomic(
       path,
-      `${JSON.stringify(EMPTY_TERMINAL_SESSION_STATE, null, 2)}\n`
+      `${JSON.stringify(createEmptyState(), null, 2)}\n`
     );
   }
-  const release = await lockfile.lock(path);
+}
+
+async function mutateState(
+  mutator: (state: TerminalSessionState) => boolean
+): Promise<void> {
+  const path = resolveFilePath();
+  await ensureStateFile(path);
+  const release = await lockfile.lock(path, LOCK_OPTIONS);
   try {
-    await writeFileAtomic(path, `${JSON.stringify(state, null, 2)}\n`);
+    const state = await readStateFromPath(path);
+    if (mutator(state)) {
+      await writeFileAtomic(path, `${JSON.stringify(state, null, 2)}\n`);
+    }
   } finally {
     await release();
   }
+}
+
+function enqueueStateMutation(
+  mutator: (state: TerminalSessionState) => boolean
+): Promise<void> {
+  const run = stateMutationQueue.then(
+    () => mutateState(mutator),
+    () => mutateState(mutator)
+  );
+  stateMutationQueue = run.catch(() => undefined);
+  return run;
 }
 
 function isNonEmptyId(value: string): boolean {
@@ -117,14 +154,15 @@ export async function updateTerminalPanelCwd(
   if (!isRestorableCwd(cwd)) {
     return;
   }
-  const state = await readState();
-  const windowState = state.windows[windowId] ?? { panels: {} };
-  state.windows[windowId] = windowState;
-  windowState.panels[panelId] = {
-    cwd,
-    updatedAt: new Date().toISOString(),
-  };
-  await writeState(state);
+  await enqueueStateMutation((state) => {
+    const windowState = state.windows[windowId] ?? { panels: {} };
+    state.windows[windowId] = windowState;
+    windowState.panels[panelId] = {
+      cwd,
+      updatedAt: new Date().toISOString(),
+    };
+    return true;
+  });
 }
 
 export async function removeTerminalPanelSession(
@@ -134,14 +172,15 @@ export async function removeTerminalPanelSession(
   if (!(isNonEmptyId(windowId) && isNonEmptyId(panelId))) {
     return;
   }
-  const state = await readState();
-  const windowState = state.windows[windowId];
-  if (!windowState?.panels[panelId]) {
-    return;
-  }
-  delete windowState.panels[panelId];
-  if (Object.keys(windowState.panels).length === 0) {
-    delete state.windows[windowId];
-  }
-  await writeState(state);
+  await enqueueStateMutation((state) => {
+    const windowState = state.windows[windowId];
+    if (!windowState?.panels[panelId]) {
+      return false;
+    }
+    delete windowState.panels[panelId];
+    if (Object.keys(windowState.panels).length === 0) {
+      delete state.windows[windowId];
+    }
+    return true;
+  });
 }

--- a/src/main/windows/app-window.ts
+++ b/src/main/windows/app-window.ts
@@ -1,0 +1,45 @@
+import type { BaseWindow, WebContents, WebContentsView } from "electron";
+
+export interface AppWindow {
+  readonly appView: WebContentsView | null;
+  close(): void;
+  destroy(): void;
+  focus(): void;
+  getNativeWindowHandle(): Buffer;
+  readonly host: BaseWindow;
+  readonly id: number;
+  isDestroyed(): boolean;
+  isFocused(): boolean;
+  isMinimized(): boolean;
+  moveTop(): void;
+  restore(): void;
+  setBackgroundColor(color: string): void;
+  readonly webContents: WebContents;
+}
+
+export function createAppWindow(
+  host: BaseWindow,
+  webContents: WebContents,
+  appView: WebContentsView | null
+): AppWindow {
+  return {
+    appView,
+    close: () => host.close(),
+    destroy: () => host.destroy(),
+    focus: () => host.focus(),
+    get host() {
+      return host;
+    },
+    get id() {
+      return host.id;
+    },
+    getNativeWindowHandle: () => host.getNativeWindowHandle(),
+    isDestroyed: () => host.isDestroyed(),
+    isFocused: () => host.isFocused(),
+    isMinimized: () => host.isMinimized(),
+    moveTop: () => host.moveTop(),
+    restore: () => host.restore(),
+    setBackgroundColor: (color) => host.setBackgroundColor(color),
+    webContents,
+  };
+}

--- a/src/main/windows/window-identity.ts
+++ b/src/main/windows/window-identity.ts
@@ -1,18 +1,38 @@
-import type { BrowserWindow } from "electron";
+import type { WebContents } from "electron";
+import type { AppWindow } from "./app-window.ts";
 
-const browserWindowIds = new WeakMap<BrowserWindow, string>();
+const appWindowIds = new WeakMap<AppWindow, string>();
+const appWindowElectronIds = new WeakMap<AppWindow, number>();
+const appWindowsByElectronId = new Map<number, AppWindow>();
+const appWindowsByWebContents = new WeakMap<WebContents, AppWindow>();
 
-export function rememberBrowserWindowId(
-  window: BrowserWindow,
-  id: string
-): void {
-  browserWindowIds.set(window, id);
+export function rememberAppWindow(window: AppWindow, id: string): void {
+  const electronId = window.id;
+  appWindowIds.set(window, id);
+  appWindowElectronIds.set(window, electronId);
+  appWindowsByElectronId.set(electronId, window);
+  appWindowsByWebContents.set(window.webContents, window);
 }
 
-export function forgetBrowserWindowId(window: BrowserWindow): void {
-  browserWindowIds.delete(window);
+export function forgetAppWindow(window: AppWindow): void {
+  appWindowIds.delete(window);
+  const electronId = appWindowElectronIds.get(window);
+  if (electronId !== undefined) {
+    appWindowsByElectronId.delete(electronId);
+    appWindowElectronIds.delete(window);
+  }
 }
 
-export function findBrowserWindowId(window: BrowserWindow): string | null {
-  return browserWindowIds.get(window) ?? null;
+export function findInternalWindowId(window: AppWindow): string | null {
+  return appWindowIds.get(window) ?? null;
+}
+
+export function findAppWindowByElectronId(id: number): AppWindow | null {
+  return appWindowsByElectronId.get(id) ?? null;
+}
+
+export function findAppWindowByWebContents(
+  webContents: WebContents
+): AppWindow | null {
+  return appWindowsByWebContents.get(webContents) ?? null;
 }

--- a/src/main/windows/window-manager.ts
+++ b/src/main/windows/window-manager.ts
@@ -4,7 +4,7 @@
  * 从 loomdesk 精简移植: 保留 create/list/focus/close + ID 分配, 去掉 PTY 迁移 /
  * close-guard 两段式 / route pending / reload detach 等 pier 暂不需要的能力.
  *
- *   - create(): 分配 id (首窗口 "main", 后续 w-{N}), 创建 BrowserWindow, 注册到 Map.
+ *   - create(): 分配 id (首窗口 "main", 后续 w-{N}), 创建 app window, 注册到 Map.
  *   - list(): 返回所有存活窗口的 { id, focused }.
  *   - focus(): 聚焦/恢复指定窗口.
  *   - close(): 关闭指定窗口.
@@ -13,18 +13,27 @@
  * 窗口关闭后自动从 Map 移除并释放 ID; window-all-closed 由 main 侧处理.
  */
 import { join } from "node:path";
-import { app, BrowserWindow, nativeTheme, shell } from "electron";
+import {
+  app,
+  BaseWindow,
+  BrowserWindow,
+  nativeTheme,
+  shell,
+  WebContentsView,
+} from "electron";
 import { installDetachedDevToolsHandlers } from "../devtools.ts";
 import {
   blurActivePanelFocus,
   getTerminalAddon,
   restoreActivePanelFocus,
 } from "../ipc/terminal.ts";
+import { type AppWindow, createAppWindow } from "./app-window.ts";
 import { WindowIdAllocator } from "./window-id-allocator.ts";
 import {
-  findBrowserWindowId,
-  forgetBrowserWindowId,
-  rememberBrowserWindowId,
+  findAppWindowByWebContents,
+  findInternalWindowId,
+  forgetAppWindow,
+  rememberAppWindow,
 } from "./window-identity.ts";
 
 const WINDOW_ID_REGEX = /^(main|w-\d+)$/;
@@ -53,26 +62,15 @@ function resolveDevIcon(): string | undefined {
   return isDev ? join(import.meta.dirname, "../../build/icon.png") : undefined;
 }
 
-/** macOS reload 期间临时用于覆盖非终端区域的 chrome 色 fallback (跟 windowed
- *  默认 dark 一致). renderer hydrate 完会调 setNativeChrome 推真实 chrome 色, 这里
- *  只在 setNativeChrome 还没到 (首次启动) 时兜底. */
-const RELOAD_CHROME_FALLBACK_MAC = "#1e1e1e";
-
 class WindowManager {
-  private readonly windows = new Map<string, BrowserWindow>();
+  private readonly windows = new Map<string, AppWindow>();
   private readonly allocator = new WindowIdAllocator();
   private readonly onCloseCallbacks: Array<(windowId: string) => void> = [];
-  /** macOS reload 期间临时切的 chrome 色, 每窗口独立 (多窗口主题可独立). */
-  private readonly reloadChromeColor = new WeakMap<BrowserWindow, string>();
 
-  /**
-   * 由 theme IPC 调:记录该 window 当前的 chrome 色 (sidebar/titlebar 同款),
-   * 供 reload 期间临时覆盖非终端区域用. 不立刻 setBackgroundColor — 平时窗口
-   * 必须保持 #00000000 透明让 terminal NSView 透出. 只在 did-start-loading →
-   * did-finish-load 窗口期短暂切换.
-   */
-  setReloadChromeColor(window: BrowserWindow, color: string): void {
-    this.reloadChromeColor.set(window, color);
+  setNativeChromeColor(window: AppWindow, color: string): void {
+    if (isMac) {
+      window.setBackgroundColor(color);
+    }
   }
 
   onClose(callback: (windowId: string) => void): void {
@@ -95,41 +93,45 @@ class WindowManager {
       light: "#ffffff",
       dark: "#1e1e1e",
     };
-    const winOpts: Electron.BrowserWindowConstructorOptions = {
+    const preload = join(import.meta.dirname, "../preload/index.cjs");
+    const webPreferences: Electron.WebPreferences = {
+      preload,
+      sandbox: true,
+      contextIsolation: true,
+      nodeIntegration: false,
+      additionalArguments: [`--window-id=${id}`],
+    };
+    const baseOpts: Electron.BaseWindowConstructorOptions = {
       width: opts.bounds?.width ?? 1280,
       height: opts.bounds?.height ?? 800,
       show: false,
       autoHideMenuBar: true,
-      transparent: isMac,
-      backgroundColor: isMac ? "#00000000" : bgPalette[resolved],
+      backgroundColor: bgPalette[resolved],
       ...(isMac && {
         titleBarStyle: "hiddenInset" as const,
         trafficLightPosition: { x: 12, y: 12 },
       }),
-      webPreferences: {
-        preload: join(import.meta.dirname, "../preload/index.cjs"),
-        sandbox: true,
-        contextIsolation: true,
-        nodeIntegration: false,
-        additionalArguments: [`--window-id=${id}`],
-      },
     };
     if (opts.bounds?.x !== undefined) {
-      winOpts.x = opts.bounds.x;
+      baseOpts.x = opts.bounds.x;
     }
     if (opts.bounds?.y !== undefined) {
-      winOpts.y = opts.bounds.y;
+      baseOpts.y = opts.bounds.y;
     }
     const devIcon = resolveDevIcon();
-    if (!isMac && devIcon) {
-      winOpts.icon = devIcon;
-    }
+    const window = isMac
+      ? this.createMacWindow(baseOpts, webPreferences)
+      : this.createBrowserWindow(baseOpts, webPreferences, devIcon);
+    rememberAppWindow(window, id);
 
-    const window = new BrowserWindow(winOpts);
-    rememberBrowserWindowId(window, id);
-
-    window.on("ready-to-show", () => window.show());
-    window.on("blur", () => {
+    const showOnce = () => {
+      if (!window.isDestroyed()) {
+        window.host.show();
+      }
+    };
+    window.webContents.once("did-finish-load", showOnce);
+    window.webContents.once("did-fail-load", showOnce);
+    window.host.on("blur", () => {
       blurActivePanelFocus(window);
     });
 
@@ -148,9 +150,8 @@ class WindowManager {
 
     // Crash 兜底: 渲染进程异常退出 (非主动 reload) 时清理 terminal NSView, 防止
     // 旧 view 残留在 contentView.subviews 中. 正常 reload 不在这里清 — NSView 跟
-    // BrowserWindow.contentView 是 native subview 关系, webContents reload 不动它;
-    // 新 renderer mount 后会调 terminal.reconcile(activeIds) 主动清差集, terminal
-    // panel 的 PTY / session / 屏幕内容跨 reload 完整保留 (零闪烁 + 不丢 shell 状态).
+    // NSWindow.contentView 是 native subview 关系, webContents reload 不动它; 新
+    // renderer mount 后会调 terminal.reconcile(activeIds) 主动清差集.
     window.webContents.on("render-process-gone", () => {
       try {
         getTerminalAddon()?.closeAllTerminals(window.getNativeWindowHandle());
@@ -158,43 +159,13 @@ class WindowManager {
         // ignore: window 即将销毁/已销毁
       }
     });
-
-    // macOS reload 非终端区域闪烁修复:
-    //
-    // BrowserWindow 平时 backgroundColor=#00000000 (透明), 让 terminal NSView 从
-    // contentView.subviews[0] 透出. reload 期间 WKWebView 短暂卸载, 非终端区域
-    // 没有 web 内容铺底, 透明窗口直接透到桌面 → 视觉上"非终端区域闪一下".
-    //
-    // 修复:did-start-loading 把 backgroundColor 临时切到当前 chrome 色 (sidebar/
-    // titlebar 同款的 --muted), did-finish-load 再切回透明. 反正 reload 完成后
-    // web 层会覆盖整个非终端区域, chrome 色一闪即被覆盖, 视觉上无感.
-    //
-    // terminal NSView 在 NSWindow backing 之上 (它是 contentView 的 subview),
-    // 临时 backgroundColor 不会遮挡它 — 但若实测发现遮挡, 退路是在 web 端 reload
-    // 前先把 NSView 主动 hide, 再 reload, 切回时 show. 当前实测以无遮挡为前提.
-    if (isMac) {
-      let hasFinishedFirstLoad = false;
-      window.webContents.on("did-finish-load", () => {
-        hasFinishedFirstLoad = true;
-        try {
-          window.setBackgroundColor("#00000000");
-        } catch {
-          // ignore: window 即将销毁
-        }
-      });
-      window.webContents.on("did-start-loading", () => {
-        if (!hasFinishedFirstLoad) {
-          return; // 首次加载不动 — 透明窗口背景下 splash 阶段不需要 chrome 色
-        }
-        const chromeColor =
-          this.reloadChromeColor.get(window) ?? RELOAD_CHROME_FALLBACK_MAC;
-        try {
-          window.setBackgroundColor(chromeColor);
-        } catch {
-          // ignore: window 即将销毁
-        }
-      });
-    }
+    window.webContents.on("preload-error", (_event, preloadPath, error) => {
+      console.error(
+        "[pier-preload-error]",
+        preloadPath,
+        error instanceof Error ? error.message : String(error)
+      );
+    });
 
     // Window 即将销毁: 在 handle 失效前抢先 detach native 资源 (closeAll + 卸
     // EventRouter + 卸 NSEvent monitor). 用 `close` 而非 `closed` 因为 `closed`
@@ -203,7 +174,7 @@ class WindowManager {
     // 不 detach 的话:
     // - NSEvent application-level monitor 永远活在 process 里 (内存泄漏)
     // - GhosttyBridgeImpl.eventRouters dict 累积已死 window 的 router 引用
-    window.on("close", () => {
+    window.host.on("close", () => {
       try {
         getTerminalAddon()?.detachWindow(window.getNativeWindowHandle());
       } catch {
@@ -211,22 +182,25 @@ class WindowManager {
       }
     });
 
-    window.on("closed", () => {
+    window.host.on("closed", () => {
+      if (window.appView && !window.webContents.isDestroyed()) {
+        window.webContents.close();
+      }
+      forgetAppWindow(window);
+      this.windows.delete(id);
+      this.allocator.release(id);
       for (const cb of this.onCloseCallbacks) {
         cb(id);
       }
-      forgetBrowserWindowId(window);
-      this.windows.delete(id);
-      this.allocator.release(id);
     });
 
     const rendererUrl = process.env.ELECTRON_RENDERER_URL;
     if (isDev && rendererUrl) {
-      window.loadURL(rendererUrl).catch(() => {
+      window.webContents.loadURL(rendererUrl).catch(() => {
         // ignore: load 失败由 ready-to-show / did-fail-load 兜底
       });
     } else {
-      window
+      window.webContents
         .loadFile(join(import.meta.dirname, "../renderer/index.html"))
         .catch(() => {
           // ignore: load 失败由 ready-to-show / did-fail-load 兜底
@@ -235,6 +209,37 @@ class WindowManager {
 
     this.windows.set(id, window);
     return id;
+  }
+
+  private createMacWindow(
+    baseOpts: Electron.BaseWindowConstructorOptions,
+    webPreferences: Electron.WebPreferences
+  ): AppWindow {
+    const host = new BaseWindow(baseOpts);
+    const appView = new WebContentsView({ webPreferences });
+    appView.setBackgroundColor("#00000000");
+    host.contentView.addChildView(appView);
+    const resizeAppView = () => {
+      const [width = 0, height = 0] = host.getContentSize();
+      appView.setBounds({ x: 0, y: 0, width, height });
+    };
+    resizeAppView();
+    host.on("resize", resizeAppView);
+    return createAppWindow(host, appView.webContents, appView);
+  }
+
+  private createBrowserWindow(
+    baseOpts: Electron.BaseWindowConstructorOptions,
+    webPreferences: Electron.WebPreferences,
+    devIcon: string | undefined
+  ): AppWindow {
+    const browserOpts: Electron.BrowserWindowConstructorOptions = {
+      ...baseOpts,
+      ...(devIcon ? { icon: devIcon } : {}),
+      webPreferences,
+    };
+    const host = new BrowserWindow(browserOpts);
+    return createAppWindow(host, host.webContents, null);
   }
 
   list(): WindowInfo[] {
@@ -259,17 +264,41 @@ class WindowManager {
     this.windows.get(id)?.close();
   }
 
-  get(id: string): BrowserWindow | undefined {
+  destroyAllForQuit(): void {
+    for (const window of this.windows.values()) {
+      if (!window.isDestroyed()) {
+        try {
+          getTerminalAddon()?.detachWindow(window.getNativeWindowHandle());
+        } catch {
+          // ignore: app 正在退出
+        }
+        if (window.appView && !window.webContents.isDestroyed()) {
+          window.webContents.close();
+        }
+        window.destroy();
+      }
+    }
+  }
+
+  get(id: string): AppWindow | undefined {
     return this.windows.get(id);
   }
 
-  getAll(): BrowserWindow[] {
+  getAll(): AppWindow[] {
     return [...this.windows.values()];
   }
 
-  /** 通过 BrowserWindow 实例反查内部 string id. */
-  findInternalIdByBrowserWindow(bw: BrowserWindow): string | null {
-    return findBrowserWindowId(bw);
+  getFocused(): AppWindow | null {
+    return this.getAll().find((win) => win.isFocused()) ?? null;
+  }
+
+  fromWebContents(webContents: Electron.WebContents): AppWindow | null {
+    return findAppWindowByWebContents(webContents);
+  }
+
+  /** 通过 AppWindow 实例反查内部 string id. */
+  findInternalIdByWindow(window: AppWindow): string | null {
+    return findInternalWindowId(window);
   }
 }
 

--- a/src/main/windows/window-manager.ts
+++ b/src/main/windows/window-manager.ts
@@ -13,6 +13,7 @@
  * 窗口关闭后自动从 Map 移除并释放 ID; window-all-closed 由 main 侧处理.
  */
 import { join } from "node:path";
+import { PIER_BROADCAST } from "@shared/ipc-channels.ts";
 import {
   app,
   BaseWindow,
@@ -223,8 +224,23 @@ class WindowManager {
       const [width = 0, height = 0] = host.getContentSize();
       appView.setBounds({ x: 0, y: 0, width, height });
     };
+    const sendLayoutPulse = (reason: "resize" | "zoom") => {
+      if (!appView.webContents.isDestroyed()) {
+        appView.webContents.send(PIER_BROADCAST.WINDOW_LAYOUT_PULSE, {
+          reason,
+        });
+      }
+    };
     resizeAppView();
-    host.on("resize", resizeAppView);
+    host.on("resize", () => {
+      resizeAppView();
+      sendLayoutPulse("resize");
+    });
+    host.on("resized", () => sendLayoutPulse("resize"));
+    host.on("maximize", () => sendLayoutPulse("zoom"));
+    host.on("unmaximize", () => sendLayoutPulse("zoom"));
+    host.on("enter-full-screen", () => sendLayoutPulse("zoom"));
+    host.on("leave-full-screen", () => sendLayoutPulse("zoom"));
     return createAppWindow(host, appView.webContents, appView);
   }
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -13,6 +13,7 @@ import {
   RENDERER_COMMAND_RESULT_CHANNEL,
 } from "@shared/contracts/renderer-command-channels.ts";
 import type { TerminalAPI } from "@shared/contracts/terminal.ts";
+import { PIER_BROADCAST } from "@shared/ipc-channels.ts";
 import { contextBridge, ipcRenderer } from "electron";
 
 export interface WindowInfo {
@@ -83,6 +84,10 @@ export interface PierMenuAPI {
   ) => Promise<MenuPopupResult>;
 }
 
+export interface WindowLayoutPulse {
+  reason: "resize" | "zoom";
+}
+
 export interface PierWindowAPI {
   closeCurrentWindow: () => Promise<void>;
   closeWindow: (windowId: string) => Promise<void>;
@@ -92,6 +97,7 @@ export interface PierWindowAPI {
   keybinding: PierKeybindingAPI;
   listWindows: () => Promise<WindowInfo[]>;
   menu: PierMenuAPI;
+  onWindowLayoutPulse: (cb: (pulse: WindowLayoutPulse) => void) => () => void;
   platform: NodeJS.Platform;
   preferences: PierPreferencesAPI;
   rendererCommand: PierRendererCommandAPI;
@@ -206,6 +212,8 @@ const api: PierWindowAPI = {
   keybinding: keybindingApi,
   listWindows: () => ipcRenderer.invoke("pier://window:list"),
   menu: menuApi,
+  onWindowLayoutPulse: (cb) =>
+    subscribeIpc(PIER_BROADCAST.WINDOW_LAYOUT_PULSE, cb),
   platform: process.platform,
   preferences: preferencesApi,
   rendererCommand: rendererCommandApi,

--- a/src/renderer/app/globals.css
+++ b/src/renderer/app/globals.css
@@ -820,3 +820,8 @@ body {
 .dockview-theme-pier .dv-drop-target-container {
   --dv-transition-duration: 100ms;
 }
+
+
+.dockview-theme-pier .dv-tabs-and-actions-container {
+  border-bottom: none;
+}

--- a/src/renderer/app/globals.css
+++ b/src/renderer/app/globals.css
@@ -542,6 +542,7 @@
 html,
 body {
   height: 100%;
+  overflow: hidden;
   padding: 0;
   margin: 0;
   font-family: var(--pier-ui-font-family);
@@ -619,6 +620,7 @@ body {
 
 #root {
   height: 100%;
+  overflow: hidden;
   background: transparent;
 }
 
@@ -695,6 +697,13 @@ body {
 .dockview-theme-pier .dv-dockview,
 .dockview-theme-pier .dv-groupview {
   background-color: transparent !important;
+}
+
+/* dockview 自带 web scrollbar 在 resize 时会短暂显现；Pier terminal 区域由
+   native view 承载，resize 期间隐藏这层 web scrollbar，保留正常 tab overflow。 */
+.dockview-theme-pier .dv-scrollable.dv-scrollable-resizing .dv-scrollbar {
+  opacity: 0;
+  pointer-events: none;
 }
 
 /* — hover: 非选中 tab 微亮 — */

--- a/src/renderer/components/common/app-shell.tsx
+++ b/src/renderer/components/common/app-shell.tsx
@@ -9,14 +9,14 @@ const IS_MAC = window.pier?.platform === "darwin";
 
 export function AppShell() {
   return (
-    <div className="flex h-full flex-col">
+    <div className="flex h-full flex-col overflow-hidden">
       <DocumentTitle />
       {IS_MAC && <TitleBar />}
-      <ShellKeybindings />
-      <CommandPalette />
-      <div className="min-h-0 flex-1">
+      <div className="min-h-0 flex-1 overflow-hidden">
         <WorkspaceHost />
       </div>
+      <ShellKeybindings />
+      <CommandPalette />
       <SettingsDialog />
     </div>
   );

--- a/src/renderer/components/primitives/command.tsx
+++ b/src/renderer/components/primitives/command.tsx
@@ -54,6 +54,7 @@ function CommandDialog({
           "top-1/3 translate-y-0 overflow-hidden rounded-3xl! p-0",
           className
         )}
+        overlayClassName="bg-transparent duration-0 data-open:animate-none data-closed:animate-none supports-backdrop-filter:backdrop-blur-none"
         showCloseButton={showCloseButton}
       >
         {children}

--- a/src/renderer/components/primitives/dialog.tsx
+++ b/src/renderer/components/primitives/dialog.tsx
@@ -95,16 +95,18 @@ function wasInnerPortalOpenRecently(): boolean {
 function DialogContent({
   className,
   children,
+  overlayClassName,
   showCloseButton = true,
   onPointerDownOutside,
   onInteractOutside,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  overlayClassName?: string;
   showCloseButton?: boolean;
 }) {
   return (
     <DialogPortal>
-      <DialogOverlay />
+      <DialogOverlay className={overlayClassName} />
       <DialogPrimitive.Content
         className={cn(
           "app-no-drag data-open:fade-in-0 data-open:zoom-in-95 data-closed:fade-out-0 data-closed:zoom-out-95 fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-6 rounded-[min(var(--radius-4xl),24px)] bg-popover p-6 text-popover-foreground text-sm shadow-xl outline-none ring-1 ring-foreground/5 duration-100 data-closed:animate-out data-open:animate-in sm:max-w-md dark:ring-foreground/10",

--- a/src/renderer/components/workspace/workspace-host.tsx
+++ b/src/renderer/components/workspace/workspace-host.tsx
@@ -38,7 +38,7 @@ import { PanelTabHeader } from "./panel-tab-header.tsx";
  * 跟 sash 内线并列显示成"两条线"伪影.
  *
  * dndOverlayMounting: 'absolute' — 让 root drop overlay 渲染到 shell 根层级,
- * 配合 setOverlayActive 隐藏 terminal NSView 使 group drop overlay 也可见.
+ * 配合 setOverlayActive 暂停 EventRouter 拦截, 使 group drop overlay 可接收输入.
  */
 const pierTheme: DockviewTheme = {
   name: "pier",
@@ -305,7 +305,7 @@ export function WorkspaceHost() {
   );
 
   return (
-    <div className="h-full w-full">
+    <div className="h-full w-full overflow-hidden">
       <DockviewReact
         components={panelComponents}
         defaultTabComponent={PanelTabHeader}

--- a/src/renderer/components/workspace/workspace-host.tsx
+++ b/src/renderer/components/workspace/workspace-host.tsx
@@ -8,6 +8,7 @@ import {
 import { useCallback } from "react";
 import "dockview-react/dist/styles/dockview.css";
 import { activateTerminalPanelFromFocusRequest } from "@/lib/workspace/terminal-focus-request.ts";
+import { flushTerminalLayoutFramesTrailing } from "@/panel-kits/terminal/terminal-layout-coordinator.ts";
 import { useKeybindingScope } from "@/stores/keybinding-scope.store.ts";
 import { usePanelDescriptorStore } from "@/stores/panel-descriptor.store.ts";
 import { useWorkspaceStore } from "@/stores/workspace.store.ts";
@@ -204,6 +205,7 @@ export function WorkspaceHost() {
           return; // program-driven, 不算 user touched
         }
         userTouched = true;
+        flushTerminalLayoutFramesTrailing("dockview-layout");
         if (saveTimer) {
           clearTimeout(saveTimer);
         }
@@ -218,6 +220,10 @@ export function WorkspaceHost() {
             console.error("[workspace] toJSON failed:", err);
           }
         }, SAVE_DEBOUNCE_MS);
+      });
+
+      event.api.onDidMaximizedGroupChange(() => {
+        flushTerminalLayoutFramesTrailing("dockview-maximize");
       });
 
       // Active panel 变化 (含同 group 切 tab, panel 创建/删除导致 active 切换) →

--- a/src/renderer/panel-kits/terminal/terminal-layout-coordinator.ts
+++ b/src/renderer/panel-kits/terminal/terminal-layout-coordinator.ts
@@ -1,0 +1,194 @@
+import type { TerminalFrame } from "@shared/contracts/terminal.ts";
+
+type WindowLayoutPulseReason = "resize" | "zoom";
+
+export type TerminalLayoutFlushReason =
+  | "anchor-resize"
+  | "dockview-dimensions"
+  | "dockview-layout"
+  | "dockview-maximize"
+  | "visibility"
+  | "window-resize"
+  | `window-${WindowLayoutPulseReason}`;
+
+interface TerminalAnchorState {
+  anchor: HTMLDivElement;
+  frameRequest: number | null;
+  lastFrameKey: string;
+  panelId: string;
+  resizeObserver: ResizeObserver | null;
+}
+
+export interface TerminalLayoutRegistration {
+  dispose(): void;
+  flushNow(reason: TerminalLayoutFlushReason): void;
+  flushTrailing(reason: TerminalLayoutFlushReason): void;
+}
+
+const anchors = new Map<string, TerminalAnchorState>();
+let windowResizeInstalled = false;
+let windowLayoutPulseDispose: (() => void) | null = null;
+
+export function readTerminalAnchorFrame(
+  anchor: HTMLDivElement
+): TerminalFrame | null {
+  const r = anchor.getBoundingClientRect();
+  if (r.width < 10 || r.height < 10) {
+    return null;
+  }
+  return { x: r.x, y: r.y, width: r.width, height: r.height };
+}
+
+function frameKey(frame: TerminalFrame): string {
+  return `${frame.x},${frame.y},${frame.width},${frame.height}`;
+}
+
+function debugEnabled(): boolean {
+  try {
+    return window.localStorage?.getItem("pierTerminalLayoutDebug") === "1";
+  } catch {
+    return false;
+  }
+}
+
+function debugFrame(
+  reason: TerminalLayoutFlushReason,
+  panelId: string,
+  frame: TerminalFrame
+): void {
+  if (!debugEnabled()) {
+    return;
+  }
+  console.debug("[pier-terminal-layout]", {
+    frame,
+    panelId,
+    reason,
+    time: performance.now(),
+  });
+}
+
+function sendFrameNow(
+  state: TerminalAnchorState,
+  reason: TerminalLayoutFlushReason
+): void {
+  const frame = readTerminalAnchorFrame(state.anchor);
+  if (!frame) {
+    return;
+  }
+  const key = frameKey(frame);
+  if (key === state.lastFrameKey) {
+    return;
+  }
+  state.lastFrameKey = key;
+  debugFrame(reason, state.panelId, frame);
+  window.pier.terminal.setFrame(state.panelId, frame);
+}
+
+function flushTrailing(
+  state: TerminalAnchorState,
+  reason: TerminalLayoutFlushReason
+): void {
+  sendFrameNow(state, reason);
+  if (state.frameRequest !== null) {
+    cancelAnimationFrame(state.frameRequest);
+  }
+
+  let remainingFrames = 2;
+  const tick = () => {
+    sendFrameNow(state, reason);
+    remainingFrames -= 1;
+    if (remainingFrames > 0) {
+      state.frameRequest = requestAnimationFrame(tick);
+      return;
+    }
+    state.frameRequest = null;
+  };
+  state.frameRequest = requestAnimationFrame(tick);
+}
+
+export function flushTerminalLayoutFrames(
+  reason: TerminalLayoutFlushReason
+): void {
+  for (const state of anchors.values()) {
+    sendFrameNow(state, reason);
+  }
+}
+
+export function flushTerminalLayoutFramesTrailing(
+  reason: TerminalLayoutFlushReason
+): void {
+  for (const state of anchors.values()) {
+    flushTrailing(state, reason);
+  }
+}
+
+function handleWindowResize(): void {
+  flushTerminalLayoutFramesTrailing("window-resize");
+}
+
+function ensureGlobalListeners(): void {
+  if (!windowResizeInstalled) {
+    window.addEventListener("resize", handleWindowResize);
+    windowResizeInstalled = true;
+  }
+  if (!windowLayoutPulseDispose) {
+    windowLayoutPulseDispose =
+      window.pier?.onWindowLayoutPulse?.((pulse) => {
+        flushTerminalLayoutFramesTrailing(`window-${pulse.reason}`);
+      }) ?? null;
+  }
+}
+
+function maybeDisposeGlobalListeners(): void {
+  if (anchors.size > 0) {
+    return;
+  }
+  if (windowResizeInstalled) {
+    window.removeEventListener("resize", handleWindowResize);
+    windowResizeInstalled = false;
+  }
+  windowLayoutPulseDispose?.();
+  windowLayoutPulseDispose = null;
+}
+
+export function registerTerminalLayoutAnchor(
+  panelId: string,
+  anchor: HTMLDivElement
+): TerminalLayoutRegistration {
+  const pendingFrameRequest = anchors.get(panelId)?.frameRequest;
+  if (pendingFrameRequest !== null && pendingFrameRequest !== undefined) {
+    cancelAnimationFrame(pendingFrameRequest);
+  }
+  const state: TerminalAnchorState = {
+    anchor,
+    frameRequest: null,
+    lastFrameKey: "",
+    panelId,
+    resizeObserver: null,
+  };
+  state.resizeObserver = new ResizeObserver(() => {
+    sendFrameNow(state, "anchor-resize");
+  });
+  state.resizeObserver.observe(anchor);
+  anchors.set(panelId, state);
+  ensureGlobalListeners();
+
+  return {
+    dispose() {
+      if (state.frameRequest !== null) {
+        cancelAnimationFrame(state.frameRequest);
+      }
+      state.resizeObserver?.disconnect();
+      if (anchors.get(panelId) === state) {
+        anchors.delete(panelId);
+      }
+      maybeDisposeGlobalListeners();
+    },
+    flushNow(reason) {
+      sendFrameNow(state, reason);
+    },
+    flushTrailing(reason) {
+      flushTrailing(state, reason);
+    },
+  };
+}

--- a/src/renderer/panel-kits/terminal/terminal-panel.tsx
+++ b/src/renderer/panel-kits/terminal/terminal-panel.tsx
@@ -1,6 +1,6 @@
 import type { TerminalFrame } from "@shared/contracts/terminal.ts";
 import type { IDockviewPanelProps } from "dockview-react";
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { usePanelDescriptor } from "@/hooks/use-panel-descriptor.ts";
 import { usePanelEventState } from "@/hooks/use-panel-event-state.ts";
 import { popupContextMenuAt } from "@/lib/context-menu/use-context-menu.ts";
@@ -47,7 +47,6 @@ export function TerminalPanel(props: IDockviewPanelProps) {
   const monoFontFamily = useFontStore((s) => s.monoFontFamily);
   const monoFontSize = useFontStore((s) => s.monoFontSize);
   const anchorRef = useRef<HTMLDivElement>(null);
-  const parentRef = useRef<HTMLDivElement>(null);
   const [error, setError] = useState<string | null>(null);
 
   // 订阅 swift OSC 7 → main → 这里. usePanelEventState 自动按 panelId 过滤 +
@@ -74,24 +73,6 @@ export function TerminalPanel(props: IDockviewPanelProps) {
     long: sequenceTitle ?? cwd ?? undefined,
     path: cwd ?? undefined,
   });
-
-  useLayoutEffect(() => {
-    const parent = parentRef.current?.parentElement;
-    const anchor = anchorRef.current;
-    if (!(parent && anchor)) {
-      return;
-    }
-
-    const sync = () => {
-      anchor.style.width = `${parent.clientWidth}px`;
-      anchor.style.height = `${parent.clientHeight}px`;
-    };
-    sync();
-
-    const ro = new ResizeObserver(sync);
-    ro.observe(parent);
-    return () => ro.disconnect();
-  }, []);
 
   const monoFontFamilyRef = useRef(monoFontFamily);
   const monoFontSizeRef = useRef(monoFontSize);
@@ -122,17 +103,6 @@ export function TerminalPanel(props: IDockviewPanelProps) {
       }
       lastFrame = key;
       window.pier.terminal.setFrame(panelId, frame);
-    };
-
-    let rafId = 0;
-    const scheduleSync = () => {
-      if (rafId) {
-        return;
-      }
-      rafId = requestAnimationFrame(() => {
-        rafId = 0;
-        sendFrameNow();
-      });
     };
 
     const init = async () => {
@@ -186,12 +156,7 @@ export function TerminalPanel(props: IDockviewPanelProps) {
         })
       );
 
-      const parent = anchor.parentElement;
-      if (parent) {
-        const ro = new ResizeObserver(scheduleSync);
-        ro.observe(parent);
-        subscriptions.push({ dispose: () => ro.disconnect() });
-      }
+      subscriptions.push(api.onDidDimensionsChange(sendFrameNow));
 
       const onWindowResize = () => sendFrameNow();
       window.addEventListener("resize", onWindowResize);
@@ -204,9 +169,6 @@ export function TerminalPanel(props: IDockviewPanelProps) {
 
     return () => {
       disposed = true;
-      if (rafId) {
-        cancelAnimationFrame(rafId);
-      }
       for (const s of subscriptions) {
         s.dispose();
       }
@@ -248,8 +210,8 @@ export function TerminalPanel(props: IDockviewPanelProps) {
   }
 
   return (
-    <div className="h-full" ref={parentRef}>
-      <div className="terminal-anchor" ref={anchorRef} />
+    <div className="relative h-full min-h-0 w-full min-w-0 overflow-hidden">
+      <div className="terminal-anchor absolute inset-0" ref={anchorRef} />
     </div>
   );
 }

--- a/src/renderer/panel-kits/terminal/terminal-panel.tsx
+++ b/src/renderer/panel-kits/terminal/terminal-panel.tsx
@@ -1,24 +1,20 @@
-import type { TerminalFrame } from "@shared/contracts/terminal.ts";
 import type { IDockviewPanelProps } from "dockview-react";
 import { useEffect, useRef, useState } from "react";
 import { usePanelDescriptor } from "@/hooks/use-panel-descriptor.ts";
 import { usePanelEventState } from "@/hooks/use-panel-event-state.ts";
 import { popupContextMenuAt } from "@/lib/context-menu/use-context-menu.ts";
 import { computeMonoFontFamily, useFontStore } from "@/stores/font.store.ts";
-
-function getAnchorFrame(anchor: HTMLDivElement): TerminalFrame | null {
-  const r = anchor.getBoundingClientRect();
-  if (r.width < 10 || r.height < 10) {
-    return null;
-  }
-  return { x: r.x, y: r.y, width: r.width, height: r.height };
-}
+import {
+  readTerminalAnchorFrame,
+  registerTerminalLayoutAnchor,
+  type TerminalLayoutRegistration,
+} from "./terminal-layout-coordinator.ts";
 
 function waitForRealSize(anchor: HTMLDivElement): Promise<void> {
   return new Promise((resolve) => {
     const check = () => {
-      const r = anchor.getBoundingClientRect();
-      if (r.width > 100 && r.height > 100) {
+      const frame = readTerminalAnchorFrame(anchor);
+      if (frame && frame.width > 100 && frame.height > 100) {
         resolve();
         return;
       }
@@ -87,22 +83,13 @@ export function TerminalPanel(props: IDockviewPanelProps) {
 
     let disposed = false;
     const subscriptions: Array<{ dispose(): void }> = [];
-    let lastFrame = "";
+    let layoutRegistration: TerminalLayoutRegistration | null = null;
 
     const sendFrameNow = () => {
       if (disposed) {
         return;
       }
-      const frame = getAnchorFrame(anchor);
-      if (!frame) {
-        return;
-      }
-      const key = `${frame.x},${frame.y},${frame.width},${frame.height}`;
-      if (key === lastFrame) {
-        return;
-      }
-      lastFrame = key;
-      window.pier.terminal.setFrame(panelId, frame);
+      layoutRegistration?.flushNow("dockview-dimensions");
     };
 
     const init = async () => {
@@ -111,7 +98,7 @@ export function TerminalPanel(props: IDockviewPanelProps) {
         return;
       }
 
-      const frame = getAnchorFrame(anchor);
+      const frame = readTerminalAnchorFrame(anchor);
       if (!frame) {
         setError("无法获取面板坐标");
         return;
@@ -130,11 +117,12 @@ export function TerminalPanel(props: IDockviewPanelProps) {
         return;
       }
 
+      layoutRegistration = registerTerminalLayoutAnchor(panelId, anchor);
+
       subscriptions.push(
         api.onDidVisibilityChange((e) => {
           if (e.isVisible) {
-            lastFrame = ""; // 强制重发 frame, 终端可能在 offscreen
-            sendFrameNow();
+            layoutRegistration?.flushTrailing("visibility");
             window.pier.terminal.show(panelId);
           } else {
             requestAnimationFrame(() => {
@@ -157,12 +145,6 @@ export function TerminalPanel(props: IDockviewPanelProps) {
       );
 
       subscriptions.push(api.onDidDimensionsChange(sendFrameNow));
-
-      const onWindowResize = () => sendFrameNow();
-      window.addEventListener("resize", onWindowResize);
-      subscriptions.push({
-        dispose: () => window.removeEventListener("resize", onWindowResize),
-      });
     };
 
     init();
@@ -172,6 +154,7 @@ export function TerminalPanel(props: IDockviewPanelProps) {
       for (const s of subscriptions) {
         s.dispose();
       }
+      layoutRegistration?.dispose();
     };
   }, [api, panelId]);
 

--- a/src/renderer/stores/terminal-overlay.store.ts
+++ b/src/renderer/stores/terminal-overlay.store.ts
@@ -22,8 +22,8 @@ export function popOverlay(): void {
 
 /**
  * 全局拖拽监听: 在 dockview tab (HTML5 drag) / sash (pointer drag) 启动时 push overlay,
- * 结束时 pop。确保拖拽期间 EventRouter 不截获事件, 并隐藏 terminal NSView 让 web
- * 层 drop overlay / sash 高亮可见。
+ * 结束时 pop。确保拖拽期间 EventRouter 不截获事件, 让 web 层 drop overlay / sash
+ * 高亮能接收输入并稳定显示在 terminal 上方。
  *
  * 两套独立监听 (HTML5 drag 与 pointer drag 是不同事件流):
  *   - dragstart/dragend: tab 拖拽 (dockview 走 HTML5 drag API)

--- a/src/renderer/stores/theme.store.ts
+++ b/src/renderer/stores/theme.store.ts
@@ -35,15 +35,6 @@ export function resolveTheme(preference: ThemePreference): ResolvedTheme {
   return prefersDark ? "dark" : "light";
 }
 
-/** 从 applyTokens 写入的 inline style 读取 --muted (sidebar/tab-bar 底色). */
-function readChromeColor(): string | undefined {
-  if (typeof document === "undefined") {
-    return;
-  }
-  const val = document.documentElement.style.getPropertyValue("--muted").trim();
-  return val || undefined;
-}
-
 function applyDocumentTheme(resolved: ResolvedTheme): void {
   if (typeof document === "undefined") {
     return;
@@ -52,9 +43,6 @@ function applyDocumentTheme(resolved: ResolvedTheme): void {
   root.classList.toggle("light", resolved === "light");
   root.classList.toggle("dark", resolved === "dark");
   syncThemeHead({ resolved });
-  window.pier?.theme
-    ?.setNativeChrome?.(resolved, readChromeColor())
-    ?.catch(() => undefined);
 }
 
 /**
@@ -89,6 +77,9 @@ function flushPendingTerminalApply(): void {
     const shiki = getShikiTheme(pending.presetId, pending.resolved);
     const colors = deriveTerminalColors(shiki, pending.resolved);
     window.pier?.terminal?.applyTheme?.(colors);
+    window.pier?.theme
+      ?.setNativeChrome?.(pending.resolved, colors.background)
+      ?.catch(() => undefined);
   } catch (err) {
     console.error("[theme.store] applyTerminalColors failed:", err);
   }
@@ -169,9 +160,6 @@ export const useThemeStore = create<ThemeState>((set) => ({
       const currentResolved = useThemeStore.getState().resolvedTheme;
       applyTokens({ presetId: nextPreset, resolved: currentResolved });
       syncThemeHead({ resolved: currentResolved });
-      window.pier?.theme
-        ?.setNativeChrome?.(currentResolved, readChromeColor())
-        ?.catch(() => undefined);
       applyTerminalColors(nextPreset, currentResolved);
       set({
         stylePresetId: nextPreset,

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -14,6 +14,8 @@ export const PIER = {
 } as const;
 
 export const PIER_BROADCAST = {
+  // 原生窗口几何变化后触发 renderer 补发 overlay / native view layout.
+  WINDOW_LAYOUT_PULSE: "pier:window:layout-pulse",
   // macOS 原生全屏进出 (main → renderer, payload { isFullscreen }).
   WINDOW_FULLSCREEN_CHANGED: "pier://window:fullscreen-changed",
 } as const;

--- a/tests/component/command-dialog-overlay.test.tsx
+++ b/tests/component/command-dialog-overlay.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { CommandDialog } from "@/components/primitives/command.tsx";
+import { Dialog, DialogContent } from "@/components/primitives/dialog.tsx";
+
+describe("CommandDialog overlay", () => {
+  it("keeps the command palette backdrop transparent so the native terminal stays visible", () => {
+    render(
+      <CommandDialog open>
+        <div>Palette content</div>
+      </CommandDialog>
+    );
+
+    const overlay = document.querySelector('[data-slot="dialog-overlay"]');
+
+    expect(overlay).toBeInstanceOf(HTMLElement);
+    expect(overlay?.className).toContain("bg-transparent");
+    expect(overlay?.className).toContain("backdrop-blur-none");
+    expect(overlay?.className).not.toContain("bg-black/30");
+    expect(overlay?.className).not.toContain("backdrop-blur-sm");
+    expect(screen.getByText("Palette content")).toBeDefined();
+  });
+
+  it("does not change the default dialog backdrop", () => {
+    render(
+      <Dialog open>
+        <DialogContent>
+          <div>Dialog content</div>
+        </DialogContent>
+      </Dialog>
+    );
+
+    const overlay = document.querySelector('[data-slot="dialog-overlay"]');
+
+    expect(overlay).toBeInstanceOf(HTMLElement);
+    expect(overlay?.className).toContain("bg-black/30");
+    expect(overlay?.className).toContain("backdrop-blur-sm");
+    expect(screen.getByText("Dialog content")).toBeDefined();
+  });
+});

--- a/tests/component/terminal-panel-lifecycle.test.tsx
+++ b/tests/component/terminal-panel-lifecycle.test.tsx
@@ -4,24 +4,45 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TerminalPanel } from "@/panel-kits/terminal/terminal-panel.tsx";
 
 class TestResizeObserver {
+  static observeCount = 0;
+
   observe() {
-    // Test no-op.
+    TestResizeObserver.observeCount += 1;
   }
   disconnect() {
     // Test no-op.
   }
 }
 
-function createPanelProps(): IDockviewPanelProps {
-  return {
+interface TestPanelProps extends IDockviewPanelProps {
+  emitDimensions(event: { height: number; width: number }): void;
+}
+
+function createPanelProps(): TestPanelProps {
+  let onDidDimensionsChange:
+    | ((event: { height: number; width: number }) => void)
+    | null = null;
+  const props = {
     api: {
+      height: 300,
       id: "terminal-1",
       onDidActiveChange: vi.fn(() => ({ dispose: vi.fn() })),
+      onDidDimensionsChange: vi.fn(
+        (listener: (event: { height: number; width: number }) => void) => {
+          onDidDimensionsChange = listener;
+          return { dispose: vi.fn() };
+        }
+      ),
       onDidVisibilityChange: vi.fn(() => ({ dispose: vi.fn() })),
       setTitle: vi.fn(),
+      width: 400,
     },
     containerApi: {},
-  } as unknown as IDockviewPanelProps;
+    emitDimensions(event: { height: number; width: number }) {
+      onDidDimensionsChange?.(event);
+    },
+  };
+  return props as unknown as TestPanelProps;
 }
 
 describe("TerminalPanel lifecycle", () => {
@@ -29,6 +50,7 @@ describe("TerminalPanel lifecycle", () => {
     HTMLElement.prototype.getBoundingClientRect;
 
   beforeEach(() => {
+    TestResizeObserver.observeCount = 0;
     vi.stubGlobal("ResizeObserver", TestResizeObserver);
     vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) =>
       window.setTimeout(() => cb(performance.now()), 0)
@@ -91,5 +113,33 @@ describe("TerminalPanel lifecycle", () => {
     unmount();
 
     expect(window.pier.terminal.close).not.toHaveBeenCalled();
+  });
+
+  it("uses dockview dimension events instead of ResizeObserver for terminal frame updates", async () => {
+    const props = createPanelProps();
+
+    render(<TerminalPanel {...props} />);
+
+    await waitFor(() => {
+      expect(window.pier.terminal.create).toHaveBeenCalledWith(
+        expect.objectContaining({ panelId: "terminal-1" })
+      );
+    });
+    vi.mocked(window.pier.terminal.setFrame).mockClear();
+
+    props.emitDimensions({ height: 340, width: 460 });
+
+    await waitFor(() => {
+      expect(window.pier.terminal.setFrame).toHaveBeenCalledWith(
+        "terminal-1",
+        expect.objectContaining({
+          height: 300,
+          width: 400,
+          x: 10,
+          y: 20,
+        })
+      );
+    });
+    expect(TestResizeObserver.observeCount).toBe(0);
   });
 });

--- a/tests/component/terminal-panel-lifecycle.test.tsx
+++ b/tests/component/terminal-panel-lifecycle.test.tsx
@@ -5,12 +5,22 @@ import { TerminalPanel } from "@/panel-kits/terminal/terminal-panel.tsx";
 
 class TestResizeObserver {
   static observeCount = 0;
+  static instances: TestResizeObserver[] = [];
+  private readonly cb: ResizeObserverCallback;
+
+  constructor(cb: ResizeObserverCallback) {
+    this.cb = cb;
+    TestResizeObserver.instances.push(this);
+  }
 
   observe() {
     TestResizeObserver.observeCount += 1;
   }
   disconnect() {
     // Test no-op.
+  }
+  emit() {
+    this.cb([], this as unknown as ResizeObserver);
   }
 }
 
@@ -48,9 +58,26 @@ function createPanelProps(): TestPanelProps {
 describe("TerminalPanel lifecycle", () => {
   const originalGetBoundingClientRect =
     HTMLElement.prototype.getBoundingClientRect;
+  let anchorFrame = {
+    height: 300,
+    width: 400,
+    x: 10,
+    y: 20,
+  };
+  let emitWindowLayoutPulse:
+    | ((pulse: { reason: "resize" | "zoom" }) => void)
+    | null = null;
 
   beforeEach(() => {
+    anchorFrame = {
+      height: 300,
+      width: 400,
+      x: 10,
+      y: 20,
+    };
+    emitWindowLayoutPulse = null;
     TestResizeObserver.observeCount = 0;
+    TestResizeObserver.instances = [];
     vi.stubGlobal("ResizeObserver", TestResizeObserver);
     vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) =>
       window.setTimeout(() => cb(performance.now()), 0)
@@ -62,14 +89,14 @@ describe("TerminalPanel lifecycle", () => {
     HTMLElement.prototype.getBoundingClientRect = function () {
       if (this.classList.contains("terminal-anchor")) {
         return {
-          bottom: 320,
-          height: 300,
-          left: 10,
-          right: 410,
-          top: 20,
-          width: 400,
-          x: 10,
-          y: 20,
+          bottom: anchorFrame.y + anchorFrame.height,
+          height: anchorFrame.height,
+          left: anchorFrame.x,
+          right: anchorFrame.x + anchorFrame.width,
+          top: anchorFrame.y,
+          width: anchorFrame.width,
+          x: anchorFrame.x,
+          y: anchorFrame.y,
           toJSON: () => null,
         } as DOMRect;
       }
@@ -79,6 +106,12 @@ describe("TerminalPanel lifecycle", () => {
     Object.defineProperty(window, "pier", {
       configurable: true,
       value: {
+        onWindowLayoutPulse: vi.fn(
+          (cb: (pulse: { reason: "resize" | "zoom" }) => void) => {
+            emitWindowLayoutPulse = cb;
+            return vi.fn();
+          }
+        ),
         terminal: {
           close: vi.fn(),
           create: vi.fn(async () => ({ ok: true })),
@@ -115,7 +148,7 @@ describe("TerminalPanel lifecycle", () => {
     expect(window.pier.terminal.close).not.toHaveBeenCalled();
   });
 
-  it("uses dockview dimension events instead of ResizeObserver for terminal frame updates", async () => {
+  it("uses dockview dimension events and anchor resize observations for terminal frame updates", async () => {
     const props = createPanelProps();
 
     render(<TerminalPanel {...props} />);
@@ -140,6 +173,58 @@ describe("TerminalPanel lifecycle", () => {
         })
       );
     });
-    expect(TestResizeObserver.observeCount).toBe(0);
+    expect(TestResizeObserver.observeCount).toBe(1);
+
+    vi.mocked(window.pier.terminal.setFrame).mockClear();
+    anchorFrame = {
+      height: 340,
+      width: 460,
+      x: 10,
+      y: 20,
+    };
+    TestResizeObserver.instances[0]?.emit();
+
+    await waitFor(() => {
+      expect(window.pier.terminal.setFrame).toHaveBeenCalledWith(
+        "terminal-1",
+        expect.objectContaining({
+          height: 340,
+          width: 460,
+          x: 10,
+          y: 20,
+        })
+      );
+    });
+  });
+
+  it("sends a trailing native frame after window layout pulses settle", async () => {
+    render(<TerminalPanel {...createPanelProps()} />);
+
+    await waitFor(() => {
+      expect(window.pier.terminal.create).toHaveBeenCalledWith(
+        expect.objectContaining({ panelId: "terminal-1" })
+      );
+    });
+    vi.mocked(window.pier.terminal.setFrame).mockClear();
+
+    emitWindowLayoutPulse?.({ reason: "zoom" });
+    anchorFrame = {
+      height: 620,
+      width: 900,
+      x: 10,
+      y: 20,
+    };
+
+    await waitFor(() => {
+      expect(window.pier.terminal.setFrame).toHaveBeenCalledWith(
+        "terminal-1",
+        expect.objectContaining({
+          height: 620,
+          width: 900,
+          x: 10,
+          y: 20,
+        })
+      );
+    });
   });
 });

--- a/tests/unit/main/devtools.test.ts
+++ b/tests/unit/main/devtools.test.ts
@@ -21,10 +21,16 @@ import {
 describe("detached DevTools", () => {
   function fakeWindow(isOpen = false) {
     return {
+      focus: vi.fn(),
+      isDestroyed: () => false,
+      isMinimized: () => false,
+      moveTop: vi.fn(),
+      restore: vi.fn(),
       webContents: {
         closeDevTools: vi.fn(),
         isDestroyed: () => false,
         isDevToolsOpened: () => isOpen,
+        on: vi.fn(),
         openDevTools: vi.fn(),
       },
     };

--- a/tests/unit/main/terminal-focus.test.ts
+++ b/tests/unit/main/terminal-focus.test.ts
@@ -29,7 +29,7 @@ describe("terminal focus restoration", () => {
       setPwdForwardCallback: vi.fn(),
       setTerminalFont: vi.fn(),
       setTitleForwardCallback: vi.fn(),
-      setupWindow: vi.fn(),
+      setupWindow: vi.fn(() => true),
       showTerminal: vi.fn(),
     };
     const createFakeWindow = (focused = true) => ({
@@ -40,6 +40,7 @@ describe("terminal focus restoration", () => {
       isFocused: () => focused,
       isMinimized: () => false,
       restore: vi.fn(),
+      setBackgroundColor: vi.fn(),
       webContents: {
         focus: vi.fn(),
         isDestroyed: () => false,
@@ -60,10 +61,7 @@ describe("terminal focus restoration", () => {
     };
 
     vi.doMock("electron", () => ({
-      BrowserWindow: {
-        fromId: vi.fn((id: number) => (id === ipcWindow.id ? ipcWindow : null)),
-        fromWebContents: vi.fn(() => ipcWindow),
-      },
+      // terminal.ts only imports Electron types at runtime now.
     }));
     vi.doMock("node:module", () => ({
       createRequire: vi.fn(() => vi.fn(() => fakeAddon)),
@@ -79,7 +77,11 @@ describe("terminal focus restoration", () => {
       updateTerminalPanelCwd: vi.fn(async () => undefined),
     }));
     vi.doMock("@main/windows/window-identity.ts", () => ({
-      findBrowserWindowId: vi.fn(() => "main"),
+      findAppWindowByElectronId: vi.fn((id: number) =>
+        id === ipcWindow.id ? ipcWindow : null
+      ),
+      findAppWindowByWebContents: vi.fn(() => ipcWindow),
+      findInternalWindowId: vi.fn(() => "main"),
     }));
 
     const { registerTerminalIpc, restoreActivePanelFocus } = await import(
@@ -196,6 +198,22 @@ describe("terminal focus restoration", () => {
       "Menlo",
       13,
       "/Users/xyz/ABC/pier"
+    );
+  });
+
+  it("does not make the host window transparent during terminal setup", async () => {
+    const { fakeAddon, invokeHandlers, ipcWindow } =
+      await setupTerminalFocusHarness();
+
+    const result = invokeHandlers.get("pier:terminal:setup")?.({
+      sender: ipcWindow.webContents,
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(ipcWindow.setBackgroundColor).not.toHaveBeenCalled();
+    expect(fakeAddon.setupWindow).toHaveBeenCalledWith(
+      Buffer.from("window"),
+      ipcWindow.id
     );
   });
 

--- a/tests/unit/main/terminal-session-state.test.ts
+++ b/tests/unit/main/terminal-session-state.test.ts
@@ -56,4 +56,30 @@ describe("terminal session state", () => {
       readTerminalPanelSession("main", "terminal-1")
     ).resolves.toBeNull();
   });
+
+  it("serializes concurrent cwd updates without dropping panel sessions", async () => {
+    const { readTerminalPanelSession, updateTerminalPanelCwd } = await import(
+      "@main/state/terminal-session-state.ts"
+    );
+
+    await expect(
+      Promise.all(
+        Array.from({ length: 20 }, (_, index) =>
+          updateTerminalPanelCwd(
+            "main",
+            `terminal-${index}`,
+            `/tmp/pier-terminal-${index}`
+          )
+        )
+      )
+    ).resolves.toHaveLength(20);
+
+    for (let index = 0; index < 20; index += 1) {
+      await expect(
+        readTerminalPanelSession("main", `terminal-${index}`)
+      ).resolves.toMatchObject({
+        cwd: `/tmp/pier-terminal-${index}`,
+      });
+    }
+  });
 });

--- a/tests/unit/main/window-manager-webcontents-view.test.ts
+++ b/tests/unit/main/window-manager-webcontents-view.test.ts
@@ -184,5 +184,26 @@ describe.runIf(process.platform === "darwin")(
       }).not.toThrow();
       expect(findAppWindowByElectronId(42)).toBeNull();
     });
+
+    it("notifies the renderer after native window geometry changes", async () => {
+      const { windowManager } = await import("@main/windows/window-manager.ts");
+
+      windowManager.create({ id: "main" });
+      electronMock.webContents.send.mockClear();
+
+      electronMock.hostListeners.get("resize")?.();
+      electronMock.hostListeners.get("maximize")?.();
+      electronMock.hostListeners.get("unmaximize")?.();
+
+      expect(electronMock.webContents.send).toHaveBeenCalledWith(
+        "pier:window:layout-pulse",
+        { reason: "resize" }
+      );
+      expect(electronMock.webContents.send).toHaveBeenCalledWith(
+        "pier:window:layout-pulse",
+        { reason: "zoom" }
+      );
+      expect(electronMock.webContents.send).toHaveBeenCalledTimes(3);
+    });
   }
 );

--- a/tests/unit/main/window-manager-webcontents-view.test.ts
+++ b/tests/unit/main/window-manager-webcontents-view.test.ts
@@ -1,0 +1,188 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const electronMock = vi.hoisted(() => {
+  const hostListeners = new Map<string, (...args: never[]) => void>();
+  const webListeners = new Map<string, (...args: never[]) => void>();
+  const webOnceListeners = new Map<string, (...args: never[]) => void>();
+  const state = {
+    throwWhenReadingWindowId: false,
+  };
+
+  const webContents = {
+    close: vi.fn(),
+    focus: vi.fn(),
+    isDestroyed: vi.fn(() => false),
+    loadFile: vi.fn(async () => undefined),
+    loadURL: vi.fn(async () => undefined),
+    on: vi.fn((event: string, listener: (...args: never[]) => void) => {
+      webListeners.set(event, listener);
+      return webContents;
+    }),
+    once: vi.fn((event: string, listener: (...args: never[]) => void) => {
+      webOnceListeners.set(event, listener);
+      return webContents;
+    }),
+    send: vi.fn(),
+    setWindowOpenHandler: vi.fn(),
+  };
+
+  const appView = {
+    setBackgroundColor: vi.fn(),
+    setBounds: vi.fn(),
+    webContents,
+  };
+
+  const baseWindow = {
+    close: vi.fn(),
+    contentView: {
+      addChildView: vi.fn(),
+    },
+    focus: vi.fn(),
+    getContentSize: vi.fn(() => [1280, 800]),
+    getNativeWindowHandle: vi.fn(() => Buffer.from("window")),
+    get id() {
+      if (state.throwWhenReadingWindowId) {
+        throw new TypeError("Object has been destroyed");
+      }
+      return 42;
+    },
+    isDestroyed: vi.fn(() => false),
+    isFocused: vi.fn(() => true),
+    isMinimized: vi.fn(() => false),
+    moveTop: vi.fn(),
+    on: vi.fn((event: string, listener: (...args: never[]) => void) => {
+      hostListeners.set(event, listener);
+      return baseWindow;
+    }),
+    restore: vi.fn(),
+    setBackgroundColor: vi.fn(),
+    show: vi.fn(),
+  };
+
+  const browserWindowCtor = vi.fn(function BrowserWindow() {
+    throw new Error("BrowserWindow should not be used on macOS");
+  });
+
+  return {
+    appView,
+    baseWindow,
+    browserWindowCtor,
+    hostListeners,
+    state,
+    webContents,
+    webListeners,
+    webOnceListeners,
+  };
+});
+
+vi.mock("electron", () => ({
+  app: {
+    isPackaged: false,
+  },
+  BaseWindow: vi.fn(function BaseWindow() {
+    return electronMock.baseWindow;
+  }),
+  BrowserWindow: Object.assign(electronMock.browserWindowCtor, {
+    fromId: vi.fn(),
+    getAllWindows: vi.fn(() => []),
+    getFocusedWindow: vi.fn(() => null),
+  }),
+  nativeTheme: {
+    shouldUseDarkColors: true,
+  },
+  shell: {
+    openExternal: vi.fn(async () => undefined),
+  },
+  WebContentsView: vi.fn(function WebContentsView() {
+    return electronMock.appView;
+  }),
+}));
+
+describe.runIf(process.platform === "darwin")(
+  "macOS window manager WebContentsView hosting",
+  () => {
+    beforeEach(() => {
+      vi.resetModules();
+      vi.clearAllMocks();
+      electronMock.hostListeners.clear();
+      electronMock.state.throwWhenReadingWindowId = false;
+      electronMock.webListeners.clear();
+      electronMock.webOnceListeners.clear();
+      vi.stubEnv("ELECTRON_RENDERER_URL", "http://127.0.0.1:5173");
+    });
+
+    it("creates an opaque BaseWindow with a transparent full-window WebContentsView", async () => {
+      const electron = await import("electron");
+      const { windowManager } = await import("@main/windows/window-manager.ts");
+
+      windowManager.create({ id: "main" });
+
+      expect(electron.BaseWindow).toHaveBeenCalledWith(
+        expect.objectContaining({
+          backgroundColor: "#1e1e1e",
+          show: false,
+          titleBarStyle: "hiddenInset",
+        })
+      );
+      expect(electron.BrowserWindow).not.toHaveBeenCalled();
+      expect(electron.WebContentsView).toHaveBeenCalledWith(
+        expect.objectContaining({
+          webPreferences: expect.objectContaining({
+            additionalArguments: ["--window-id=main"],
+            contextIsolation: true,
+            nodeIntegration: false,
+            preload: expect.stringContaining("preload/index.cjs"),
+            sandbox: true,
+          }),
+        })
+      );
+      expect(
+        electronMock.baseWindow.contentView.addChildView
+      ).toHaveBeenCalledWith(electronMock.appView);
+      expect(electronMock.appView.setBackgroundColor).toHaveBeenCalledWith(
+        "#00000000"
+      );
+      expect(electronMock.appView.setBounds).toHaveBeenCalledWith({
+        height: 800,
+        width: 1280,
+        x: 0,
+        y: 0,
+      });
+    });
+
+    it("maps renderer webContents back to the owning app window", async () => {
+      const { windowManager } = await import("@main/windows/window-manager.ts");
+
+      windowManager.create({ id: "main" });
+      const win = windowManager.get("main");
+
+      expect(
+        windowManager.fromWebContents(electronMock.webContents as never)
+      ).toBe(win);
+    });
+
+    it("closes the hosted webContents when the BaseWindow closes", async () => {
+      const { windowManager } = await import("@main/windows/window-manager.ts");
+
+      windowManager.create({ id: "main" });
+      electronMock.hostListeners.get("closed")?.();
+
+      expect(electronMock.webContents.close).toHaveBeenCalledOnce();
+    });
+
+    it("does not read the Electron id after a destroyed BaseWindow emits closed", async () => {
+      const { windowManager } = await import("@main/windows/window-manager.ts");
+      const { findAppWindowByElectronId } = await import(
+        "@main/windows/window-identity.ts"
+      );
+
+      windowManager.create({ id: "main" });
+      electronMock.state.throwWhenReadingWindowId = true;
+
+      expect(() => {
+        electronMock.hostListeners.get("closed")?.();
+      }).not.toThrow();
+      expect(findAppWindowByElectronId(42)).toBeNull();
+    });
+  }
+);

--- a/tests/unit/renderer/stores/theme-store-native-chrome.test.ts
+++ b/tests/unit/renderer/stores/theme-store-native-chrome.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { deriveTerminalColors } from "@/lib/theme/derive-terminal-colors.ts";
+import { getShikiTheme } from "@/lib/theme/preset-registry.ts";
+
+describe("theme store native chrome backing", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+      cb(performance.now());
+      return 1;
+    });
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+    document.documentElement.removeAttribute("style");
+    document.documentElement.className = "";
+    Object.defineProperty(window, "pier", {
+      configurable: true,
+      value: {
+        terminal: {
+          applyTheme: vi.fn(),
+        },
+        theme: {
+          setNativeChrome: vi.fn(async () => undefined),
+        },
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("uses the terminal background as the macOS backing color", async () => {
+    const { applyThemeVisual } = await import("@/stores/theme.store.ts");
+    const expected = deriveTerminalColors(
+      getShikiTheme("pierre", "dark"),
+      "dark"
+    ).background;
+
+    applyThemeVisual("dark", "pierre");
+
+    expect(window.pier.theme.setNativeChrome).toHaveBeenLastCalledWith(
+      "dark",
+      expected
+    );
+  });
+});

--- a/tests/unit/renderer/styles/dockview-scrollbar-css.test.ts
+++ b/tests/unit/renderer/styles/dockview-scrollbar-css.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("Pier dockview resize scrollbar CSS", () => {
+  it("hides dockview web scrollbars during live resize", () => {
+    const css = readFileSync(
+      join(process.cwd(), "src/renderer/app/globals.css"),
+      "utf8"
+    );
+
+    expect(css).toContain(
+      ".dockview-theme-pier .dv-scrollable.dv-scrollable-resizing .dv-scrollbar"
+    );
+    expect(css).toContain("opacity: 0");
+    expect(css).toContain("pointer-events: none");
+  });
+});


### PR DESCRIPTION
## Summary
- Tighten the native terminal window lifecycle across main, preload, renderer, and Ghostty bridge layers
- Improve resize, focus, and live-resize prediction handling for terminal panels
- Align overlay, theme, and app-shell behavior with the native chrome path
- Add and update unit/component coverage for terminal session state, window management, and terminal panel lifecycle

## Testing
- Updated unit tests for main-process terminal focus, session state, devtools, and window manager behavior
- Updated renderer tests for terminal panel lifecycle, overlay behavior, theme/native chrome styling, and command dialog rendering
- Added native bridge tests for host resize and live-resize prediction logic