### PR TITLE
[codex] Preserve terminal input after panel drag

### DIFF
--- a/native/Tests/GhosttyBridgeTests/TerminalHostResizeTests.swift
+++ b/native/Tests/GhosttyBridgeTests/TerminalHostResizeTests.swift
@@ -30,4 +30,43 @@ final class TerminalHostResizeTests: XCTestCase {
             NSRect(x: 466, y: 0, width: 14, height: 320)
         )
     }
+
+    func testTerminalContainerHitTargetRoutesScrollbarOnlyWhenScrollable() {
+        let bounds = NSRect(x: 0, y: 0, width: 480, height: 320)
+        let scrollbarPoint = NSPoint(x: 472, y: 160)
+        let terminalPoint = NSPoint(x: 120, y: 160)
+        let outsidePoint = NSPoint(x: 500, y: 160)
+
+        XCTAssertEqual(
+            TerminalContainerLayout.hitTarget(
+                at: scrollbarPoint,
+                in: bounds,
+                scrollbarActive: true
+            ),
+            .scrollbar
+        )
+        XCTAssertEqual(
+            TerminalContainerLayout.hitTarget(
+                at: scrollbarPoint,
+                in: bounds,
+                scrollbarActive: false
+            ),
+            .terminal
+        )
+        XCTAssertEqual(
+            TerminalContainerLayout.hitTarget(
+                at: terminalPoint,
+                in: bounds,
+                scrollbarActive: true
+            ),
+            .terminal
+        )
+        XCTAssertNil(
+            TerminalContainerLayout.hitTarget(
+                at: outsidePoint,
+                in: bounds,
+                scrollbarActive: true
+            )
+        )
+    }
 }

--- a/src/renderer/panel-kits/terminal/terminal-panel.tsx
+++ b/src/renderer/panel-kits/terminal/terminal-panel.tsx
@@ -119,11 +119,18 @@ export function TerminalPanel(props: IDockviewPanelProps) {
 
       layoutRegistration = registerTerminalLayoutAnchor(panelId, anchor);
 
+      const focusIfActive = () => {
+        if (api.isActive && api.isVisible) {
+          window.pier.terminal.focus(panelId);
+        }
+      };
+
       subscriptions.push(
         api.onDidVisibilityChange((e) => {
           if (e.isVisible) {
             layoutRegistration?.flushTrailing("visibility");
             window.pier.terminal.show(panelId);
+            focusIfActive();
           } else {
             // 直接发 hide IPC. swift hide 总是执行 (移 offscreen + remove targets),
             // 由后续 setFrame 把 NSView 移回新位置自动恢复 visible (drag 场景), 或者
@@ -133,6 +140,17 @@ export function TerminalPanel(props: IDockviewPanelProps) {
             // 变成 hidden. 直接 hide + 不延迟最干净.
             window.pier.terminal.hide(panelId);
           }
+        })
+      );
+
+      subscriptions.push(
+        api.onDidGroupChange(() => {
+          if (!(api.isActive && api.isVisible)) {
+            return;
+          }
+          layoutRegistration?.flushTrailing("dockview-layout");
+          window.pier.terminal.show(panelId);
+          window.pier.terminal.focus(panelId);
         })
       );
 

--- a/src/renderer/stores/terminal-overlay.store.ts
+++ b/src/renderer/stores/terminal-overlay.store.ts
@@ -6,6 +6,12 @@
  *   - dockview drag (tab 拖拽 / sash 调整): installDragWatcher 自动管理
  */
 let overlayCount = 0;
+const TAB_DRAG_FALLBACK_MS = 5000;
+const DRAG_WATCHER_CLEANUP_KEY = "__pierTerminalDragWatcherCleanup__";
+
+interface DragWatcherDocument extends Document {
+  [DRAG_WATCHER_CLEANUP_KEY]?: () => void;
+}
 
 export function pushOverlay(): void {
   if (++overlayCount === 1) {
@@ -35,55 +41,128 @@ export function installDragWatcher(): void {
   if (dragWatcherInstalled) {
     return;
   }
+  const watcherDocument = document as DragWatcherDocument;
+  watcherDocument[DRAG_WATCHER_CLEANUP_KEY]?.();
   dragWatcherInstalled = true;
 
   // HTML5 drag (tab): dragstart 是 panel/tab 拖拽的唯一可靠信号, pointerdown 在
   // Electron + macOS 上不一定能可靠触达 web (mouse events 被 EventRouter / NSView 抢)
   let dragActive = false;
-  document.addEventListener(
-    "dragstart",
-    (e) => {
-      const t = e.target as HTMLElement | null;
-      if (!t?.closest?.(".dv-tab")) {
-        return;
-      }
-      if (dragActive) {
-        return;
-      }
-      dragActive = true;
-      pushOverlay();
-    },
-    true
-  );
-  document.addEventListener(
-    "dragend",
-    () => {
-      if (!dragActive) {
-        return;
-      }
-      dragActive = false;
-      popOverlay();
-    },
-    true
-  );
+  let dragFallbackTimer: number | null = null;
+
+  const clearDragFallback = () => {
+    if (dragFallbackTimer === null) {
+      return;
+    }
+    window.clearTimeout(dragFallbackTimer);
+    dragFallbackTimer = null;
+  };
+
+  const endTabDrag = () => {
+    if (!dragActive) {
+      return;
+    }
+    dragActive = false;
+    clearDragFallback();
+    popOverlay();
+  };
+
+  const armDragFallback = () => {
+    clearDragFallback();
+    dragFallbackTimer = window.setTimeout(endTabDrag, TAB_DRAG_FALLBACK_MS);
+  };
+
+  const beginTabDrag = () => {
+    if (dragActive) {
+      return;
+    }
+    dragActive = true;
+    pushOverlay();
+    armDragFallback();
+  };
+
+  const onDragStart = (e: DragEvent) => {
+    const t = e.target as HTMLElement | null;
+    if (!t?.closest?.(".dv-tab")) {
+      return;
+    }
+    beginTabDrag();
+  };
+
+  const onDrop = () => {
+    if (!dragActive) {
+      return;
+    }
+    window.setTimeout(endTabDrag, 0);
+  };
+
+  const onVisibilityChange = () => {
+    if (document.visibilityState === "hidden") {
+      endTabDrag();
+    }
+  };
+
+  const onKeyDown = (e: KeyboardEvent) => {
+    if (e.key === "Escape") {
+      endTabDrag();
+    }
+  };
+
+  document.addEventListener("dragstart", onDragStart, true);
+  document.addEventListener("dragend", endTabDrag, true);
+  document.addEventListener("drop", onDrop, true);
+  document.addEventListener("visibilitychange", onVisibilityChange, true);
+  window.addEventListener("blur", endTabDrag);
+  window.addEventListener("keydown", onKeyDown, true);
 
   // Sash / resize handle 走 pointer events, 没有 HTML5 drag
-  document.addEventListener(
-    "pointerdown",
-    (e) => {
-      const t = e.target as HTMLElement;
-      if (!(t.closest(".dv-sash") || t.closest(".dv-resize-container"))) {
+  let sashDragActive = false;
+  let endSashDrag: (() => void) | null = null;
+  const beginSashDrag = () => {
+    if (sashDragActive) {
+      return;
+    }
+    sashDragActive = true;
+    pushOverlay();
+    const cleanup = () => {
+      if (!sashDragActive) {
         return;
       }
-      pushOverlay();
-      const cleanup = () => {
-        popOverlay();
-        window.removeEventListener("pointerup", cleanup);
-        window.removeEventListener("pointercancel", cleanup);
-      };
-      window.addEventListener("pointerup", cleanup);
-      window.addEventListener("pointercancel", cleanup);
-    },
-    true
-  );
+      sashDragActive = false;
+      popOverlay();
+      window.removeEventListener("pointerup", cleanup);
+      window.removeEventListener("pointercancel", cleanup);
+      window.removeEventListener("blur", cleanup);
+      endSashDrag = null;
+    };
+    endSashDrag = cleanup;
+    window.addEventListener("pointerup", cleanup);
+    window.addEventListener("pointercancel", cleanup);
+    window.addEventListener("blur", cleanup);
+  };
+
+  const onPointerDown = (e: PointerEvent) => {
+    const t = e.target as HTMLElement;
+    if (!(t.closest(".dv-sash") || t.closest(".dv-resize-container"))) {
+      return;
+    }
+    beginSashDrag();
+  };
+
+  document.addEventListener("pointerdown", onPointerDown, true);
+
+  watcherDocument[DRAG_WATCHER_CLEANUP_KEY] = () => {
+    endTabDrag();
+    endSashDrag?.();
+    clearDragFallback();
+    document.removeEventListener("dragstart", onDragStart, true);
+    document.removeEventListener("dragend", endTabDrag, true);
+    document.removeEventListener("drop", onDrop, true);
+    document.removeEventListener("visibilitychange", onVisibilityChange, true);
+    document.removeEventListener("pointerdown", onPointerDown, true);
+    window.removeEventListener("blur", endTabDrag);
+    window.removeEventListener("keydown", onKeyDown, true);
+    dragWatcherInstalled = false;
+    delete watcherDocument[DRAG_WATCHER_CLEANUP_KEY];
+  };
 }

--- a/tests/component/terminal-panel-lifecycle.test.tsx
+++ b/tests/component/terminal-panel-lifecycle.test.tsx
@@ -26,30 +26,71 @@ class TestResizeObserver {
 
 interface TestPanelProps extends IDockviewPanelProps {
   emitDimensions(event: { height: number; width: number }): void;
+  emitGroupChange(): void;
+  emitVisibility(event: { isVisible: boolean }): void;
 }
 
-function createPanelProps(): TestPanelProps {
+function createPanelProps(
+  options: { isActive?: boolean; isVisible?: boolean } = {}
+): TestPanelProps {
+  let isActive = options.isActive ?? false;
+  let isVisible = options.isVisible ?? true;
+  let onDidActiveChange: ((event: { isActive: boolean }) => void) | null = null;
   let onDidDimensionsChange:
     | ((event: { height: number; width: number }) => void)
     | null = null;
+  let onDidGroupChange: (() => void) | null = null;
+  let onDidVisibilityChange: ((event: { isVisible: boolean }) => void) | null =
+    null;
   const props = {
     api: {
       height: 300,
       id: "terminal-1",
-      onDidActiveChange: vi.fn(() => ({ dispose: vi.fn() })),
+      get isActive() {
+        return isActive;
+      },
+      get isVisible() {
+        return isVisible;
+      },
+      onDidActiveChange: vi.fn(
+        (listener: (event: { isActive: boolean }) => void) => {
+          onDidActiveChange = listener;
+          return { dispose: vi.fn() };
+        }
+      ),
       onDidDimensionsChange: vi.fn(
         (listener: (event: { height: number; width: number }) => void) => {
           onDidDimensionsChange = listener;
           return { dispose: vi.fn() };
         }
       ),
-      onDidVisibilityChange: vi.fn(() => ({ dispose: vi.fn() })),
+      onDidGroupChange: vi.fn((listener: () => void) => {
+        onDidGroupChange = listener;
+        return { dispose: vi.fn() };
+      }),
+      onDidVisibilityChange: vi.fn(
+        (listener: (event: { isVisible: boolean }) => void) => {
+          onDidVisibilityChange = listener;
+          return { dispose: vi.fn() };
+        }
+      ),
       setTitle: vi.fn(),
       width: 400,
     },
     containerApi: {},
+    emitGroupChange() {
+      onDidGroupChange?.();
+    },
+    emitActive(event: { isActive: boolean }) {
+      isActive = event.isActive;
+      onDidActiveChange?.(event);
+    },
     emitDimensions(event: { height: number; width: number }) {
       onDidDimensionsChange?.(event);
+    },
+    emitVisibility(event: { isVisible: boolean }) {
+      isVisible = event.isVisible;
+      onDidVisibilityChange?.(event);
     },
   };
   return props as unknown as TestPanelProps;
@@ -226,5 +267,73 @@ describe("TerminalPanel lifecycle", () => {
         })
       );
     });
+  });
+
+  it("refocuses an active native terminal when dockview shows it after tab drag", async () => {
+    const props = createPanelProps({ isActive: true });
+    render(<TerminalPanel {...props} />);
+
+    await waitFor(() => {
+      expect(window.pier.terminal.create).toHaveBeenCalledWith(
+        expect.objectContaining({ panelId: "terminal-1" })
+      );
+    });
+    vi.mocked(window.pier.terminal.focus).mockClear();
+
+    props.emitVisibility({ isVisible: false });
+    props.emitVisibility({ isVisible: true });
+
+    expect(window.pier.terminal.show).toHaveBeenCalledWith("terminal-1");
+    expect(window.pier.terminal.focus).toHaveBeenCalledWith("terminal-1");
+  });
+
+  it("refocuses an active native terminal when dockview moves it to another group", async () => {
+    const props = createPanelProps({ isActive: true });
+    render(<TerminalPanel {...props} />);
+
+    await waitFor(() => {
+      expect(window.pier.terminal.create).toHaveBeenCalledWith(
+        expect.objectContaining({ panelId: "terminal-1" })
+      );
+    });
+    vi.mocked(window.pier.terminal.focus).mockClear();
+
+    props.emitGroupChange();
+
+    expect(window.pier.terminal.focus).toHaveBeenCalledWith("terminal-1");
+  });
+
+  it("does not focus a terminal that becomes visible while inactive", async () => {
+    const props = createPanelProps({ isActive: false });
+    render(<TerminalPanel {...props} />);
+
+    await waitFor(() => {
+      expect(window.pier.terminal.create).toHaveBeenCalledWith(
+        expect.objectContaining({ panelId: "terminal-1" })
+      );
+    });
+    vi.mocked(window.pier.terminal.focus).mockClear();
+
+    props.emitVisibility({ isVisible: false });
+    props.emitVisibility({ isVisible: true });
+
+    expect(window.pier.terminal.show).toHaveBeenCalledWith("terminal-1");
+    expect(window.pier.terminal.focus).not.toHaveBeenCalled();
+  });
+
+  it("does not focus a terminal moved between groups while hidden", async () => {
+    const props = createPanelProps({ isActive: true, isVisible: false });
+    render(<TerminalPanel {...props} />);
+
+    await waitFor(() => {
+      expect(window.pier.terminal.create).toHaveBeenCalledWith(
+        expect.objectContaining({ panelId: "terminal-1" })
+      );
+    });
+    vi.mocked(window.pier.terminal.focus).mockClear();
+
+    props.emitGroupChange();
+
+    expect(window.pier.terminal.focus).not.toHaveBeenCalled();
   });
 });

--- a/tests/e2e/native-terminal-focus.spec.ts
+++ b/tests/e2e/native-terminal-focus.spec.ts
@@ -1,0 +1,280 @@
+import { execFile } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import {
+  type ElectronApplication,
+  _electron as electron,
+  expect,
+  type Page,
+  test,
+} from "@playwright/test";
+
+const OUT_MAIN = join(
+  import.meta.dirname,
+  "..",
+  "..",
+  "out",
+  "main",
+  "index.js"
+);
+
+test.skip(process.platform !== "darwin", "native terminal is macOS-only");
+
+const execFileAsync = promisify(execFile);
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function appleScriptString(value: string): string {
+  return `"${value.replaceAll("\\", "\\\\").replaceAll('"', '\\"')}"`;
+}
+
+async function focusElectronApp(app: ElectronApplication) {
+  await app.evaluate(({ app: electronApp, BrowserWindow }) => {
+    electronApp.focus({ steal: true });
+    BrowserWindow.getAllWindows()[0]?.focus();
+  });
+}
+
+async function pasteTextIntoFocusedApp(text: string) {
+  await execFileAsync("osascript", [
+    "-e",
+    "set previousClipboard to missing value",
+    "-e",
+    "try",
+    "-e",
+    "set previousClipboard to the clipboard",
+    "-e",
+    "end try",
+    "-e",
+    "try",
+    "-e",
+    `set the clipboard to ${appleScriptString(text)}`,
+    "-e",
+    'tell application "System Events" to keystroke "v" using command down',
+    "-e",
+    "delay 0.1",
+    "-e",
+    'tell application "System Events" to key code 36',
+    "-e",
+    "delay 0.1",
+    "-e",
+    "on error errorMessage number errorNumber",
+    "-e",
+    "if previousClipboard is not missing value then set the clipboard to previousClipboard",
+    "-e",
+    "error errorMessage number errorNumber",
+    "-e",
+    "end try",
+    "-e",
+    "if previousClipboard is not missing value then set the clipboard to previousClipboard",
+  ]);
+}
+
+async function waitForTerminalCount(win: Page, count: number) {
+  await expect(win.locator(".terminal-anchor")).toHaveCount(count, {
+    timeout: 10_000,
+  });
+  await win.waitForTimeout(800);
+}
+
+async function focusTerminalAt(win: Page, index: number) {
+  const anchor = win.locator(".terminal-anchor").nth(index);
+  await expect(anchor).toBeAttached({ timeout: 10_000 });
+  const box = await anchor.boundingBox();
+  if (!box) {
+    throw new Error(`terminal anchor ${index} has no bounding box`);
+  }
+  await win.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
+  await win.waitForTimeout(300);
+}
+
+async function writeMarkerFromTerminal(
+  app: ElectronApplication,
+  win: Page,
+  filePath: string,
+  marker: string
+) {
+  const command = `printf ${shellQuote(marker)} > ${shellQuote(filePath)}`;
+  await focusElectronApp(app);
+  await win.waitForTimeout(300);
+  await pasteTextIntoFocusedApp(command);
+  await expect
+    .poll(() => (existsSync(filePath) ? readFileSync(filePath, "utf8") : ""), {
+      timeout: 10_000,
+    })
+    .toBe(marker);
+}
+
+async function buildFourTerminalGrid(win: Page) {
+  await waitForTerminalCount(win, 1);
+  await focusTerminalAt(win, 0);
+  await win.keyboard.press("Meta+KeyD");
+  await waitForTerminalCount(win, 2);
+
+  await win.keyboard.press("Control+Shift+ArrowLeft");
+  await win.waitForTimeout(300);
+  await win.keyboard.press("Meta+Shift+KeyD");
+  await waitForTerminalCount(win, 3);
+
+  await win.keyboard.press("Control+Shift+ArrowRight");
+  await win.waitForTimeout(300);
+  await win.keyboard.press("Meta+Shift+KeyD");
+  await waitForTerminalCount(win, 4);
+}
+
+async function dragTopLeftTabIntoBottomLeftRightSplit(win: Page) {
+  const tabs = await win.locator(".dv-tab").evaluateAll((elements) =>
+    elements
+      .map((element, index) => {
+        const rect = element.getBoundingClientRect();
+        return {
+          height: rect.height,
+          index,
+          text: element.textContent ?? "",
+          width: rect.width,
+          x: rect.x,
+          y: rect.y,
+        };
+      })
+      .filter((tab) => tab.width > 0 && tab.height > 0)
+      .sort((a, b) => a.y - b.y || a.x - b.x)
+  );
+  const anchors = await win
+    .locator(".terminal-anchor")
+    .evaluateAll((elements) =>
+      elements
+        .map((element, index) => {
+          const rect = element.getBoundingClientRect();
+          return {
+            height: rect.height,
+            index,
+            width: rect.width,
+            x: rect.x,
+            y: rect.y,
+          };
+        })
+        .sort((a, b) => a.y - b.y || a.x - b.x)
+    );
+
+  if (tabs.length < 4 || anchors.length < 4) {
+    throw new Error(
+      `expected four terminal tabs and anchors, got ${tabs.length} tabs and ${anchors.length} anchors`
+    );
+  }
+
+  const source = tabs[0];
+  const bottomLeft = anchors[2];
+  if (!(source && bottomLeft)) {
+    throw new Error(
+      "failed to locate source tab or bottom-left terminal anchor"
+    );
+  }
+  await win.mouse.move(
+    source.x + source.width / 2,
+    source.y + source.height / 2
+  );
+  await win.mouse.down();
+  await win.mouse.move(
+    bottomLeft.x + bottomLeft.width * 0.75,
+    bottomLeft.y + bottomLeft.height * 0.5,
+    { steps: 24 }
+  );
+  await win.waitForTimeout(300);
+  await win.mouse.up();
+  await win.waitForTimeout(1200);
+}
+
+test.describe("Native terminal focus e2e", () => {
+  test("initial terminal accepts shell input", async () => {
+    const userDataDir = mkdtempSync(join(tmpdir(), "pier-terminal-e2e-"));
+    const markerDir = mkdtempSync(join(tmpdir(), "pier-terminal-marker-"));
+    const app = await electron.launch({
+      args: [OUT_MAIN, `--user-data-dir=${userDataDir}`],
+    });
+    try {
+      const win = await app.firstWindow();
+      await win.waitForLoadState("domcontentloaded");
+      await waitForTerminalCount(win, 1);
+      await focusTerminalAt(win, 0);
+
+      await writeMarkerFromTerminal(
+        app,
+        win,
+        join(markerDir, "initial.txt"),
+        "initial-ok"
+      );
+    } finally {
+      await app.close();
+      rmSync(userDataDir, { recursive: true, force: true });
+      rmSync(markerDir, { recursive: true, force: true });
+    }
+  });
+
+  test("terminal accepts shell input after tab drag into split group", async () => {
+    const userDataDir = mkdtempSync(join(tmpdir(), "pier-terminal-e2e-"));
+    const markerDir = mkdtempSync(join(tmpdir(), "pier-terminal-marker-"));
+    const app = await electron.launch({
+      args: [OUT_MAIN, `--user-data-dir=${userDataDir}`],
+    });
+    try {
+      const win = await app.firstWindow();
+      await win.waitForLoadState("domcontentloaded");
+      await app.evaluate(({ BrowserWindow }) => {
+        BrowserWindow.getAllWindows()[0]?.setSize(1200, 820);
+      });
+
+      await buildFourTerminalGrid(win);
+      await dragTopLeftTabIntoBottomLeftRightSplit(win);
+
+      await writeMarkerFromTerminal(
+        app,
+        win,
+        join(markerDir, "dragged.txt"),
+        "dragged-ok"
+      );
+    } finally {
+      await app.close();
+      rmSync(userDataDir, { recursive: true, force: true });
+      rmSync(markerDir, { recursive: true, force: true });
+    }
+  });
+
+  test("terminal accepts shell input after command palette overlay closes", async () => {
+    const userDataDir = mkdtempSync(join(tmpdir(), "pier-terminal-e2e-"));
+    const markerDir = mkdtempSync(join(tmpdir(), "pier-terminal-marker-"));
+    const app = await electron.launch({
+      args: [OUT_MAIN, `--user-data-dir=${userDataDir}`],
+    });
+    try {
+      const win = await app.firstWindow();
+      await win.waitForLoadState("domcontentloaded");
+      await waitForTerminalCount(win, 1);
+      await focusTerminalAt(win, 0);
+
+      await win.keyboard.press("Meta+Shift+KeyP");
+      await expect(win.locator('[role="dialog"]')).toBeAttached({
+        timeout: 5000,
+      });
+      await win.keyboard.press("Escape");
+      await expect(win.locator('[role="dialog"]')).not.toBeAttached({
+        timeout: 5000,
+      });
+      await focusTerminalAt(win, 0);
+
+      await writeMarkerFromTerminal(
+        app,
+        win,
+        join(markerDir, "overlay.txt"),
+        "overlay-ok"
+      );
+    } finally {
+      await app.close();
+      rmSync(userDataDir, { recursive: true, force: true });
+      rmSync(markerDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/unit/main/terminal-state-consistency.test.ts
+++ b/tests/unit/main/terminal-state-consistency.test.ts
@@ -215,4 +215,84 @@ describe("Swift terminal state consistency via main IPC paths", () => {
       ["7::panel-a", "7::panel-b"]
     );
   });
+
+  it("activates web focus only when terminal overlay is enabled", async () => {
+    const { fakeAddon, handlers, win } = await setupHarness();
+
+    handlers.get("pier:terminal:set-overlay")?.(
+      { sender: win.webContents },
+      true
+    );
+
+    expect(fakeAddon.setOverlayActive).toHaveBeenCalledWith(
+      Buffer.from("window"),
+      true
+    );
+    expect(win.webContents.focus).toHaveBeenCalledOnce();
+
+    vi.mocked(win.webContents.focus).mockClear();
+
+    handlers.get("pier:terminal:set-overlay")?.(
+      { sender: win.webContents },
+      false
+    );
+
+    expect(fakeAddon.setOverlayActive).toHaveBeenLastCalledWith(
+      Buffer.from("window"),
+      false
+    );
+    expect(win.webContents.focus).not.toHaveBeenCalled();
+  });
+
+  it("routes terminal theme application through the sender window", async () => {
+    const { fakeAddon, handlers, win } = await setupHarness();
+    const colors = {
+      background: "#000000",
+      black: "#000000",
+      blue: "#0000ff",
+      brightBlack: "#111111",
+      brightBlue: "#2222ff",
+      brightCyan: "#22ffff",
+      brightGreen: "#22ff22",
+      brightMagenta: "#ff22ff",
+      brightRed: "#ff2222",
+      brightWhite: "#ffffff",
+      brightYellow: "#ffff22",
+      cursor: "#ffffff",
+      cyan: "#00ffff",
+      foreground: "#ffffff",
+      green: "#00ff00",
+      magenta: "#ff00ff",
+      red: "#ff0000",
+      selection: "#333333",
+      white: "#eeeeee",
+      yellow: "#ffff00",
+    };
+
+    handlers.get("pier:terminal:apply-theme")?.(
+      { sender: win.webContents },
+      colors
+    );
+
+    expect(fakeAddon.applyTerminalTheme).toHaveBeenCalledWith(
+      Buffer.from("window"),
+      colors
+    );
+  });
+
+  it("routes terminal font application through the sender window", async () => {
+    const { fakeAddon, handlers, win } = await setupHarness();
+
+    handlers.get("pier:terminal:set-font")?.(
+      { sender: win.webContents },
+      "panel-1",
+      { family: "Menlo", size: 14 }
+    );
+
+    expect(fakeAddon.setTerminalFont).toHaveBeenCalledWith(
+      Buffer.from("window"),
+      "Menlo",
+      14
+    );
+  });
 });

--- a/tests/unit/renderer/stores/terminal-overlay.test.ts
+++ b/tests/unit/renderer/stores/terminal-overlay.test.ts
@@ -1,0 +1,191 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("terminal drag overlay", () => {
+  function installPierHarness() {
+    const setOverlayActive = vi.fn();
+    Object.defineProperty(window, "pier", {
+      configurable: true,
+      value: {
+        terminal: {
+          setOverlayActive,
+        },
+      },
+    });
+    return { setOverlayActive };
+  }
+
+  function createDockviewTab() {
+    const tab = document.createElement("div");
+    tab.className = "dv-tab";
+    document.body.appendChild(tab);
+    return tab;
+  }
+
+  function createDockviewSash() {
+    const sash = document.createElement("div");
+    sash.className = "dv-sash";
+    document.body.appendChild(sash);
+    return sash;
+  }
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.useFakeTimers();
+    document.body.innerHTML = "";
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      value: "visible",
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    document.body.innerHTML = "";
+  });
+
+  it("releases the tab-drag overlay on drop even when dragend does not arrive", async () => {
+    const { setOverlayActive } = installPierHarness();
+
+    const { installDragWatcher } = await import(
+      "@/stores/terminal-overlay.store.ts"
+    );
+    installDragWatcher();
+
+    const tab = createDockviewTab();
+
+    tab.dispatchEvent(new Event("dragstart", { bubbles: true }));
+    expect(setOverlayActive).toHaveBeenCalledWith(true);
+
+    document.dispatchEvent(new Event("drop", { bubbles: true }));
+    await vi.runAllTimersAsync();
+
+    expect(setOverlayActive).toHaveBeenLastCalledWith(false);
+  });
+
+  it("releases the tab-drag overlay on window blur when dragend and drop are lost", async () => {
+    const { setOverlayActive } = installPierHarness();
+    const { installDragWatcher } = await import(
+      "@/stores/terminal-overlay.store.ts"
+    );
+    installDragWatcher();
+
+    createDockviewTab().dispatchEvent(
+      new Event("dragstart", { bubbles: true })
+    );
+
+    window.dispatchEvent(new Event("blur"));
+
+    expect(setOverlayActive).toHaveBeenLastCalledWith(false);
+  });
+
+  it("releases the tab-drag overlay when the document becomes hidden", async () => {
+    const { setOverlayActive } = installPierHarness();
+    const { installDragWatcher } = await import(
+      "@/stores/terminal-overlay.store.ts"
+    );
+    installDragWatcher();
+
+    createDockviewTab().dispatchEvent(
+      new Event("dragstart", { bubbles: true })
+    );
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      value: "hidden",
+    });
+
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    expect(setOverlayActive).toHaveBeenLastCalledWith(false);
+  });
+
+  it("releases the tab-drag overlay on Escape", async () => {
+    const { setOverlayActive } = installPierHarness();
+    const { installDragWatcher } = await import(
+      "@/stores/terminal-overlay.store.ts"
+    );
+    installDragWatcher();
+
+    createDockviewTab().dispatchEvent(
+      new Event("dragstart", { bubbles: true })
+    );
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+
+    expect(setOverlayActive).toHaveBeenLastCalledWith(false);
+  });
+
+  it("releases the tab-drag overlay after the fallback timeout", async () => {
+    const { setOverlayActive } = installPierHarness();
+    const { installDragWatcher } = await import(
+      "@/stores/terminal-overlay.store.ts"
+    );
+    installDragWatcher();
+
+    createDockviewTab().dispatchEvent(
+      new Event("dragstart", { bubbles: true })
+    );
+
+    await vi.advanceTimersByTimeAsync(5000);
+
+    expect(setOverlayActive).toHaveBeenLastCalledWith(false);
+  });
+
+  it("keeps an existing overlay active when a tab drag ends", async () => {
+    const { setOverlayActive } = installPierHarness();
+    const { installDragWatcher, popOverlay, pushOverlay } = await import(
+      "@/stores/terminal-overlay.store.ts"
+    );
+    installDragWatcher();
+
+    pushOverlay();
+    createDockviewTab().dispatchEvent(
+      new Event("dragstart", { bubbles: true })
+    );
+    document.dispatchEvent(new Event("dragend", { bubbles: true }));
+
+    expect(setOverlayActive).toHaveBeenCalledTimes(1);
+    expect(setOverlayActive).toHaveBeenLastCalledWith(true);
+
+    popOverlay();
+
+    expect(setOverlayActive).toHaveBeenLastCalledWith(false);
+  });
+
+  it("releases the sash overlay on window blur when pointerup is lost", async () => {
+    const { setOverlayActive } = installPierHarness();
+    const { installDragWatcher } = await import(
+      "@/stores/terminal-overlay.store.ts"
+    );
+    installDragWatcher();
+
+    createDockviewSash().dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true })
+    );
+    expect(setOverlayActive).toHaveBeenCalledWith(true);
+
+    window.dispatchEvent(new Event("blur"));
+
+    expect(setOverlayActive).toHaveBeenLastCalledWith(false);
+  });
+
+  it("only releases a sash overlay once if blur is followed by pointerup", async () => {
+    const { setOverlayActive } = installPierHarness();
+    const { installDragWatcher } = await import(
+      "@/stores/terminal-overlay.store.ts"
+    );
+    installDragWatcher();
+
+    createDockviewSash().dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true })
+    );
+
+    window.dispatchEvent(new Event("blur"));
+    window.dispatchEvent(new PointerEvent("pointerup"));
+
+    expect(setOverlayActive).toHaveBeenCalledTimes(2);
+    expect(setOverlayActive).toHaveBeenNthCalledWith(1, true);
+    expect(setOverlayActive).toHaveBeenNthCalledWith(2, false);
+  });
+});

--- a/tests/unit/renderer/stores/workspace-store-terminal-close.test.ts
+++ b/tests/unit/renderer/stores/workspace-store-terminal-close.test.ts
@@ -1,21 +1,58 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const closeCurrentWindowMock = vi.hoisted(() => vi.fn(async () => undefined));
+
+vi.mock("@/lib/ipc/window-ipc.ts", () => ({
+  closeCurrentWindow: closeCurrentWindowMock,
+}));
+
 import { useWorkspaceStore } from "@/stores/workspace.store.ts";
 
 function terminalPanel(id: string) {
   return {
+    api: { setActive: vi.fn() },
     id,
     title: "Terminal",
     view: { contentComponent: "terminal" },
   };
 }
 
+function webPanel(id: string) {
+  return {
+    api: { setActive: vi.fn() },
+    id,
+    title: "Welcome",
+    view: { contentComponent: "welcome" },
+  };
+}
+
+function createApi(panels: ReturnType<typeof terminalPanel>[]) {
+  return {
+    activePanel: panels[0] ?? null,
+    addPanel: vi.fn(),
+    panels,
+    removePanel: vi.fn(),
+    totalPanels: panels.length,
+  };
+}
+
+function firstInvocationOrder(fn: { mock: { invocationCallOrder: number[] } }) {
+  const order = fn.mock.invocationCallOrder[0];
+  if (order === undefined) {
+    throw new Error("expected mock to be called");
+  }
+  return order;
+}
+
 describe("workspace terminal close lifecycle", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    closeCurrentWindowMock.mockClear();
     Object.defineProperty(window, "pier", {
       configurable: true,
       value: {
         terminal: { close: vi.fn() },
+        workspace: { clearLayout: vi.fn(async () => undefined) },
       },
     });
     useWorkspaceStore.getState().setApi(null);
@@ -23,12 +60,7 @@ describe("workspace terminal close lifecycle", () => {
 
   it("closes the native terminal when a terminal panel is explicitly closed", () => {
     const panel = terminalPanel("terminal-1");
-    const api = {
-      activePanel: panel,
-      panels: [panel, { ...terminalPanel("terminal-2"), id: "welcome-1" }],
-      removePanel: vi.fn(),
-      totalPanels: 2,
-    };
+    const api = createApi([panel, webPanel("welcome-1")]);
 
     useWorkspaceStore.getState().setApi(api as never);
 
@@ -36,5 +68,89 @@ describe("workspace terminal close lifecycle", () => {
 
     expect(window.pier.terminal.close).toHaveBeenCalledWith("terminal-1");
     expect(api.removePanel).toHaveBeenCalledWith(panel);
+  });
+
+  it("does not close a native terminal when a web panel is explicitly closed", () => {
+    const terminal = terminalPanel("terminal-1");
+    const web = webPanel("welcome-1");
+    const api = createApi([terminal, web]);
+
+    useWorkspaceStore.getState().setApi(api as never);
+
+    useWorkspaceStore.getState().closePanel("welcome-1");
+
+    expect(window.pier.terminal.close).not.toHaveBeenCalled();
+    expect(api.removePanel).toHaveBeenCalledWith(web);
+  });
+
+  it("closes the native terminal when the active terminal panel is closed", () => {
+    const terminal = terminalPanel("terminal-1");
+    const api = createApi([terminal, webPanel("welcome-1")]);
+
+    useWorkspaceStore.getState().setApi(api as never);
+
+    useWorkspaceStore.getState().closeActivePanel();
+
+    expect(window.pier.terminal.close).toHaveBeenCalledWith("terminal-1");
+    expect(api.removePanel).toHaveBeenCalledWith(terminal);
+  });
+
+  it("closes only terminal panels removed by closeOthers", () => {
+    const keep = terminalPanel("terminal-keep");
+    const terminal = terminalPanel("terminal-close");
+    const web = webPanel("welcome-close");
+    const api = createApi([keep, terminal, web]);
+
+    useWorkspaceStore.getState().setApi(api as never);
+
+    useWorkspaceStore.getState().closeOthers("terminal-keep");
+
+    expect(window.pier.terminal.close).toHaveBeenCalledOnce();
+    expect(window.pier.terminal.close).toHaveBeenCalledWith("terminal-close");
+    expect(api.removePanel).toHaveBeenCalledWith(terminal);
+    expect(api.removePanel).toHaveBeenCalledWith(web);
+    expect(api.removePanel).not.toHaveBeenCalledWith(keep);
+  });
+
+  it("clears layout before closing terminal panels during closeAll", async () => {
+    const terminal = terminalPanel("terminal-1");
+    const web = webPanel("welcome-1");
+    const api = createApi([terminal, web]);
+
+    useWorkspaceStore.getState().setApi(api as never);
+
+    await useWorkspaceStore.getState().closeAll();
+
+    expect(window.pier.workspace.clearLayout).toHaveBeenCalledOnce();
+    expect(window.pier.terminal.close).toHaveBeenCalledWith("terminal-1");
+    expect(api.removePanel).toHaveBeenCalledWith(terminal);
+    expect(api.removePanel).toHaveBeenCalledWith(web);
+    expect(closeCurrentWindowMock).toHaveBeenCalledOnce();
+    expect(
+      firstInvocationOrder(vi.mocked(window.pier.workspace.clearLayout))
+    ).toBeLessThan(firstInvocationOrder(vi.mocked(window.pier.terminal.close)));
+  });
+
+  it("clears layout, closes old terminals, and rebuilds default terminal during resetLayout", async () => {
+    const oldTerminal = terminalPanel("terminal-old");
+    const web = webPanel("welcome-old");
+    const api = createApi([oldTerminal, web]);
+
+    useWorkspaceStore.getState().setApi(api as never);
+
+    await useWorkspaceStore.getState().resetLayout();
+
+    expect(window.pier.workspace.clearLayout).toHaveBeenCalledOnce();
+    expect(window.pier.terminal.close).toHaveBeenCalledWith("terminal-old");
+    expect(api.removePanel).toHaveBeenCalledWith(oldTerminal);
+    expect(api.removePanel).toHaveBeenCalledWith(web);
+    expect(api.addPanel).toHaveBeenCalledWith({
+      component: "terminal",
+      id: "terminal-1",
+      title: "Terminal",
+    });
+    expect(
+      firstInvocationOrder(vi.mocked(window.pier.workspace.clearLayout))
+    ).toBeLessThan(firstInvocationOrder(vi.mocked(window.pier.terminal.close)));
   });
 });


### PR DESCRIPTION
## Summary
- Harden terminal overlay cleanup for tab drag and sash resize so native terminal input mode cannot remain blocked after lost drag events.
- Re-focus the active visible terminal after visibility and group changes without stealing focus from inactive or hidden panels.
- Add renderer, main, native, workspace-close, and Electron E2E coverage proving shell input still reaches the native terminal after drag and overlay flows.

## Validation
- pnpm exec playwright test --config playwright.config.ts tests/e2e/native-terminal-focus.spec.ts
- pnpm check

## Notes
- `pnpm check` still reports existing soft file-size warnings only; hard cap passes.
