### PR TITLE
[codex] Stabilize window restore semantics

### DIFF
--- a/src/main/app-core/app-core.ts
+++ b/src/main/app-core/app-core.ts
@@ -78,15 +78,26 @@ function sendRendererCommand(
 function createPierAppCore(): PierAppCore {
   const eventBus = createPierEventBus();
   const clients = createClientRegistry();
+  const rendererCommand = createRendererCommandService({
+    host: { send: sendRendererCommand },
+  });
   const services: PierCoreServices = {
     commandPaletteMru: createCommandPaletteMruService({
       broadcast: broadcastMruState,
     }),
     preferences: createPreferencesService({ eventBus }),
-    rendererCommand: createRendererCommandService({
-      host: { send: sendRendererCommand },
+    rendererCommand,
+    window: createWindowService({
+      flushRendererLayout: async (windowId) => {
+        const result = await rendererCommand.execute({
+          type: "workspace.flushLayout",
+          windowId,
+        });
+        if (!result.ok) {
+          throw new Error(result.error.message);
+        }
+      },
     }),
-    window: createWindowService(),
     workspace: createWorkspaceService(),
   };
   return {

--- a/src/main/app-core/command-router.ts
+++ b/src/main/app-core/command-router.ts
@@ -6,6 +6,7 @@ import {
 } from "@shared/contracts/commands.ts";
 import type { WindowInfo } from "@shared/contracts/events.ts";
 import type { ProjectPreferences } from "@shared/contracts/preferences.ts";
+import type { WindowCreateOptions } from "@shared/contracts/window.ts";
 import type { RendererCommandService } from "../services/renderer-command-service.ts";
 import type { PierClientRegistry } from "./client-registry.ts";
 import { authorizeCommand } from "./permissions.ts";
@@ -23,14 +24,26 @@ export interface PierCoreServices {
   rendererCommand: RendererCommandService;
   window: {
     close(windowId: string): void;
-    create(): { windowId: string };
+    create(options?: WindowCreateOptions): Promise<{
+      recordId: string;
+      windowId: string;
+    }>;
     focus(windowId: string): void;
+    flushOpenWindows(): Promise<void>;
+    flushWindow(windowId: string): Promise<void>;
     list(): WindowInfo[];
+    restoreMostRecentClosed(): Promise<{
+      recordId: string;
+      windowId: string;
+    } | null>;
+    restoreOpenWindows(): Promise<
+      Array<{ recordId: string; windowId: string }>
+    >;
   };
   workspace: {
-    clearLayout(): Promise<void>;
-    readLayout(): Promise<unknown | null>;
-    saveLayout(layout: unknown): Promise<void>;
+    clearLayout(recordId: string): Promise<void>;
+    readLayout(recordId: string): Promise<unknown | null>;
+    saveLayout(layout: unknown, recordId: string): Promise<void>;
   };
 }
 
@@ -124,19 +137,25 @@ export function createCommandRouter({
             services.window.close(command.windowId);
             return success(requestId, null);
           case "window.create":
-            return success(requestId, services.window.create());
+            return success(requestId, await services.window.create());
           case "window.focus":
             services.window.focus(command.windowId);
             return success(requestId, null);
           case "window.list":
             return success(requestId, services.window.list());
           case "workspace.layout.clear":
-            await services.workspace.clearLayout();
+            await services.workspace.clearLayout(command.recordId);
             return success(requestId, null);
           case "workspace.layout.read":
-            return success(requestId, await services.workspace.readLayout());
+            return success(
+              requestId,
+              await services.workspace.readLayout(command.recordId)
+            );
           case "workspace.layout.save":
-            await services.workspace.saveLayout(command.layout);
+            await services.workspace.saveLayout(
+              command.layout,
+              command.recordId
+            );
             return success(requestId, null);
           case "panel.focus":
           case "panel.list":

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -10,6 +10,7 @@ import {
   type RegisteredLocalControl,
   registerCliLocalControl,
 } from "./adapters/cli/register-local-control.ts";
+import { appCore } from "./app-core/app-core.ts";
 import { installCsp } from "./csp.ts";
 import { createDetachedDevToolsMenuItem } from "./devtools.ts";
 import { registerCommandPaletteMruIpc } from "./ipc/command-palette-mru.ts";
@@ -26,6 +27,7 @@ const isDev = !app.isPackaged;
 const isMac = process.platform === "darwin";
 const DEV_USER_DATA_ROOT = "Pier-dev";
 let localControl: RegisteredLocalControl | null = null;
+let didFlushBeforeQuit = false;
 
 // dev mode silence "Insecure CSP (unsafe-eval)" warning: dev CSP 必须含 'unsafe-eval'
 // (vite HMR + react-refresh 依赖 eval).
@@ -129,7 +131,14 @@ function buildAppMenu(): Menu {
   };
 
   const newWindowMenuItem: MenuItemConstructorOptions = {
-    click: () => windowManager.create(),
+    click: () => {
+      appCore.services.window.create({ mode: "fresh" }).catch((error) => {
+        console.error(
+          "[window] failed to create new window:",
+          error instanceof Error ? error.message : String(error)
+        );
+      });
+    },
     label: "New Window",
   };
 
@@ -164,7 +173,7 @@ function buildAppMenu(): Menu {
   return Menu.buildFromTemplate(template);
 }
 
-app.whenReady().then(() => {
+app.whenReady().then(async () => {
   installCsp();
   Menu.setApplicationMenu(buildAppMenu());
 
@@ -196,12 +205,26 @@ app.whenReady().then(() => {
       );
     });
 
-  // 首窗口 id 固定 "main".
-  windowManager.create({ id: "main" });
+  const restored = await appCore.services.window.restoreOpenWindows();
+  if (restored.length === 0) {
+    await appCore.services.window.create({ mode: "fresh" });
+  }
 
   app.on("activate", () => {
     if (windowManager.getAll().length === 0) {
-      windowManager.create({ id: "main" });
+      appCore.services.window
+        .restoreMostRecentClosed()
+        .then(async (restoredWindow) => {
+          if (!restoredWindow) {
+            await appCore.services.window.create({ mode: "fresh" });
+          }
+        })
+        .catch((error) => {
+          console.error(
+            "[window] failed to restore window on activate:",
+            error instanceof Error ? error.message : String(error)
+          );
+        });
     }
   });
 });
@@ -212,7 +235,23 @@ app.on("window-all-closed", () => {
   }
 });
 
-app.on("before-quit", () => {
+app.on("before-quit", (event) => {
+  if (!didFlushBeforeQuit) {
+    event.preventDefault();
+    didFlushBeforeQuit = true;
+    appCore.services.window
+      .flushOpenWindows()
+      .catch((error) => {
+        console.error(
+          "[window] failed to flush windows before quit:",
+          error instanceof Error ? error.message : String(error)
+        );
+      })
+      .finally(() => {
+        app.quit();
+      });
+    return;
+  }
   windowManager.destroyAllForQuit();
   localControl?.close().catch(() => {
     // ignore: app 正在退出

--- a/src/main/ipc/terminal.ts
+++ b/src/main/ipc/terminal.ts
@@ -14,6 +14,7 @@ import {
   readTerminalPanelSession,
   removeTerminalPanelSession,
   updateTerminalPanelCwd,
+  updateTerminalPanelTitle,
 } from "../state/terminal-session-state.ts";
 import type { AppWindow } from "../windows/app-window.ts";
 import {
@@ -230,10 +231,18 @@ export function registerTerminalIpc(ipcMain: IpcMain): void {
     );
   });
   addon?.setTitleForwardCallback((id, panelId, title) => {
+    const rawPanelId = unscopePanelId(panelId);
+    const targetWindow = findAppWindowByElectronId(id);
+    if (targetWindow && !targetWindow.isDestroyed()) {
+      const windowId = stableWindowIdFor(targetWindow);
+      updateTerminalPanelTitle(windowId, rawPanelId, title).catch((err) => {
+        console.error("[pier-title-persist] failed:", err);
+      });
+    }
     forwardToWindow(
       id,
       "pier:terminal:title-change",
-      { panelId: unscopePanelId(panelId), title },
+      { panelId: rawPanelId, title },
       "pier-title-forward"
     );
   });
@@ -289,6 +298,17 @@ export function registerTerminalIpc(ipcMain: IpcMain): void {
           error: e instanceof Error ? e.message : String(e),
         };
       }
+    }
+  );
+
+  ipcMain.handle(
+    "pier:terminal:read-session",
+    async (event, panelId: string) => {
+      const win = windowFromWebContents(event.sender);
+      if (!win) {
+        return null;
+      }
+      return await readTerminalPanelSession(stableWindowIdFor(win), panelId);
     }
   );
 

--- a/src/main/ipc/terminal.ts
+++ b/src/main/ipc/terminal.ts
@@ -21,6 +21,7 @@ import {
   findAppWindowByElectronId,
   findAppWindowByWebContents,
   findInternalWindowId,
+  findWindowSessionId,
 } from "../windows/window-identity.ts";
 import type { NativeAddon } from "./terminal-native-addon.ts";
 
@@ -48,6 +49,10 @@ function rememberActivePanelFocus(
 
 function stableWindowIdFor(win: AppWindow): string {
   return findInternalWindowId(win) ?? `window-${win.id}`;
+}
+
+function terminalSessionScopeFor(win: AppWindow): string {
+  return findWindowSessionId(win) ?? stableWindowIdFor(win);
 }
 
 /**
@@ -218,8 +223,8 @@ export function registerTerminalIpc(ipcMain: IpcMain): void {
     const rawPanelId = unscopePanelId(panelId);
     const targetWindow = findAppWindowByElectronId(id);
     if (targetWindow && !targetWindow.isDestroyed()) {
-      const windowId = stableWindowIdFor(targetWindow);
-      updateTerminalPanelCwd(windowId, rawPanelId, cwd).catch((err) => {
+      const sessionScope = terminalSessionScopeFor(targetWindow);
+      updateTerminalPanelCwd(sessionScope, rawPanelId, cwd).catch((err) => {
         console.error("[pier-cwd-persist] failed:", err);
       });
     }
@@ -234,8 +239,8 @@ export function registerTerminalIpc(ipcMain: IpcMain): void {
     const rawPanelId = unscopePanelId(panelId);
     const targetWindow = findAppWindowByElectronId(id);
     if (targetWindow && !targetWindow.isDestroyed()) {
-      const windowId = stableWindowIdFor(targetWindow);
-      updateTerminalPanelTitle(windowId, rawPanelId, title).catch((err) => {
+      const sessionScope = terminalSessionScopeFor(targetWindow);
+      updateTerminalPanelTitle(sessionScope, rawPanelId, title).catch((err) => {
         console.error("[pier-title-persist] failed:", err);
       });
     }
@@ -278,8 +283,11 @@ export function registerTerminalIpc(ipcMain: IpcMain): void {
       }
       try {
         const handle = win.getNativeWindowHandle();
-        const windowId = stableWindowIdFor(win);
-        const saved = await readTerminalPanelSession(windowId, args.panelId);
+        const sessionScope = terminalSessionScopeFor(win);
+        const saved = await readTerminalPanelSession(
+          sessionScope,
+          args.panelId
+        );
         const cwd = args.cwd ?? saved?.cwd;
         const ok = addon.createTerminal(
           handle,
@@ -308,7 +316,10 @@ export function registerTerminalIpc(ipcMain: IpcMain): void {
       if (!win) {
         return null;
       }
-      return await readTerminalPanelSession(stableWindowIdFor(win), panelId);
+      return await readTerminalPanelSession(
+        terminalSessionScopeFor(win),
+        panelId
+      );
     }
   );
 
@@ -340,8 +351,8 @@ export function registerTerminalIpc(ipcMain: IpcMain): void {
   ipcMain.on("pier:terminal:close", (event, panelId: string) => {
     const win = windowFromWebContents(event.sender);
     if (win) {
-      const windowId = stableWindowIdFor(win);
-      removeTerminalPanelSession(windowId, panelId).catch((err) => {
+      const sessionScope = terminalSessionScopeFor(win);
+      removeTerminalPanelSession(sessionScope, panelId).catch((err) => {
         console.error("[pier-cwd-remove] failed:", err);
       });
       addon?.closeTerminal(scopePanelId(win, panelId));

--- a/src/main/ipc/window.ts
+++ b/src/main/ipc/window.ts
@@ -8,10 +8,23 @@
 import { PIER } from "@shared/ipc-channels.ts";
 import type { IpcMain } from "electron";
 import { appCore } from "../app-core/app-core.ts";
+import { findWindowContext } from "../windows/window-identity.ts";
 import { windowManager } from "../windows/window-manager.ts";
 
 export function registerWindowIpc(ipcMain: IpcMain): void {
   ipcMain.handle(PIER.WINDOW_CREATE, () => appCore.services.window.create());
+
+  ipcMain.handle(PIER.WINDOW_CONTEXT, (event) => {
+    const win = windowManager.fromWebContents(event.sender);
+    if (!win) {
+      throw new Error("window not found");
+    }
+    const context = findWindowContext(win);
+    if (!context) {
+      throw new Error("window context not found");
+    }
+    return context;
+  });
 
   ipcMain.handle(PIER.WINDOW_LIST, () => appCore.services.window.list());
 

--- a/src/main/ipc/workspace.ts
+++ b/src/main/ipc/workspace.ts
@@ -1,17 +1,31 @@
 import type { IpcMain } from "electron";
 import { appCore } from "../app-core/app-core.ts";
 
+function requireRecordId(recordId: unknown): string {
+  if (typeof recordId !== "string" || recordId.trim().length === 0) {
+    throw new Error("workspace layout recordId required");
+  }
+  return recordId;
+}
+
 export function registerWorkspaceIpc(ipcMain: IpcMain): void {
-  ipcMain.handle("pier:workspace:load-layout", async () =>
-    appCore.services.workspace.readLayout()
+  ipcMain.handle(
+    "pier:workspace:load-layout",
+    async (_event, recordId: unknown) =>
+      appCore.services.workspace.readLayout(requireRecordId(recordId))
   );
   ipcMain.handle(
     "pier:workspace:save-layout",
-    async (_event, layout: unknown) => {
-      await appCore.services.workspace.saveLayout(layout);
+    async (_event, layout: unknown, recordId: unknown) => {
+      await appCore.services.workspace.saveLayout(
+        layout,
+        requireRecordId(recordId)
+      );
     }
   );
-  ipcMain.handle("pier:workspace:clear-layout", async () =>
-    appCore.services.workspace.clearLayout()
+  ipcMain.handle(
+    "pier:workspace:clear-layout",
+    async (_event, recordId: unknown) =>
+      appCore.services.workspace.clearLayout(requireRecordId(recordId))
   );
 }

--- a/src/main/services/renderer-command-service.ts
+++ b/src/main/services/renderer-command-service.ts
@@ -46,6 +46,7 @@ function shouldFocusRendererWindow(command: RendererCommand): boolean {
       return command.focus ?? true;
     case "panel.list":
     case "terminal.list":
+    case "workspace.flushLayout":
       return false;
     default: {
       const _exhaustive: never = command;

--- a/src/main/services/window-service.ts
+++ b/src/main/services/window-service.ts
@@ -1,18 +1,146 @@
 import type { WindowInfo } from "@shared/contracts/events.ts";
+import type {
+  WindowCreateOptions,
+  WindowCreateResult,
+} from "@shared/contracts/window.ts";
+import { flushTerminalSessionState } from "../state/terminal-session-state.ts";
+import {
+  createWindowRecord,
+  flushWindowRecordState,
+  markWindowRecordClosed,
+  markWindowRecordOpen,
+  readMostRecentClosedWindowRecordId,
+  readOpenWindowRecordIds,
+} from "../state/window-record-state.ts";
+import { findWindowContext } from "../windows/window-identity.ts";
 import { windowManager } from "../windows/window-manager.ts";
 
 export interface WindowService {
   close(windowId: string): void;
-  create(): { windowId: string };
+  create(options?: WindowCreateOptions): Promise<WindowCreateResult>;
+  flushOpenWindows(): Promise<void>;
+  flushWindow(windowId: string): Promise<void>;
   focus(windowId: string): void;
   list(): WindowInfo[];
+  restoreMostRecentClosed(): Promise<WindowCreateResult | null>;
+  restoreOpenWindows(): Promise<WindowCreateResult[]>;
 }
 
-export function createWindowService(): WindowService {
+export interface CreateWindowServiceArgs {
+  flushRendererLayout?: (windowId: string) => Promise<void>;
+}
+
+let didRegisterCloseHandler = false;
+let currentFlushRendererLayout: (windowId: string) => Promise<void> =
+  async () => undefined;
+
+async function flushWindowBeforeClose(windowId: string): Promise<void> {
+  try {
+    await currentFlushRendererLayout(windowId);
+  } catch (err) {
+    console.error(
+      "[window-layout-flush] failed:",
+      err instanceof Error ? err.message : String(err)
+    );
+  }
+  await Promise.all([flushTerminalSessionState(), flushWindowRecordState()]);
+}
+
+function ensureCloseHandler(): void {
+  if (didRegisterCloseHandler) {
+    return;
+  }
+  didRegisterCloseHandler = true;
+  windowManager.onBeforeClose(({ windowId }) =>
+    flushWindowBeforeClose(windowId)
+  );
+  windowManager.onClose(({ recordId }) => {
+    markWindowRecordClosed(recordId).catch((err) => {
+      console.error("[window-record-close] failed:", err);
+    });
+  });
+}
+
+function nextRuntimeWindowId(): string | undefined {
+  return windowManager.getAll().length === 0 ? "main" : undefined;
+}
+
+function isWindowRecordOpenInLiveWindow(recordId: string): boolean {
+  return windowManager
+    .getAll()
+    .some((win) => findWindowContext(win)?.recordId === recordId);
+}
+
+export function createWindowService(
+  args: CreateWindowServiceArgs = {}
+): WindowService {
+  currentFlushRendererLayout =
+    args.flushRendererLayout ?? (async () => undefined);
+  ensureCloseHandler();
+
+  async function create(
+    options: WindowCreateOptions = {}
+  ): Promise<WindowCreateResult> {
+    const mode = options.mode ?? "fresh";
+    const recordId = (await createWindowRecord()).id;
+    return await createFromRecord({ mode, recordId });
+  }
+
+  async function createFromRecord(options: {
+    mode: "fresh" | "restore";
+    recordId: string;
+  }): Promise<WindowCreateResult> {
+    const { mode, recordId } = options;
+    if (isWindowRecordOpenInLiveWindow(recordId)) {
+      throw new Error(`window record already open: ${recordId}`);
+    }
+    const runtimeWindowId = nextRuntimeWindowId();
+    const windowId = windowManager.create({
+      ...(runtimeWindowId ? { id: runtimeWindowId } : {}),
+      mode,
+      recordId,
+    });
+    await markWindowRecordOpen(recordId);
+    return { recordId, windowId };
+  }
+
   return {
     close: (windowId) => windowManager.close(windowId),
-    create: () => ({ windowId: windowManager.create() }),
+    create,
     focus: (windowId) => windowManager.focus(windowId),
+    flushOpenWindows: async () => {
+      const windows = windowManager.list();
+      for (const windowInfo of windows) {
+        try {
+          await currentFlushRendererLayout(windowInfo.id);
+        } catch (err) {
+          console.error(
+            "[window-layout-flush] failed:",
+            err instanceof Error ? err.message : String(err)
+          );
+        }
+      }
+      await Promise.all([
+        flushTerminalSessionState(),
+        flushWindowRecordState(),
+      ]);
+    },
+    flushWindow: flushWindowBeforeClose,
     list: () => windowManager.list(),
+    restoreMostRecentClosed: async () => {
+      const recordId = await readMostRecentClosedWindowRecordId();
+      if (!recordId) {
+        return null;
+      }
+      return await createFromRecord({ mode: "restore", recordId });
+    },
+    restoreOpenWindows: async () => {
+      const recordIds = await readOpenWindowRecordIds();
+      const results: WindowCreateResult[] = [];
+      for (const recordId of recordIds) {
+        results.push(await createFromRecord({ mode: "restore", recordId }));
+      }
+      return results;
+    },
   };
 }

--- a/src/main/services/workspace-service.ts
+++ b/src/main/services/workspace-service.ts
@@ -5,15 +5,15 @@ import {
 } from "../state/workspace-layout.ts";
 
 export interface WorkspaceService {
-  clearLayout(): Promise<void>;
-  readLayout(): Promise<unknown | null>;
-  saveLayout(layout: unknown): Promise<void>;
+  clearLayout(recordId: string): Promise<void>;
+  readLayout(recordId: string): Promise<unknown | null>;
+  saveLayout(layout: unknown, recordId: string): Promise<void>;
 }
 
 export function createWorkspaceService(): WorkspaceService {
   return {
-    clearLayout: () => clearLayoutState(),
-    readLayout: () => readLayoutState(),
-    saveLayout: (layout) => saveLayoutState(layout),
+    clearLayout: (recordId) => clearLayoutState(recordId),
+    readLayout: (recordId) => readLayoutState(recordId),
+    saveLayout: (layout, recordId) => saveLayoutState(layout, recordId),
   };
 }

--- a/src/main/state/terminal-session-state.ts
+++ b/src/main/state/terminal-session-state.ts
@@ -1,8 +1,9 @@
 /**
  * Terminal session state persistence.
  *
- * Remembers the last cwd per window id + terminal panel id, so a
- * relaunched app can create a fresh shell in the same directory.
+ * Remembers the last cwd/title per window id + terminal panel id, so a
+ * relaunched app can restore tab chrome before creating a fresh shell in the
+ * same directory.
  *
  * Uses debouncedJsonStore: in-memory state + 500ms debounced atomic write.
  * No file lock — single-process, no cross-process contention.
@@ -16,7 +17,8 @@ import {
 } from "./debounced-store.ts";
 
 const terminalPanelSessionSchema = z.object({
-  cwd: z.string(),
+  cwd: z.string().optional(),
+  title: z.string().optional(),
   updatedAt: z.string(),
 });
 
@@ -92,6 +94,10 @@ function isRestorableCwd(cwd: string): boolean {
   return cwd.trim() === cwd && cwd.length > 0 && isAbsolute(cwd);
 }
 
+function isRestorableTitle(title: string): boolean {
+  return title.trim().length > 0;
+}
+
 export async function updateTerminalPanelCwd(
   windowId: string,
   panelId: string,
@@ -107,8 +113,35 @@ export async function updateTerminalPanelCwd(
   s.mutate((state) => {
     const windowState = state.windows[windowId] ?? { panels: {} };
     state.windows[windowId] = windowState;
+    const current = windowState.panels[panelId] ?? {};
     windowState.panels[panelId] = {
+      ...current,
       cwd,
+      updatedAt: new Date().toISOString(),
+    };
+    return state;
+  });
+}
+
+export async function updateTerminalPanelTitle(
+  windowId: string,
+  panelId: string,
+  title: string
+): Promise<void> {
+  if (windowId.trim().length === 0 || panelId.trim().length === 0) {
+    return;
+  }
+  if (!isRestorableTitle(title)) {
+    return;
+  }
+  const s = await ensureStore();
+  s.mutate((state) => {
+    const windowState = state.windows[windowId] ?? { panels: {} };
+    state.windows[windowId] = windowState;
+    const current = windowState.panels[panelId] ?? {};
+    windowState.panels[panelId] = {
+      ...current,
+      title,
       updatedAt: new Date().toISOString(),
     };
     return state;

--- a/src/main/state/terminal-session-state.ts
+++ b/src/main/state/terminal-session-state.ts
@@ -168,3 +168,8 @@ export async function removeTerminalPanelSession(
     return state;
   });
 }
+
+export async function flushTerminalSessionState(): Promise<void> {
+  const s = await ensureStore();
+  await s.flush();
+}

--- a/src/main/state/window-record-state.ts
+++ b/src/main/state/window-record-state.ts
@@ -1,0 +1,199 @@
+import { randomUUID } from "node:crypto";
+import { join } from "node:path";
+import { app } from "electron";
+import { z } from "zod";
+import {
+  type DebouncedJsonStore,
+  debouncedJsonStore,
+} from "./debounced-store.ts";
+
+const windowRecordSchema = z.object({
+  id: z.string().min(1),
+  layout: z.unknown().optional(),
+  updatedAt: z.string(),
+});
+
+const windowRecordStateSchema = z.object({
+  openWindowRecordIds: z.array(z.string().min(1)),
+  recentlyClosedWindowRecordIds: z.array(z.string().min(1)),
+  records: z.record(z.string(), windowRecordSchema),
+  version: z.literal(1),
+});
+
+export type WindowRecord = z.infer<typeof windowRecordSchema>;
+type WindowRecordState = z.infer<typeof windowRecordStateSchema>;
+
+const DEFAULTS: WindowRecordState = {
+  openWindowRecordIds: [],
+  recentlyClosedWindowRecordIds: [],
+  records: {},
+  version: 1,
+};
+
+function resolveFilePath(): string {
+  return join(app.getPath("userData"), "window-record-state.json");
+}
+
+let store: DebouncedJsonStore<WindowRecordState> | undefined;
+
+function getStore(): DebouncedJsonStore<WindowRecordState> {
+  if (!store) {
+    store = debouncedJsonStore<WindowRecordState>({
+      filePath: resolveFilePath(),
+      defaults: DEFAULTS,
+      debounceMs: 500,
+    });
+  }
+  return store;
+}
+
+async function ensureStore(): Promise<DebouncedJsonStore<WindowRecordState>> {
+  const s = getStore();
+  try {
+    const raw = await s.init();
+    windowRecordStateSchema.parse(raw);
+  } catch (err) {
+    console.warn(
+      "[window-record-state] parse failed, resetting to defaults:",
+      err
+    );
+    await s.clear();
+    await s.init();
+  }
+  return s;
+}
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+function ensureRecord(
+  state: WindowRecordState,
+  recordId: string
+): WindowRecord {
+  const existing = state.records[recordId];
+  if (existing) {
+    return existing;
+  }
+  const record = {
+    id: recordId,
+    updatedAt: now(),
+  };
+  state.records[recordId] = record;
+  return record;
+}
+
+function withoutId(ids: readonly string[], recordId: string): string[] {
+  return ids.filter((id) => id !== recordId);
+}
+
+export async function createWindowRecord(): Promise<WindowRecord> {
+  const s = await ensureStore();
+  const id = randomUUID();
+  const record = {
+    id,
+    updatedAt: now(),
+  };
+  s.mutate((state) => {
+    state.records[id] = record;
+    return state;
+  });
+  return record;
+}
+
+export async function markWindowRecordOpen(recordId: string): Promise<void> {
+  if (recordId.trim().length === 0) {
+    return;
+  }
+  const s = await ensureStore();
+  s.mutate((state) => {
+    const record = ensureRecord(state, recordId);
+    record.updatedAt = now();
+    state.openWindowRecordIds = [
+      ...withoutId(state.openWindowRecordIds, recordId),
+      recordId,
+    ];
+    state.recentlyClosedWindowRecordIds = withoutId(
+      state.recentlyClosedWindowRecordIds,
+      recordId
+    );
+    return state;
+  });
+}
+
+export async function markWindowRecordClosed(recordId: string): Promise<void> {
+  if (recordId.trim().length === 0) {
+    return;
+  }
+  const s = await ensureStore();
+  s.mutate((state) => {
+    const record = ensureRecord(state, recordId);
+    record.updatedAt = now();
+    state.openWindowRecordIds = withoutId(state.openWindowRecordIds, recordId);
+    state.recentlyClosedWindowRecordIds = [
+      recordId,
+      ...withoutId(state.recentlyClosedWindowRecordIds, recordId),
+    ];
+    return state;
+  });
+}
+
+export async function readOpenWindowRecordIds(): Promise<string[]> {
+  const s = await ensureStore();
+  return [...s.get().openWindowRecordIds];
+}
+
+export async function readMostRecentClosedWindowRecordId(): Promise<
+  string | null
+> {
+  const s = await ensureStore();
+  return s.get().recentlyClosedWindowRecordIds[0] ?? null;
+}
+
+export async function readWindowRecordLayout(
+  recordId: string
+): Promise<unknown | null> {
+  if (recordId.trim().length === 0) {
+    return null;
+  }
+  const s = await ensureStore();
+  return s.get().records[recordId]?.layout ?? null;
+}
+
+export async function saveWindowRecordLayout(
+  recordId: string,
+  layout: unknown
+): Promise<void> {
+  if (recordId.trim().length === 0) {
+    return;
+  }
+  const s = await ensureStore();
+  s.mutate((state) => {
+    const record = ensureRecord(state, recordId);
+    record.layout = layout;
+    record.updatedAt = now();
+    return state;
+  });
+}
+
+export async function clearWindowRecordLayout(recordId: string): Promise<void> {
+  if (recordId.trim().length === 0) {
+    return;
+  }
+  const s = await ensureStore();
+  s.mutate((state) => {
+    const record = state.records[recordId];
+    if (record) {
+      state.records[recordId] = {
+        id: record.id,
+        updatedAt: now(),
+      };
+    }
+    return state;
+  });
+}
+
+export async function flushWindowRecordState(): Promise<void> {
+  const s = await ensureStore();
+  await s.flush();
+}

--- a/src/main/state/workspace-layout.ts
+++ b/src/main/state/workspace-layout.ts
@@ -1,56 +1,27 @@
 /**
- * Workspace 布局持久化 — 存 dockview 的 toJSON() 序列化结果到 userData.
- * reload / 重启窗口后从这里恢复 panel 布局.
+ * Workspace 布局持久化 — 按 durable window record 保存 dockview 的 toJSON().
+ * runtime windowId 会复用, 不能作为布局持久化 key.
  */
-import { join } from "node:path";
-import { app } from "electron";
 import {
-  type DebouncedJsonStore,
-  debouncedJsonStore,
-} from "./debounced-store.ts";
+  clearWindowRecordLayout,
+  readWindowRecordLayout,
+  saveWindowRecordLayout,
+} from "./window-record-state.ts";
 
-function resolveFilePath(): string {
-  return join(app.getPath("userData"), "workspace-layout.json");
+export async function readLayout(recordId: string): Promise<unknown | null> {
+  return await readWindowRecordLayout(recordId);
 }
 
-let store: DebouncedJsonStore<unknown> | undefined;
-
-function getStore(): DebouncedJsonStore<unknown> {
-  if (!store) {
-    store = debouncedJsonStore<unknown>({
-      filePath: resolveFilePath(),
-      defaults: null,
-      debounceMs: 500,
-    });
-  }
-  return store;
-}
-
-async function ensureStore(): Promise<DebouncedJsonStore<unknown>> {
-  const s = getStore();
-  await s.init();
-  return s;
-}
-
-export async function readLayout(): Promise<unknown | null> {
-  const s = await ensureStore();
-  const state = s.get();
-  // null means no layout was ever persisted or it was cleared
-  return state;
-}
-
-export async function saveLayout(layout: unknown): Promise<void> {
-  const s = await ensureStore();
-  s.replace(layout);
+export async function saveLayout(
+  layout: unknown,
+  recordId: string
+): Promise<void> {
+  await saveWindowRecordLayout(recordId, layout);
 }
 
 /**
- * 删除持久化 layout 文件. 用于命令面板"重置布局"操作 — renderer 删 dockview
- * 所有 panel + 重建 default panel 后再调本方法, 防止后续 reload 又恢复旧 layout.
- *
- * 文件不存在视为成功 (idempotent).
+ * 删除当前 window record 的 layout. 用于命令面板"重置布局"和 closeAll.
  */
-export async function clearLayout(): Promise<void> {
-  const s = await ensureStore();
-  await s.clear();
+export async function clearLayout(recordId: string): Promise<void> {
+  await clearWindowRecordLayout(recordId);
 }

--- a/src/main/windows/window-identity.ts
+++ b/src/main/windows/window-identity.ts
@@ -1,14 +1,20 @@
+import type { WindowContext } from "@shared/contracts/window.ts";
 import type { WebContents } from "electron";
 import type { AppWindow } from "./app-window.ts";
 
 const appWindowIds = new WeakMap<AppWindow, string>();
+const appWindowContexts = new WeakMap<AppWindow, WindowContext>();
 const appWindowElectronIds = new WeakMap<AppWindow, number>();
 const appWindowsByElectronId = new Map<number, AppWindow>();
 const appWindowsByWebContents = new WeakMap<WebContents, AppWindow>();
 
-export function rememberAppWindow(window: AppWindow, id: string): void {
+export function rememberAppWindow(
+  window: AppWindow,
+  context: WindowContext
+): void {
   const electronId = window.id;
-  appWindowIds.set(window, id);
+  appWindowIds.set(window, context.windowId);
+  appWindowContexts.set(window, context);
   appWindowElectronIds.set(window, electronId);
   appWindowsByElectronId.set(electronId, window);
   appWindowsByWebContents.set(window.webContents, window);
@@ -16,6 +22,7 @@ export function rememberAppWindow(window: AppWindow, id: string): void {
 
 export function forgetAppWindow(window: AppWindow): void {
   appWindowIds.delete(window);
+  appWindowContexts.delete(window);
   const electronId = appWindowElectronIds.get(window);
   if (electronId !== undefined) {
     appWindowsByElectronId.delete(electronId);
@@ -25,6 +32,14 @@ export function forgetAppWindow(window: AppWindow): void {
 
 export function findInternalWindowId(window: AppWindow): string | null {
   return appWindowIds.get(window) ?? null;
+}
+
+export function findWindowContext(window: AppWindow): WindowContext | null {
+  return appWindowContexts.get(window) ?? null;
+}
+
+export function findWindowSessionId(window: AppWindow): string | null {
+  return findWindowContext(window)?.sessionId ?? null;
 }
 
 export function findAppWindowByElectronId(id: number): AppWindow | null {

--- a/src/main/windows/window-manager.ts
+++ b/src/main/windows/window-manager.ts
@@ -5,7 +5,7 @@
  * close-guard 两段式 / route pending / reload detach 等 pier 暂不需要的能力.
  *
  *   - create(): 分配 id (首窗口 "main", 后续 w-{N}), 创建 app window, 注册到 Map.
- *   - list(): 返回所有存活窗口的 { id, focused }.
+ *   - list(): 返回所有存活窗口的 { id, recordId, focused }.
  *   - focus(): 聚焦/恢复指定窗口.
  *   - close(): 关闭指定窗口.
  *   - onClose(): 关闭回调 (供 main 侧清理).
@@ -13,6 +13,7 @@
  * 窗口关闭后自动从 Map 移除并释放 ID; window-all-closed 由 main 侧处理.
  */
 import { join } from "node:path";
+import type { WindowOpenMode } from "@shared/contracts/window.ts";
 import { PIER_BROADCAST } from "@shared/ipc-channels.ts";
 import {
   app,
@@ -33,6 +34,7 @@ import { WindowIdAllocator } from "./window-id-allocator.ts";
 import {
   findAppWindowByWebContents,
   findInternalWindowId,
+  findWindowContext,
   forgetAppWindow,
   rememberAppWindow,
 } from "./window-identity.ts";
@@ -49,11 +51,14 @@ export interface WindowBounds {
 export interface CreateWindowOptions {
   bounds?: WindowBounds;
   id?: string;
+  mode?: WindowOpenMode;
+  recordId?: string;
 }
 
 export interface WindowInfo {
   focused: boolean;
   id: string;
+  recordId: string;
 }
 
 const isDev = !app.isPackaged;
@@ -66,7 +71,15 @@ function resolveDevIcon(): string | undefined {
 class WindowManager {
   private readonly windows = new Map<string, AppWindow>();
   private readonly allocator = new WindowIdAllocator();
-  private readonly onCloseCallbacks: Array<(windowId: string) => void> = [];
+  private readonly onBeforeCloseCallbacks: Array<
+    (payload: { recordId: string; windowId: string }) => Promise<void> | void
+  > = [];
+  private readonly onCloseCallbacks: Array<
+    (payload: { recordId: string; windowId: string }) => void
+  > = [];
+  private isDestroyingAllForQuit = false;
+  private readonly closeFlushDone = new WeakSet<AppWindow>();
+  private readonly closeFlushPending = new WeakSet<AppWindow>();
 
   setNativeChromeColor(window: AppWindow, color: string): void {
     if (isMac) {
@@ -74,12 +87,24 @@ class WindowManager {
     }
   }
 
-  onClose(callback: (windowId: string) => void): void {
+  onClose(
+    callback: (payload: { recordId: string; windowId: string }) => void
+  ): void {
     this.onCloseCallbacks.push(callback);
+  }
+
+  onBeforeClose(
+    callback: (payload: {
+      recordId: string;
+      windowId: string;
+    }) => Promise<void> | void
+  ): void {
+    this.onBeforeCloseCallbacks.push(callback);
   }
 
   create(opts: CreateWindowOptions = {}): string {
     const id = opts.id ?? this.allocator.next();
+    const mode = opts.mode ?? "restore";
     if (!WINDOW_ID_REGEX.test(id)) {
       throw new Error(`invalid windowId: ${JSON.stringify(id)}`);
     }
@@ -123,7 +148,12 @@ class WindowManager {
     const window = isMac
       ? this.createMacWindow(baseOpts, webPreferences)
       : this.createBrowserWindow(baseOpts, webPreferences, devIcon);
-    rememberAppWindow(window, id);
+    rememberAppWindow(window, {
+      mode,
+      recordId: opts.recordId ?? id,
+      sessionId: opts.recordId ?? id,
+      windowId: id,
+    });
 
     const showOnce = () => {
       if (!window.isDestroyed()) {
@@ -185,7 +215,29 @@ class WindowManager {
     // 不 detach 的话:
     // - NSEvent application-level monitor 永远活在 process 里 (内存泄漏)
     // - GhosttyBridgeImpl.eventRouters dict 累积已死 window 的 router 引用
-    window.host.on("close", () => {
+    window.host.on("close", (event: Electron.Event) => {
+      const context = findWindowContext(window);
+      if (
+        !this.isDestroyingAllForQuit &&
+        context &&
+        !this.closeFlushDone.has(window)
+      ) {
+        event.preventDefault();
+        if (!this.closeFlushPending.has(window)) {
+          this.closeFlushPending.add(window);
+          this.flushBeforeClose(window, {
+            recordId: context.recordId,
+            windowId: id,
+          }).finally(() => {
+            this.closeFlushPending.delete(window);
+            this.closeFlushDone.add(window);
+            if (!window.isDestroyed()) {
+              window.close();
+            }
+          });
+        }
+        return;
+      }
       try {
         getTerminalAddon()?.detachWindow(window.getNativeWindowHandle());
       } catch {
@@ -197,11 +249,14 @@ class WindowManager {
       if (window.appView && !window.webContents.isDestroyed()) {
         window.webContents.close();
       }
+      const context = findWindowContext(window);
       forgetAppWindow(window);
       this.windows.delete(id);
       this.allocator.release(id);
-      for (const cb of this.onCloseCallbacks) {
-        cb(id);
+      if (!this.isDestroyingAllForQuit && context) {
+        for (const cb of this.onCloseCallbacks) {
+          cb({ recordId: context.recordId, windowId: id });
+        }
       }
     });
 
@@ -220,6 +275,22 @@ class WindowManager {
 
     this.windows.set(id, window);
     return id;
+  }
+
+  private async flushBeforeClose(
+    window: AppWindow,
+    payload: { recordId: string; windowId: string }
+  ): Promise<void> {
+    try {
+      await Promise.all(this.onBeforeCloseCallbacks.map((cb) => cb(payload)));
+    } catch (err) {
+      console.error(
+        "[window-before-close] failed:",
+        err instanceof Error ? err.message : String(err)
+      );
+    } finally {
+      this.closeFlushPending.delete(window);
+    }
   }
 
   private createMacWindow(
@@ -272,6 +343,7 @@ class WindowManager {
     return [...this.windows.entries()].map(([id, w]) => ({
       id,
       focused: w.isFocused(),
+      recordId: findWindowContext(w)?.recordId ?? id,
     }));
   }
 
@@ -291,6 +363,7 @@ class WindowManager {
   }
 
   destroyAllForQuit(): void {
+    this.isDestroyingAllForQuit = true;
     for (const window of this.windows.values()) {
       if (!window.isDestroyed()) {
         try {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -145,6 +145,8 @@ const terminalApi: TerminalAPI = {
   onCwdChange: (cb) => subscribeIpc("pier:terminal:cwd-change", cb),
   onFocusRequest: (cb) => subscribeIpc("pier:terminal:focus-request", cb),
   onTitleChange: (cb) => subscribeIpc("pier:terminal:title-change", cb),
+  readSession: (panelId) =>
+    ipcRenderer.invoke("pier:terminal:read-session", panelId),
   setActivePanelKind: (kind, panelId) =>
     ipcRenderer.send("pier:terminal:set-active-panel-kind", kind, panelId),
   setFont: (panelId, font) =>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -13,12 +13,17 @@ import {
   RENDERER_COMMAND_RESULT_CHANNEL,
 } from "@shared/contracts/renderer-command-channels.ts";
 import type { TerminalAPI } from "@shared/contracts/terminal.ts";
+import type {
+  WindowContext,
+  WindowCreateResult,
+} from "@shared/contracts/window.ts";
 import { PIER_BROADCAST } from "@shared/ipc-channels.ts";
 import { contextBridge, ipcRenderer } from "electron";
 
 export interface WindowInfo {
   focused: boolean;
   id: string;
+  recordId: string;
 }
 
 interface PreferencesSnapshot {
@@ -49,9 +54,9 @@ export interface PierThemeAPI {
 }
 
 export interface PierWorkspaceAPI {
-  clearLayout: () => Promise<void>;
-  loadLayout: () => Promise<unknown | null>;
-  saveLayout: (layout: unknown) => Promise<void>;
+  clearLayout: (recordId: string) => Promise<void>;
+  loadLayout: (recordId: string) => Promise<unknown | null>;
+  saveLayout: (layout: unknown, recordId: string) => Promise<void>;
 }
 
 export interface PierRendererCommandAPI {
@@ -92,8 +97,9 @@ export interface PierWindowAPI {
   closeCurrentWindow: () => Promise<void>;
   closeWindow: (windowId: string) => Promise<void>;
   commandPaletteMru: PierCommandPaletteMruAPI;
-  createWindow: () => Promise<{ windowId: string }>;
+  createWindow: () => Promise<WindowCreateResult>;
   focusWindow: (windowId: string) => Promise<void>;
+  getWindowContext: () => Promise<WindowContext>;
   keybinding: PierKeybindingAPI;
   listWindows: () => Promise<WindowInfo[]>;
   menu: PierMenuAPI;
@@ -166,10 +172,12 @@ const themeApi: PierThemeAPI = {
 };
 
 const workspaceApi: PierWorkspaceAPI = {
-  clearLayout: () => ipcRenderer.invoke("pier:workspace:clear-layout"),
-  loadLayout: () => ipcRenderer.invoke("pier:workspace:load-layout"),
-  saveLayout: (layout) =>
-    ipcRenderer.invoke("pier:workspace:save-layout", layout),
+  clearLayout: (recordId) =>
+    ipcRenderer.invoke("pier:workspace:clear-layout", recordId),
+  loadLayout: (recordId) =>
+    ipcRenderer.invoke("pier:workspace:load-layout", recordId),
+  saveLayout: (layout, recordId) =>
+    ipcRenderer.invoke("pier:workspace:save-layout", layout, recordId),
 };
 
 const rendererCommandApi: PierRendererCommandAPI = {
@@ -211,6 +219,7 @@ const api: PierWindowAPI = {
   createWindow: () => ipcRenderer.invoke("pier://window:create"),
   focusWindow: (windowId) =>
     ipcRenderer.invoke("pier://window:focus", windowId),
+  getWindowContext: () => ipcRenderer.invoke("pier://window:context"),
   keybinding: keybindingApi,
   listWindows: () => ipcRenderer.invoke("pier://window:list"),
   menu: menuApi,

--- a/src/renderer/components/workspace/workspace-host.tsx
+++ b/src/renderer/components/workspace/workspace-host.tsx
@@ -162,6 +162,9 @@ function runRendererCommand(envelope: RendererCommandEnvelope): void {
         });
         return;
       }
+      case "workspace.flushLayout": {
+        throw new Error("workspace.flushLayout requires workspace api context");
+      }
       default: {
         const _exhaustive: never = envelope.command;
         throw new Error(`unsupported renderer command: ${String(_exhaustive)}`);
@@ -197,6 +200,42 @@ export function WorkspaceHost() {
       // / 拖 panel 等), userTouched=true. loadLayout 完成时如果 user 已操作, fromJSON
       // 跳过 (不覆盖 user 操作) — user 显式新建的 panel 优先于磁盘旧 layout.
       let userTouched = false;
+      const windowContextPromise = window.pier.getWindowContext();
+
+      const saveCurrentLayout = async (): Promise<void> => {
+        const json = event.api.toJSON();
+        const windowContext = await windowContextPromise;
+        await window.pier.workspace.saveLayout(json, windowContext.recordId);
+      };
+
+      const flushCurrentLayout = async (
+        envelope: RendererCommandEnvelope
+      ): Promise<void> => {
+        try {
+          const windowContext = await windowContextPromise;
+          if (event.api.totalPanels === 0) {
+            await window.pier.workspace.clearLayout(windowContext.recordId);
+          } else {
+            await window.pier.workspace.saveLayout(
+              event.api.toJSON(),
+              windowContext.recordId
+            );
+          }
+          window.pier.rendererCommand.resolve({
+            data: null,
+            ok: true,
+            requestId: envelope.requestId,
+          });
+        } catch (error) {
+          window.pier.rendererCommand.resolve({
+            error: {
+              message: error instanceof Error ? error.message : String(error),
+            },
+            ok: false,
+            requestId: envelope.requestId,
+          });
+        }
+      };
 
       // onDidLayoutChange 双责任: 标记 userTouched (防 fromJSON 覆盖) + debounced save
       let saveTimer: ReturnType<typeof setTimeout> | null = null;
@@ -211,14 +250,9 @@ export function WorkspaceHost() {
         }
         saveTimer = setTimeout(() => {
           saveTimer = null;
-          try {
-            const json = event.api.toJSON();
-            window.pier.workspace.saveLayout(json).catch((err) => {
-              console.error("[workspace] saveLayout failed:", err);
-            });
-          } catch (err) {
-            console.error("[workspace] toJSON failed:", err);
-          }
+          saveCurrentLayout().catch((err) => {
+            console.error("[workspace] saveLayout failed:", err);
+          });
         }, SAVE_DEBOUNCE_MS);
       });
 
@@ -264,7 +298,15 @@ export function WorkspaceHost() {
         }
       });
 
-      window.pier.rendererCommand.onCommand(runRendererCommand);
+      window.pier.rendererCommand.onCommand((envelope) => {
+        if (envelope.command.type === "workspace.flushLayout") {
+          flushCurrentLayout(envelope).catch((error) => {
+            console.error("[workspace] flushLayout failed:", error);
+          });
+          return;
+        }
+        runRendererCommand(envelope);
+      });
 
       // 异步恢复持久化 layout — 仅在 user 未触碰时应用. 失败或无持久化 layout 时
       // 用 default. 注意: applyDefaultLayout / fromJSON 都包在 isApplyingPersistedLayout
@@ -272,7 +314,10 @@ export function WorkspaceHost() {
       (async () => {
         let saved: unknown = null;
         try {
-          saved = await window.pier.workspace.loadLayout();
+          const windowContext = await windowContextPromise;
+          saved = await window.pier.workspace.loadLayout(
+            windowContext.recordId
+          );
         } catch (err) {
           console.error("[workspace] loadLayout failed:", err);
         }

--- a/src/renderer/hooks/use-panel-descriptor.ts
+++ b/src/renderer/hooks/use-panel-descriptor.ts
@@ -31,13 +31,18 @@ export interface PanelHandle {
  */
 export function usePanelDescriptor(
   panel: PanelHandle,
-  descriptor: PanelDescriptor
+  descriptor: PanelDescriptor | null
 ): void {
-  const { short, long, path } = descriptor;
+  const short = descriptor?.short;
+  const long = descriptor?.long;
+  const path = descriptor?.path;
   const upsert = usePanelDescriptorStore((s) => s.upsert);
   const remove = usePanelDescriptorStore((s) => s.remove);
 
   useEffect(() => {
+    if (short === undefined) {
+      return;
+    }
     panel.setTitle(short);
     upsert(panel.id, { short, long, path });
     return () => remove(panel.id);

--- a/src/renderer/lib/ipc/window-ipc.ts
+++ b/src/renderer/lib/ipc/window-ipc.ts
@@ -6,10 +6,18 @@
 
 export type { PierWindowAPI, WindowInfo } from "../../../preload/index.ts";
 
+import type {
+  WindowContext,
+  WindowCreateResult,
+} from "@shared/contracts/window.ts";
 import type { WindowInfo } from "../../../preload/index.ts";
 
-export function createWindow(): Promise<{ windowId: string }> {
+export function createWindow(): Promise<WindowCreateResult> {
   return window.pier.createWindow();
+}
+
+export function getWindowContext(): Promise<WindowContext> {
+  return window.pier.getWindowContext();
 }
 
 export function listWindows(): Promise<WindowInfo[]> {

--- a/src/renderer/lib/keybindings/defaults.ts
+++ b/src/renderer/lib/keybindings/defaults.ts
@@ -9,7 +9,7 @@ import type { KeybindingInput } from "./types.ts";
 
 export const DEFAULT_KEYMAP: readonly KeybindingInput[] = [
   {
-    commandId: "pier.panel.newTab",
+    commandId: "pier.panel.newTerminal",
     keys: "Mod+KeyT",
     nativeTerminal: "app",
     scope: "global",

--- a/src/renderer/panel-kits/terminal/terminal-panel.tsx
+++ b/src/renderer/panel-kits/terminal/terminal-panel.tsx
@@ -211,7 +211,7 @@ export function TerminalPanel(props: IDockviewPanelProps) {
 
     subscriptions.push(api.onDidDimensionsChange(sendFrameNow));
 
-    if (api.isVisible) {
+    if (api.isVisible || api.isActive) {
       ensureNativeTerminal().catch(logCreateError);
     }
 

--- a/src/renderer/panel-kits/terminal/terminal-panel.tsx
+++ b/src/renderer/panel-kits/terminal/terminal-panel.tsx
@@ -1,3 +1,4 @@
+import type { TerminalPanelSessionSnapshot } from "@shared/contracts/terminal.ts";
 import type { IDockviewPanelProps } from "dockview-react";
 import { useEffect, useRef, useState } from "react";
 import { usePanelDescriptor } from "@/hooks/use-panel-descriptor.ts";
@@ -44,6 +45,9 @@ export function TerminalPanel(props: IDockviewPanelProps) {
   const monoFontSize = useFontStore((s) => s.monoFontSize);
   const anchorRef = useRef<HTMLDivElement>(null);
   const [error, setError] = useState<string | null>(null);
+  const [savedSession, setSavedSession] = useState<
+    TerminalPanelSessionSnapshot | null | undefined
+  >(undefined);
 
   // 订阅 swift OSC 7 → main → 这里. usePanelEventState 自动按 panelId 过滤 +
   // 空字符串忽略 (vim set notitle / tmux detach 等清空场景不污染上一次有效值).
@@ -58,22 +62,52 @@ export function TerminalPanel(props: IDockviewPanelProps) {
     (e) => e.title
   );
 
+  const sessionLoaded = savedSession !== undefined;
+  const effectiveCwd = cwd ?? savedSession?.cwd ?? null;
+  const effectiveTitle = sequenceTitle ?? savedSession?.title ?? null;
+
   // descriptor 三字段优先级链:
   // - short: basename(cwd) — tab strip 始终显示目录, 不被 OSC 干扰 (稳定锚点)
   // - long:  sequenceTitle ?? cwd — sink 优先 OSC 自定义 ("Claude Code"),
   //          没 OSC 时 fallback cwd 完整路径
   // - path:  cwd — 真实 cwd, 不被 OSC override (breadcrumb / status bar 用)
   // hook input 接受 undefined; hook 内部按字段存在性条件 upsert 到 store.
-  usePanelDescriptor(api, {
-    short: cwd ? basename(cwd) : "Terminal",
-    long: sequenceTitle ?? cwd ?? undefined,
-    path: cwd ?? undefined,
-  });
+  usePanelDescriptor(
+    api,
+    sessionLoaded
+      ? {
+          short: effectiveCwd ? basename(effectiveCwd) : "Terminal",
+          long: effectiveTitle ?? effectiveCwd ?? undefined,
+          path: effectiveCwd ?? undefined,
+        }
+      : null
+  );
 
   const monoFontFamilyRef = useRef(monoFontFamily);
   const monoFontSizeRef = useRef(monoFontSize);
   monoFontFamilyRef.current = monoFontFamily;
   monoFontSizeRef.current = monoFontSize;
+
+  useEffect(() => {
+    let disposed = false;
+    setSavedSession(undefined);
+    window.pier.terminal
+      .readSession(panelId)
+      .then((session) => {
+        if (!disposed) {
+          setSavedSession(session);
+        }
+      })
+      .catch((err: unknown) => {
+        console.error(`[terminal-panel] read session ${panelId} failed:`, err);
+        if (!disposed) {
+          setSavedSession(null);
+        }
+      });
+    return () => {
+      disposed = true;
+    };
+  }, [panelId]);
 
   useEffect(() => {
     const anchor = anchorRef.current;
@@ -84,70 +118,102 @@ export function TerminalPanel(props: IDockviewPanelProps) {
     let disposed = false;
     const subscriptions: Array<{ dispose(): void }> = [];
     let layoutRegistration: TerminalLayoutRegistration | null = null;
+    let didCreateNativeTerminal = false;
+    let createPromise: Promise<void> | null = null;
 
     const sendFrameNow = () => {
-      if (disposed) {
+      if (disposed || !didCreateNativeTerminal) {
         return;
       }
       layoutRegistration?.flushNow("dockview-dimensions");
     };
 
-    const init = async () => {
-      await waitForRealSize(anchor);
-      if (disposed) {
-        return;
-      }
-
-      const frame = readTerminalAnchorFrame(anchor);
-      if (!frame) {
-        setError("无法获取面板坐标");
-        return;
-      }
-
-      const result = await window.pier.terminal.create({
-        panelId,
-        frame,
-        font: {
-          family: computeMonoFontFamily(monoFontFamilyRef.current),
-          size: monoFontSizeRef.current,
-        },
-      });
-      if (!result.ok) {
-        setError(result.error ?? "终端创建失败");
-        return;
-      }
-
-      layoutRegistration = registerTerminalLayoutAnchor(panelId, anchor);
-
-      subscriptions.push(
-        api.onDidVisibilityChange((e) => {
-          if (e.isVisible) {
-            layoutRegistration?.flushTrailing("visibility");
-            window.pier.terminal.show(panelId);
-          } else {
-            // 直接发 hide IPC. swift hide 总是执行 (移 offscreen + remove targets),
-            // 由后续 setFrame 把 NSView 移回新位置自动恢复 visible (drag 场景), 或者
-            // 让出 z-order 给新 active panel (tab 切换场景). 早期版本用过双 rAF 等
-            // dockview settle, 但 visibility=false → true 紧接 fire 时 (drag drop)
-            // 双 rAF 跟即时 show 形成 race:show 完成后 rAF 内的 hide 才跑, 最终状态
-            // 变成 hidden. 直接 hide + 不延迟最干净.
-            window.pier.terminal.hide(panelId);
-          }
-        })
-      );
-
-      subscriptions.push(
-        api.onDidActiveChange((e) => {
-          if (e.isActive) {
-            window.pier.terminal.focus(panelId);
-          }
-        })
-      );
-
-      subscriptions.push(api.onDidDimensionsChange(sendFrameNow));
+    const logCreateError = (err: unknown) => {
+      console.error(`[terminal-panel] create ${panelId} failed:`, err);
     };
 
-    init();
+    const ensureNativeTerminal = (): Promise<void> => {
+      if (didCreateNativeTerminal) {
+        return Promise.resolve();
+      }
+      if (createPromise) {
+        return createPromise;
+      }
+      createPromise = (async () => {
+        await waitForRealSize(anchor);
+        if (disposed || didCreateNativeTerminal) {
+          return;
+        }
+
+        const frame = readTerminalAnchorFrame(anchor);
+        if (!frame) {
+          setError("无法获取面板坐标");
+          return;
+        }
+
+        const result = await window.pier.terminal.create({
+          panelId,
+          frame,
+          font: {
+            family: computeMonoFontFamily(monoFontFamilyRef.current),
+            size: monoFontSizeRef.current,
+          },
+        });
+        if (!result.ok) {
+          setError(result.error ?? "终端创建失败");
+          return;
+        }
+
+        didCreateNativeTerminal = true;
+        layoutRegistration = registerTerminalLayoutAnchor(panelId, anchor);
+      })().finally(() => {
+        createPromise = null;
+      });
+      return createPromise;
+    };
+
+    subscriptions.push(
+      api.onDidVisibilityChange((e) => {
+        if (e.isVisible) {
+          ensureNativeTerminal()
+            .then(() => {
+              if (!disposed && didCreateNativeTerminal) {
+                layoutRegistration?.flushTrailing("visibility");
+                window.pier.terminal.show(panelId);
+              }
+            })
+            .catch(logCreateError);
+        } else if (didCreateNativeTerminal) {
+          // 直接发 hide IPC. swift hide 总是执行 (移 offscreen + remove targets),
+          // 由后续 setFrame 把 NSView 移回新位置自动恢复 visible (drag 场景), 或者
+          // 让出 z-order 给新 active panel (tab 切换场景). 早期版本用过双 rAF 等
+          // dockview settle, 但 visibility=false → true 紧接 fire 时 (drag drop)
+          // 双 rAF 跟即时 show 形成 race:show 完成后 rAF 内的 hide 才跑, 最终状态
+          // 变成 hidden. 直接 hide + 不延迟最干净.
+          window.pier.terminal.hide(panelId);
+        }
+      })
+    );
+
+    subscriptions.push(
+      api.onDidActiveChange((e) => {
+        if (e.isActive) {
+          ensureNativeTerminal()
+            .then(() => {
+              if (!disposed && didCreateNativeTerminal) {
+                window.pier.terminal.focus(panelId);
+              }
+            })
+            .catch(logCreateError);
+        }
+      })
+    );
+
+    subscriptions.push(api.onDidDimensionsChange(sendFrameNow));
+
+    if (api.isVisible) {
+      ensureNativeTerminal().catch(logCreateError);
+    }
 
     return () => {
       disposed = true;

--- a/src/renderer/stores/workspace.store.ts
+++ b/src/renderer/stores/workspace.store.ts
@@ -41,6 +41,11 @@ function getGroupElement(g: unknown): HTMLElement | null {
  */
 const FOCUS_TOL_PX = 5;
 
+async function clearCurrentWindowLayout(): Promise<void> {
+  const context = await window.pier.getWindowContext();
+  await window.pier.workspace.clearLayout(context.recordId);
+}
+
 export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
   api: null,
   setApi: (api) => set({ api }),
@@ -189,7 +194,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     // 先清磁盘 layout — 防 removePanel 触发的 debounced save 与 closeCurrentWindow 时序
     // 竞争把空 layout 写入磁盘 (下次启动 fromJSON 拿到空 panel list 应用为空 workspace).
     try {
-      await window.pier?.workspace?.clearLayout?.();
+      await clearCurrentWindowLayout();
     } catch (err) {
       console.error("[workspace] clearLayout failed:", err);
     }
@@ -286,7 +291,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     // 的时序竞争. clearLayout 后再 addPanel 触发的 save 写回的是 default layout,
     // 即使覆盖也无害.
     try {
-      await window.pier?.workspace?.clearLayout?.();
+      await clearCurrentWindowLayout();
     } catch (err) {
       console.error("[workspace] clearLayout failed:", err);
     }

--- a/src/shared/contracts/commands.ts
+++ b/src/shared/contracts/commands.ts
@@ -25,12 +25,19 @@ export const pierCommandSchema = z.discriminatedUnion("type", [
     type: z.literal("preferences.update"),
     patch: projectPreferencesPatchSchema,
   }),
-  z.object({ type: z.literal("workspace.layout.read") }),
   z.object({
-    type: z.literal("workspace.layout.save"),
-    layout: z.unknown(),
+    recordId: z.string().min(1),
+    type: z.literal("workspace.layout.read"),
   }),
-  z.object({ type: z.literal("workspace.layout.clear") }),
+  z.object({
+    layout: z.unknown(),
+    recordId: z.string().min(1),
+    type: z.literal("workspace.layout.save"),
+  }),
+  z.object({
+    recordId: z.string().min(1),
+    type: z.literal("workspace.layout.clear"),
+  }),
   z.object({
     type: z.literal("workspace.open"),
     focus: z.boolean().optional(),

--- a/src/shared/contracts/events.ts
+++ b/src/shared/contracts/events.ts
@@ -4,6 +4,7 @@ import type { ProjectPreferences } from "./preferences.ts";
 export interface WindowInfo {
   focused: boolean;
   id: string;
+  recordId: string;
 }
 
 export interface PanelSnapshot {

--- a/src/shared/contracts/renderer-command.ts
+++ b/src/shared/contracts/renderer-command.ts
@@ -35,6 +35,10 @@ export const rendererCommandSchema = z.discriminatedUnion("type", [
     placement: pierCommandPlacementSchema.optional(),
     windowId: z.string().min(1).optional(),
   }),
+  z.object({
+    type: z.literal("workspace.flushLayout"),
+    windowId: z.string().min(1).optional(),
+  }),
 ]);
 
 export type RendererCommand = z.infer<typeof rendererCommandSchema>;

--- a/src/shared/contracts/terminal.ts
+++ b/src/shared/contracts/terminal.ts
@@ -57,6 +57,12 @@ export interface TerminalTitleEvent {
   title: string;
 }
 
+export interface TerminalPanelSessionSnapshot {
+  cwd?: string | undefined;
+  title?: string | undefined;
+  updatedAt: string;
+}
+
 /**
  * ANSI 16 色 palette. 索引语义 = xterm-256color 前 16 槽:
  * 0..7   = black, red, green, yellow, blue, magenta, cyan, white
@@ -128,6 +134,11 @@ export interface TerminalAPI {
    * 与 onCwdChange 相同的"多 listener 各自过滤"模式.
    */
   onTitleChange(cb: (event: TerminalTitleEvent) => void): () => void;
+  /**
+   * 读取上次关闭前的 terminal panel 展示状态. 用于 app 重启后先恢复 tab
+   * 标题/cwd, 真正的 native terminal 可以等 panel 可见时再创建.
+   */
+  readSession(panelId: string): Promise<TerminalPanelSessionSnapshot | null>;
   /**
    * 报告 renderer 当前活跃的 terminal panelId 集合. swift 把不在集合里的 NSView
    * 清掉 — C 方案 reload 零销毁路径的孤儿兜底:reload 前 layout 有但新 layout

--- a/src/shared/contracts/window.ts
+++ b/src/shared/contracts/window.ts
@@ -1,0 +1,17 @@
+export type WindowOpenMode = "fresh" | "restore";
+
+export interface WindowCreateOptions {
+  mode?: "fresh";
+}
+
+export interface WindowCreateResult {
+  recordId: string;
+  windowId: string;
+}
+
+export interface WindowContext {
+  mode: WindowOpenMode;
+  recordId: string;
+  sessionId: string;
+  windowId: string;
+}

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -7,6 +7,7 @@ export const PIER = {
   // window
   WINDOW_CLOSE_CURRENT: "pier://window:close-current",
   WINDOW_CLOSE: "pier://window:close",
+  WINDOW_CONTEXT: "pier://window:context",
   WINDOW_CREATE: "pier://window:create",
   WINDOW_FOCUS: "pier://window:focus",
   WINDOW_FULLSCREEN_STATE: "pier://window:fullscreen-state",

--- a/tests/component/terminal-panel-lifecycle.test.tsx
+++ b/tests/component/terminal-panel-lifecycle.test.tsx
@@ -25,27 +25,38 @@ class TestResizeObserver {
 }
 
 interface TestPanelProps extends IDockviewPanelProps {
+  emitActive(event: { isActive: boolean }): void;
   emitDimensions(event: { height: number; width: number }): void;
   emitVisibility(event: { isVisible: boolean }): void;
 }
 
 function createPanelProps(
-  options: { isVisible?: boolean } = {}
+  options: { isActive?: boolean; isVisible?: boolean } = {}
 ): TestPanelProps {
+  let onDidActiveChange: ((event: { isActive: boolean }) => void) | null = null;
   let onDidDimensionsChange:
     | ((event: { height: number; width: number }) => void)
     | null = null;
   let onDidVisibilityChange: ((event: { isVisible: boolean }) => void) | null =
     null;
+  let isActive = options.isActive ?? true;
   let isVisible = options.isVisible ?? true;
   const props = {
     api: {
       height: 300,
       id: "terminal-1",
+      get isActive() {
+        return isActive;
+      },
       get isVisible() {
         return isVisible;
       },
-      onDidActiveChange: vi.fn(() => ({ dispose: vi.fn() })),
+      onDidActiveChange: vi.fn(
+        (listener: (event: { isActive: boolean }) => void) => {
+          onDidActiveChange = listener;
+          return { dispose: vi.fn() };
+        }
+      ),
       onDidDimensionsChange: vi.fn(
         (listener: (event: { height: number; width: number }) => void) => {
           onDidDimensionsChange = listener;
@@ -62,6 +73,10 @@ function createPanelProps(
       width: 400,
     },
     containerApi: {},
+    emitActive(event: { isActive: boolean }) {
+      isActive = event.isActive;
+      onDidActiveChange?.(event);
+    },
     emitDimensions(event: { height: number; width: number }) {
       onDidDimensionsChange?.(event);
     },
@@ -173,7 +188,7 @@ describe("TerminalPanel lifecycle", () => {
       title: "Claude Code",
       updatedAt: "2026-06-25T00:00:00.000Z",
     });
-    const props = createPanelProps({ isVisible: false });
+    const props = createPanelProps({ isActive: false, isVisible: false });
 
     render(<TerminalPanel {...props} />);
 
@@ -184,6 +199,18 @@ describe("TerminalPanel lifecycle", () => {
     expect(window.pier.terminal.create).not.toHaveBeenCalled();
 
     props.emitVisibility({ isVisible: true });
+
+    await waitFor(() => {
+      expect(window.pier.terminal.create).toHaveBeenCalledWith(
+        expect.objectContaining({ panelId: "terminal-1" })
+      );
+    });
+  });
+
+  it("creates a native terminal for a newly active terminal panel before visibility settles", async () => {
+    const props = createPanelProps({ isActive: true, isVisible: false });
+
+    render(<TerminalPanel {...props} />);
 
     await waitFor(() => {
       expect(window.pier.terminal.create).toHaveBeenCalledWith(

--- a/tests/component/terminal-panel-lifecycle.test.tsx
+++ b/tests/component/terminal-panel-lifecycle.test.tsx
@@ -26,16 +26,25 @@ class TestResizeObserver {
 
 interface TestPanelProps extends IDockviewPanelProps {
   emitDimensions(event: { height: number; width: number }): void;
+  emitVisibility(event: { isVisible: boolean }): void;
 }
 
-function createPanelProps(): TestPanelProps {
+function createPanelProps(
+  options: { isVisible?: boolean } = {}
+): TestPanelProps {
   let onDidDimensionsChange:
     | ((event: { height: number; width: number }) => void)
     | null = null;
+  let onDidVisibilityChange: ((event: { isVisible: boolean }) => void) | null =
+    null;
+  let isVisible = options.isVisible ?? true;
   const props = {
     api: {
       height: 300,
       id: "terminal-1",
+      get isVisible() {
+        return isVisible;
+      },
       onDidActiveChange: vi.fn(() => ({ dispose: vi.fn() })),
       onDidDimensionsChange: vi.fn(
         (listener: (event: { height: number; width: number }) => void) => {
@@ -43,13 +52,22 @@ function createPanelProps(): TestPanelProps {
           return { dispose: vi.fn() };
         }
       ),
-      onDidVisibilityChange: vi.fn(() => ({ dispose: vi.fn() })),
+      onDidVisibilityChange: vi.fn(
+        (listener: (event: { isVisible: boolean }) => void) => {
+          onDidVisibilityChange = listener;
+          return { dispose: vi.fn() };
+        }
+      ),
       setTitle: vi.fn(),
       width: 400,
     },
     containerApi: {},
     emitDimensions(event: { height: number; width: number }) {
       onDidDimensionsChange?.(event);
+    },
+    emitVisibility(event: { isVisible: boolean }) {
+      isVisible = event.isVisible;
+      onDidVisibilityChange?.(event);
     },
   };
   return props as unknown as TestPanelProps;
@@ -120,6 +138,7 @@ describe("TerminalPanel lifecycle", () => {
           onContextMenuRequest: vi.fn(() => vi.fn()),
           onCwdChange: vi.fn(() => vi.fn()),
           onTitleChange: vi.fn(() => vi.fn()),
+          readSession: vi.fn(async () => null),
           setFont: vi.fn(),
           setFrame: vi.fn(),
           show: vi.fn(),
@@ -148,6 +167,31 @@ describe("TerminalPanel lifecycle", () => {
     expect(window.pier.terminal.close).not.toHaveBeenCalled();
   });
 
+  it("restores the saved tab descriptor before creating a hidden native terminal", async () => {
+    vi.mocked(window.pier.terminal.readSession).mockResolvedValue({
+      cwd: "/Users/xyz/ABC/pier",
+      title: "Claude Code",
+      updatedAt: "2026-06-25T00:00:00.000Z",
+    });
+    const props = createPanelProps({ isVisible: false });
+
+    render(<TerminalPanel {...props} />);
+
+    await waitFor(() => {
+      expect(props.api.setTitle).toHaveBeenCalledWith("pier");
+    });
+    expect(props.api.setTitle).not.toHaveBeenCalledWith("Terminal");
+    expect(window.pier.terminal.create).not.toHaveBeenCalled();
+
+    props.emitVisibility({ isVisible: true });
+
+    await waitFor(() => {
+      expect(window.pier.terminal.create).toHaveBeenCalledWith(
+        expect.objectContaining({ panelId: "terminal-1" })
+      );
+    });
+  });
+
   it("uses dockview dimension events and anchor resize observations for terminal frame updates", async () => {
     const props = createPanelProps();
 
@@ -157,6 +201,9 @@ describe("TerminalPanel lifecycle", () => {
       expect(window.pier.terminal.create).toHaveBeenCalledWith(
         expect.objectContaining({ panelId: "terminal-1" })
       );
+    });
+    await waitFor(() => {
+      expect(TestResizeObserver.observeCount).toBe(1);
     });
     vi.mocked(window.pier.terminal.setFrame).mockClear();
 
@@ -173,8 +220,6 @@ describe("TerminalPanel lifecycle", () => {
         })
       );
     });
-    expect(TestResizeObserver.observeCount).toBe(1);
-
     vi.mocked(window.pier.terminal.setFrame).mockClear();
     anchorFrame = {
       height: 340,

--- a/tests/unit/app-core/cli-adapter.test.ts
+++ b/tests/unit/app-core/cli-adapter.test.ts
@@ -60,7 +60,7 @@ describe("createPierCliCommandClient", () => {
         request(envelope) {
           seen.push(envelope);
           return Promise.resolve({
-            data: [{ id: "main", focused: true }],
+            data: [{ id: "main", focused: true, recordId: "record-main" }],
             ok: true,
             requestId: "req-9",
           });
@@ -69,7 +69,7 @@ describe("createPierCliCommandClient", () => {
     });
 
     await expect(client.run(["windows", "list", "--json"])).resolves.toEqual({
-      data: [{ id: "main", focused: true }],
+      data: [{ id: "main", focused: true, recordId: "record-main" }],
       ok: true,
       requestId: "req-9",
     });

--- a/tests/unit/app-core/command-router.test.ts
+++ b/tests/unit/app-core/command-router.test.ts
@@ -61,9 +61,9 @@ function services(rendererCommands: unknown[] = []): PierCoreServices {
       }),
     },
     workspace: {
-      clearLayout: async () => undefined,
-      readLayout: async () => null,
-      saveLayout: async () => undefined,
+      clearLayout: async (_recordId) => undefined,
+      readLayout: async (_recordId) => null,
+      saveLayout: async (_layout, _recordId) => undefined,
     },
     rendererCommand: {
       execute: (command) => {
@@ -78,9 +78,18 @@ function services(rendererCommands: unknown[] = []): PierCoreServices {
     },
     window: {
       close: () => undefined,
-      create: () => ({ windowId: "w-1" }),
+      create: async () => ({ recordId: "record-1", windowId: "w-1" }),
       focus: () => undefined,
-      list: () => [{ focused: true, id: "main" }],
+      flushOpenWindows: async () => undefined,
+      flushWindow: async () => undefined,
+      list: () => [{ focused: true, id: "main", recordId: "record-main" }],
+      restoreMostRecentClosed: async () => ({
+        recordId: "record-closed",
+        windowId: "main",
+      }),
+      restoreOpenWindows: async () => [
+        { recordId: "record-open", windowId: "main" },
+      ],
     },
   };
 }
@@ -100,7 +109,7 @@ describe("createCommandRouter", () => {
         requestId: "req-1",
       })
     ).resolves.toEqual({
-      data: [{ focused: true, id: "main" }],
+      data: [{ focused: true, id: "main", recordId: "record-main" }],
       ok: true,
       requestId: "req-1",
     });
@@ -284,5 +293,86 @@ describe("createCommandRouter", () => {
       { type: "terminal.list", windowId: "main" },
       { panelId: "terminal-1", type: "terminal.focus", windowId: "main" },
     ]);
+  });
+
+  it("workspace layout commands require and pass through a durable window record id", async () => {
+    const calls: unknown[] = [];
+    const fakeServices = services();
+    fakeServices.workspace = {
+      clearLayout: (recordId) => {
+        calls.push(["clear", recordId]);
+        return Promise.resolve();
+      },
+      readLayout: (recordId) => {
+        calls.push(["read", recordId]);
+        return Promise.resolve({ layout: "from-record" });
+      },
+      saveLayout: (layout, recordId) => {
+        calls.push(["save", recordId, layout]);
+        return Promise.resolve();
+      },
+    };
+    const router = createCommandRouter({
+      clients: registryWith(desktopClient),
+      services: fakeServices,
+    });
+
+    await expect(
+      router.execute({
+        clientId: "desktop-1",
+        command: { recordId: "record-1", type: "workspace.layout.read" },
+        protocolVersion: 1,
+        requestId: "req-layout-read",
+      })
+    ).resolves.toEqual({
+      data: { layout: "from-record" },
+      ok: true,
+      requestId: "req-layout-read",
+    });
+    await router.execute({
+      clientId: "desktop-1",
+      command: {
+        layout: { grid: "updated" },
+        recordId: "record-1",
+        type: "workspace.layout.save",
+      },
+      protocolVersion: 1,
+      requestId: "req-layout-save",
+    });
+    await router.execute({
+      clientId: "desktop-1",
+      command: { recordId: "record-1", type: "workspace.layout.clear" },
+      protocolVersion: 1,
+      requestId: "req-layout-clear",
+    });
+
+    expect(calls).toEqual([
+      ["read", "record-1"],
+      ["save", "record-1", { grid: "updated" }],
+      ["clear", "record-1"],
+    ]);
+  });
+
+  it("rejects legacy workspace layout commands without a record id", async () => {
+    const router = createCommandRouter({
+      clients: registryWith(desktopClient),
+      services: services(),
+    });
+
+    await expect(
+      router.execute({
+        clientId: "desktop-1",
+        command: { type: "workspace.layout.read" },
+        protocolVersion: 1,
+        requestId: "req-layout-legacy",
+      })
+    ).resolves.toEqual({
+      error: {
+        code: "invalid_command",
+        message: "invalid command",
+      },
+      ok: false,
+      requestId: "req-layout-legacy",
+    });
   });
 });

--- a/tests/unit/app-core/local-control.test.ts
+++ b/tests/unit/app-core/local-control.test.ts
@@ -69,7 +69,7 @@ describe("local control socket", () => {
         const parsed = pierCommandEnvelopeSchema.parse(envelope);
         seen.push(parsed);
         return Promise.resolve({
-          data: [{ focused: true, id: "main" }],
+          data: [{ focused: true, id: "main", recordId: "record-main" }],
           ok: true,
           requestId: parsed.requestId,
         });
@@ -88,7 +88,7 @@ describe("local control socket", () => {
         requestId: "req-1",
       })
     ).resolves.toEqual({
-      data: [{ focused: true, id: "main" }],
+      data: [{ focused: true, id: "main", recordId: "record-main" }],
       ok: true,
       requestId: "req-1",
     });

--- a/tests/unit/app-core/renderer-command-service.test.ts
+++ b/tests/unit/app-core/renderer-command-service.test.ts
@@ -65,6 +65,37 @@ describe("createRendererCommandService", () => {
     });
   });
 
+  it("flush layout command 不主动聚焦窗口", async () => {
+    let focus: boolean | undefined;
+    const service = createRendererCommandService({
+      createRequestId: () => "renderer-req-flush",
+      host: {
+        send(_envelope, _windowId, options) {
+          focus = options?.focus;
+          return true;
+        },
+      },
+      timeoutMs: 1000,
+    });
+
+    const promise = service.execute({
+      type: "workspace.flushLayout",
+      windowId: "main",
+    });
+    expect(focus).toBe(false);
+    service.resolve({
+      data: null,
+      ok: true,
+      requestId: "renderer-req-flush",
+    });
+
+    await expect(promise).resolves.toEqual({
+      data: null,
+      ok: true,
+      requestId: "renderer-req-flush",
+    });
+  });
+
   it("显式 focus=false 时不主动聚焦窗口", async () => {
     let focus: boolean | undefined;
     const service = createRendererCommandService({

--- a/tests/unit/default-keymap.test.ts
+++ b/tests/unit/default-keymap.test.ts
@@ -19,7 +19,7 @@ const TERMINAL_MODE_APP_SHORTCUTS = [
 describe("DEFAULT_KEYMAP", () => {
   it("keeps tab/window panel shortcuts wired", () => {
     expect(DEFAULT_KEYMAP).toContainEqual({
-      commandId: "pier.panel.newTab",
+      commandId: "pier.panel.newTerminal",
       keys: "Mod+KeyT",
       nativeTerminal: "app",
       scope: "global",

--- a/tests/unit/main/terminal-focus.test.ts
+++ b/tests/unit/main/terminal-focus.test.ts
@@ -75,6 +75,7 @@ describe("terminal focus restoration", () => {
         updatedAt: "2026-06-24T00:00:00.000Z",
       })),
       updateTerminalPanelCwd: vi.fn(async () => undefined),
+      updateTerminalPanelTitle: vi.fn(async () => undefined),
     }));
     vi.doMock("@main/windows/window-identity.ts", () => ({
       findAppWindowByElectronId: vi.fn((id: number) =>

--- a/tests/unit/main/terminal-focus.test.ts
+++ b/tests/unit/main/terminal-focus.test.ts
@@ -83,6 +83,7 @@ describe("terminal focus restoration", () => {
       ),
       findAppWindowByWebContents: vi.fn(() => ipcWindow),
       findInternalWindowId: vi.fn(() => "main"),
+      findWindowSessionId: vi.fn(() => "session-main"),
     }));
 
     const { registerTerminalIpc, restoreActivePanelFocus } = await import(

--- a/tests/unit/main/terminal-panel-id-scoping.test.ts
+++ b/tests/unit/main/terminal-panel-id-scoping.test.ts
@@ -95,6 +95,7 @@ describe("multi-window panel id scoping (#16 #30)", () => {
       ),
       findAppWindowByWebContents: vi.fn(() => win),
       findInternalWindowId: vi.fn(() => `w${winId}`),
+      findWindowSessionId: vi.fn(() => `session-${winId}`),
     }));
 
     const { registerTerminalIpc } = await import("@main/ipc/terminal.ts");
@@ -175,6 +176,7 @@ describe("multi-window panel id scoping (#16 #30)", () => {
       // 按 webContents 反查:每个 sender 是不同 webContents 对象, 路由对应 window.
       findAppWindowByWebContents: vi.fn((wc: unknown) => wcMap.get(wc) ?? null),
       findInternalWindowId: vi.fn(() => "main"),
+      findWindowSessionId: vi.fn((win: { id: number }) => `session-${win.id}`),
     }));
 
     const fakeIpcMain = {

--- a/tests/unit/main/terminal-panel-id-scoping.test.ts
+++ b/tests/unit/main/terminal-panel-id-scoping.test.ts
@@ -87,6 +87,7 @@ describe("multi-window panel id scoping (#16 #30)", () => {
       readTerminalPanelSession: vi.fn(async () => null),
       removeTerminalPanelSession: vi.fn(async () => undefined),
       updateTerminalPanelCwd: vi.fn(async () => undefined),
+      updateTerminalPanelTitle: vi.fn(async () => undefined),
     }));
     vi.doMock("@main/windows/window-identity.ts", () => ({
       findAppWindowByElectronId: vi.fn((id: number) =>
@@ -167,6 +168,7 @@ describe("multi-window panel id scoping (#16 #30)", () => {
       readTerminalPanelSession: vi.fn(async () => null),
       removeTerminalPanelSession: vi.fn(async () => undefined),
       updateTerminalPanelCwd: vi.fn(async () => undefined),
+      updateTerminalPanelTitle: vi.fn(async () => undefined),
     }));
     vi.doMock("@main/windows/window-identity.ts", () => ({
       findAppWindowByElectronId: vi.fn((id: number) => idMap.get(id) ?? null),

--- a/tests/unit/main/terminal-session-state.test.ts
+++ b/tests/unit/main/terminal-session-state.test.ts
@@ -44,6 +44,24 @@ describe("terminal session state", () => {
     ).resolves.toBeNull();
   });
 
+  it("persists and reads the last terminal title by window and panel", async () => {
+    const {
+      readTerminalPanelSession,
+      updateTerminalPanelCwd,
+      updateTerminalPanelTitle,
+    } = await import("@main/state/terminal-session-state.ts");
+
+    await updateTerminalPanelCwd("main", "terminal-1", "/Users/xyz/ABC/pier");
+    await updateTerminalPanelTitle("main", "terminal-1", "Claude Code");
+
+    await expect(
+      readTerminalPanelSession("main", "terminal-1")
+    ).resolves.toMatchObject({
+      cwd: "/Users/xyz/ABC/pier",
+      title: "Claude Code",
+    });
+  });
+
   it("ignores blank and relative cwd updates", async () => {
     const { readTerminalPanelSession, updateTerminalPanelCwd } = await import(
       "@main/state/terminal-session-state.ts"

--- a/tests/unit/main/terminal-state-consistency.test.ts
+++ b/tests/unit/main/terminal-state-consistency.test.ts
@@ -92,6 +92,7 @@ describe("Swift terminal state consistency via main IPC paths", () => {
       ),
       findAppWindowByWebContents: vi.fn(() => win),
       findInternalWindowId: vi.fn(() => "main"),
+      findWindowSessionId: vi.fn(() => "session-main"),
     }));
 
     const { registerTerminalIpc } = await import("@main/ipc/terminal.ts");
@@ -178,7 +179,7 @@ describe("Swift terminal state consistency via main IPC paths", () => {
 
     expect(fakeAddon.closeTerminal).toHaveBeenCalledWith("7::panel-1");
     expect(sessionState.removeTerminalPanelSession).toHaveBeenCalledWith(
-      "main",
+      "session-main",
       "panel-1"
     );
   });
@@ -195,7 +196,7 @@ describe("Swift terminal state consistency via main IPC paths", () => {
     await new Promise((resolve) => setImmediate(resolve));
 
     expect(sessionState.updateTerminalPanelTitle).toHaveBeenCalledWith(
-      "main",
+      "session-main",
       "terminal-1",
       "Claude Code"
     );

--- a/tests/unit/main/terminal-state-consistency.test.ts
+++ b/tests/unit/main/terminal-state-consistency.test.ts
@@ -84,6 +84,7 @@ describe("Swift terminal state consistency via main IPC paths", () => {
       readTerminalPanelSession: vi.fn(async () => null),
       removeTerminalPanelSession: vi.fn(async () => undefined),
       updateTerminalPanelCwd: vi.fn(async () => undefined),
+      updateTerminalPanelTitle: vi.fn(async () => undefined),
     }));
     vi.doMock("@main/windows/window-identity.ts", () => ({
       findAppWindowByElectronId: vi.fn((id: number) =>
@@ -179,6 +180,31 @@ describe("Swift terminal state consistency via main IPC paths", () => {
     expect(sessionState.removeTerminalPanelSession).toHaveBeenCalledWith(
       "main",
       "panel-1"
+    );
+  });
+
+  it("persists forwarded terminal titles using the raw renderer panel id", async () => {
+    const { fakeAddon, win } = await setupHarness();
+    const sessionState = await import("@main/state/terminal-session-state.ts");
+    const callback = fakeAddon.setTitleForwardCallback.mock.calls[0]?.[0] as
+      | ((windowId: number, panelId: string, title: string) => void)
+      | undefined;
+
+    callback?.(win.id, "7::terminal-1", "Claude Code");
+
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(sessionState.updateTerminalPanelTitle).toHaveBeenCalledWith(
+      "main",
+      "terminal-1",
+      "Claude Code"
+    );
+    expect(win.webContents.send).toHaveBeenCalledWith(
+      "pier:terminal:title-change",
+      {
+        panelId: "terminal-1",
+        title: "Claude Code",
+      }
     );
   });
 

--- a/tests/unit/main/window-lifecycle-invariants.test.ts
+++ b/tests/unit/main/window-lifecycle-invariants.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const MAIN_SOURCE = readFileSync(
+  resolve(import.meta.dirname, "../../../src/main/index.ts"),
+  "utf8"
+);
+const WINDOW_MANAGER_SOURCE = readFileSync(
+  resolve(import.meta.dirname, "../../../src/main/windows/window-manager.ts"),
+  "utf8"
+);
+
+const BEFORE_QUIT_FLUSH_RE =
+  /app\.on\("before-quit",\s*\(event\) => \{[\s\S]{0,500}?event\.preventDefault\(\);[\s\S]{0,500}?appCore\.services\.window\s*\.flushOpenWindows\(\)[\s\S]{0,500}?app\.quit\(\);/;
+const CLOSE_GUARD_FLUSH_RE =
+  /window\.host\.on\("close",\s*\(event:[\s\S]{0,80}?\) => \{[\s\S]{0,700}?event\.preventDefault\(\);[\s\S]{0,700}?this\.flushBeforeClose\(window,/;
+const QUIT_DESTROY_SKIPS_CLOSE_RE =
+  /if \(\s*!this\.isDestroyingAllForQuit[\s\S]{0,200}?this\.closeFlushDone\.has\(window\)/;
+
+describe("window lifecycle persistence invariants", () => {
+  it("flushes all open window layouts before Cmd+Q destroys windows", () => {
+    expect(MAIN_SOURCE).toMatch(BEFORE_QUIT_FLUSH_RE);
+  });
+
+  it("flushes the current window before user close proceeds", () => {
+    expect(WINDOW_MANAGER_SOURCE).toMatch(CLOSE_GUARD_FLUSH_RE);
+  });
+
+  it("does not run user-close record updates during app quit destroy", () => {
+    expect(WINDOW_MANAGER_SOURCE).toMatch(QUIT_DESTROY_SKIPS_CLOSE_RE);
+  });
+});

--- a/tests/unit/main/window-manager-webcontents-view.test.ts
+++ b/tests/unit/main/window-manager-webcontents-view.test.ts
@@ -114,8 +114,12 @@ describe.runIf(process.platform === "darwin")(
     it("creates an opaque BaseWindow with a transparent full-window WebContentsView", async () => {
       const electron = await import("electron");
       const { windowManager } = await import("@main/windows/window-manager.ts");
+      const { findWindowContext } = await import(
+        "@main/windows/window-identity.ts"
+      );
 
       windowManager.create({ id: "main" });
+      const win = windowManager.get("main");
 
       expect(electron.BaseWindow).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -148,6 +152,51 @@ describe.runIf(process.platform === "darwin")(
         x: 0,
         y: 0,
       });
+      expect(win ? findWindowContext(win) : null).toMatchObject({
+        mode: "restore",
+        recordId: "main",
+        sessionId: "main",
+        windowId: "main",
+      });
+    });
+
+    it("scopes terminal sessions by durable window record, not reusable runtime id", async () => {
+      const { windowManager } = await import("@main/windows/window-manager.ts");
+      const { findWindowContext } = await import(
+        "@main/windows/window-identity.ts"
+      );
+
+      windowManager.create({
+        id: "w-1",
+        mode: "fresh",
+        recordId: "record-a",
+      });
+      const firstWin = windowManager.get("w-1");
+      const firstContext = firstWin ? findWindowContext(firstWin) : null;
+
+      electronMock.hostListeners.get("closed")?.();
+
+      windowManager.create({
+        id: "w-1",
+        mode: "fresh",
+        recordId: "record-b",
+      });
+      const secondWin = windowManager.get("w-1");
+      const secondContext = secondWin ? findWindowContext(secondWin) : null;
+
+      expect(firstContext).toMatchObject({
+        mode: "fresh",
+        recordId: "record-a",
+        sessionId: "record-a",
+        windowId: "w-1",
+      });
+      expect(secondContext).toMatchObject({
+        mode: "fresh",
+        recordId: "record-b",
+        sessionId: "record-b",
+        windowId: "w-1",
+      });
+      expect(secondContext?.sessionId).not.toBe(firstContext?.sessionId);
     });
 
     it("maps renderer webContents back to the owning app window", async () => {

--- a/tests/unit/main/window-record-state.test.ts
+++ b/tests/unit/main/window-record-state.test.ts
@@ -1,0 +1,67 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("window record state", () => {
+  let userDataDir: string;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    userDataDir = await mkdtemp(join(tmpdir(), "pier-window-record-state-"));
+    vi.doMock("electron", () => ({
+      app: {
+        getPath: vi.fn((name: string) => {
+          if (name !== "userData") {
+            throw new Error(`unexpected app path: ${name}`);
+          }
+          return userDataDir;
+        }),
+      },
+    }));
+  });
+
+  afterEach(async () => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+    await rm(userDataDir, { force: true, recursive: true });
+  });
+
+  it("tracks open and recently closed window records without deleting layout", async () => {
+    const {
+      createWindowRecord,
+      markWindowRecordClosed,
+      markWindowRecordOpen,
+      readMostRecentClosedWindowRecordId,
+      readOpenWindowRecordIds,
+      readWindowRecordLayout,
+      saveWindowRecordLayout,
+    } = await import("@main/state/window-record-state.ts");
+
+    const first = await createWindowRecord();
+    const second = await createWindowRecord();
+    await markWindowRecordOpen(first.id);
+    await markWindowRecordOpen(second.id);
+    await saveWindowRecordLayout(first.id, {
+      grid: { root: "first-layout" },
+    });
+
+    await expect(readOpenWindowRecordIds()).resolves.toEqual([
+      first.id,
+      second.id,
+    ]);
+
+    await markWindowRecordClosed(first.id);
+
+    await expect(readOpenWindowRecordIds()).resolves.toEqual([second.id]);
+    await expect(readMostRecentClosedWindowRecordId()).resolves.toBe(first.id);
+    await expect(readWindowRecordLayout(first.id)).resolves.toEqual({
+      grid: { root: "first-layout" },
+    });
+
+    await markWindowRecordClosed(second.id);
+
+    await expect(readOpenWindowRecordIds()).resolves.toEqual([]);
+    await expect(readMostRecentClosedWindowRecordId()).resolves.toBe(second.id);
+  });
+});

--- a/tests/unit/main/window-service.test.ts
+++ b/tests/unit/main/window-service.test.ts
@@ -1,0 +1,246 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  let closeCallback:
+    | ((payload: { recordId: string; windowId: string }) => void)
+    | null = null;
+  let beforeCloseCallback:
+    | ((payload: { recordId: string; windowId: string }) => void)
+    | null = null;
+  const liveWindowContexts: Array<{ recordId: string }> = [];
+  return {
+    close: vi.fn(),
+    create: vi.fn((options?: { recordId?: string }) => {
+      liveWindowContexts.push({ recordId: options?.recordId ?? "unknown" });
+      return "w-1";
+    }),
+    createWindowRecord: vi.fn(async () => ({ id: "record-new" })),
+    flushTerminalSessionState: vi.fn(async () => undefined),
+    flushWindowRecordState: vi.fn(async () => undefined),
+    focus: vi.fn(),
+    getCloseCallback: () => closeCallback,
+    getBeforeCloseCallback: () => beforeCloseCallback,
+    getAll: vi.fn(() =>
+      liveWindowContexts.map((context) => ({
+        isDestroyed: () => false,
+        __recordId: context.recordId,
+      }))
+    ),
+    list: vi.fn(
+      (): Array<{ focused: boolean; id: string; recordId: string }> => []
+    ),
+    markWindowRecordClosed: vi.fn(async () => undefined),
+    markWindowRecordOpen: vi.fn(async () => undefined),
+    onBeforeClose: vi.fn(
+      (callback: (payload: { recordId: string; windowId: string }) => void) => {
+        beforeCloseCallback = callback;
+      }
+    ),
+    onClose: vi.fn(
+      (callback: (payload: { recordId: string; windowId: string }) => void) => {
+        closeCallback = callback;
+      }
+    ),
+    readMostRecentClosedWindowRecordId: vi.fn(async () => "record-closed"),
+    readOpenWindowRecordIds: vi.fn(async () => ["record-open-1"]),
+    resetLiveWindowCount: () => {
+      liveWindowContexts.length = 0;
+    },
+    setLiveWindowRecords: (recordIds: string[]) => {
+      liveWindowContexts.length = 0;
+      liveWindowContexts.push(...recordIds.map((recordId) => ({ recordId })));
+    },
+  };
+});
+
+vi.mock("@main/state/window-record-state.ts", () => ({
+  createWindowRecord: mocks.createWindowRecord,
+  flushWindowRecordState: mocks.flushWindowRecordState,
+  markWindowRecordClosed: mocks.markWindowRecordClosed,
+  markWindowRecordOpen: mocks.markWindowRecordOpen,
+  readMostRecentClosedWindowRecordId: mocks.readMostRecentClosedWindowRecordId,
+  readOpenWindowRecordIds: mocks.readOpenWindowRecordIds,
+}));
+
+vi.mock("@main/state/terminal-session-state.ts", () => ({
+  flushTerminalSessionState: mocks.flushTerminalSessionState,
+}));
+
+vi.mock("@main/windows/window-manager.ts", () => ({
+  windowManager: {
+    close: mocks.close,
+    create: mocks.create,
+    focus: mocks.focus,
+    getAll: mocks.getAll,
+    list: mocks.list,
+    onBeforeClose: mocks.onBeforeClose,
+    onClose: mocks.onClose,
+  },
+}));
+
+vi.mock("@main/windows/window-identity.ts", () => ({
+  findWindowContext: (window: { __recordId?: string }) =>
+    window.__recordId
+      ? {
+          mode: "restore",
+          recordId: window.__recordId,
+          sessionId: window.__recordId,
+          windowId: "main",
+        }
+      : null,
+}));
+
+describe("WindowService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.resetLiveWindowCount();
+  });
+
+  it("creates Cmd+N windows from a new durable window record", async () => {
+    const { createWindowService } = await import(
+      "@main/services/window-service.ts"
+    );
+
+    const service = createWindowService();
+    const result = await service.create({ mode: "fresh" });
+
+    expect(result).toEqual({ recordId: "record-new", windowId: "w-1" });
+    expect(mocks.markWindowRecordOpen).toHaveBeenCalledWith("record-new");
+    expect(mocks.create).toHaveBeenCalledWith({
+      id: "main",
+      mode: "fresh",
+      recordId: "record-new",
+    });
+  });
+
+  it("does not mark a window record open when native window creation fails", async () => {
+    mocks.create.mockImplementationOnce(() => {
+      throw new Error("create failed");
+    });
+    const { createWindowService } = await import(
+      "@main/services/window-service.ts"
+    );
+
+    const service = createWindowService();
+
+    await expect(service.create()).rejects.toThrow("create failed");
+    expect(mocks.markWindowRecordOpen).not.toHaveBeenCalled();
+  });
+
+  it("rejects restoring a durable record that is already open in a live window", async () => {
+    mocks.setLiveWindowRecords(["record-closed"]);
+    const { createWindowService } = await import(
+      "@main/services/window-service.ts"
+    );
+
+    const service = createWindowService();
+
+    await expect(service.restoreMostRecentClosed()).rejects.toThrow(
+      "window record already open"
+    );
+    expect(mocks.create).not.toHaveBeenCalled();
+  });
+
+  it("moves a user-closed window record to recently closed records", async () => {
+    const { createWindowService } = await import(
+      "@main/services/window-service.ts"
+    );
+
+    createWindowService();
+    mocks.getCloseCallback()?.({ recordId: "record-1", windowId: "main" });
+    await Promise.resolve();
+
+    expect(mocks.markWindowRecordClosed).toHaveBeenCalledWith("record-1");
+  });
+
+  it("restores the most recently closed window record", async () => {
+    const { createWindowService } = await import(
+      "@main/services/window-service.ts"
+    );
+
+    const service = createWindowService();
+    const result = await service.restoreMostRecentClosed();
+
+    expect(result).toEqual({ recordId: "record-closed", windowId: "w-1" });
+    expect(mocks.markWindowRecordOpen).toHaveBeenCalledWith("record-closed");
+    expect(mocks.create).toHaveBeenCalledWith({
+      id: "main",
+      mode: "restore",
+      recordId: "record-closed",
+    });
+  });
+
+  it("flushes renderer layout and debounced main state before a user close completes", async () => {
+    const flushRendererLayout = vi.fn(async () => undefined);
+    const { createWindowService } = await import(
+      "@main/services/window-service.ts"
+    );
+
+    createWindowService({ flushRendererLayout });
+    await mocks.getBeforeCloseCallback()?.({
+      recordId: "record-1",
+      windowId: "main",
+    });
+
+    expect(flushRendererLayout).toHaveBeenCalledWith("main");
+    expect(mocks.flushTerminalSessionState).toHaveBeenCalled();
+    expect(mocks.flushWindowRecordState).toHaveBeenCalled();
+  });
+
+  it("flushes every live window before Cmd+Q destroys windows", async () => {
+    const flushRendererLayout = vi.fn(async () => undefined);
+    mocks.list.mockReturnValueOnce([
+      { focused: true, id: "main", recordId: "record-main" },
+      { focused: false, id: "w-1", recordId: "record-w-1" },
+    ]);
+    const { createWindowService } = await import(
+      "@main/services/window-service.ts"
+    );
+
+    const service = createWindowService({ flushRendererLayout });
+    await service.flushOpenWindows();
+
+    expect(flushRendererLayout).toHaveBeenCalledWith("main");
+    expect(flushRendererLayout).toHaveBeenCalledWith("w-1");
+    expect(mocks.flushTerminalSessionState).toHaveBeenCalled();
+    expect(mocks.flushWindowRecordState).toHaveBeenCalled();
+  });
+
+  it("restores the last user-closed window when the app is activated with no live windows", async () => {
+    const { createWindowService } = await import(
+      "@main/services/window-service.ts"
+    );
+
+    const service = createWindowService();
+    const result = await service.restoreMostRecentClosed();
+
+    expect(result).toEqual({ recordId: "record-closed", windowId: "w-1" });
+  });
+
+  it("restores all open window records for Cmd+Q relaunch", async () => {
+    mocks.readOpenWindowRecordIds.mockResolvedValueOnce([
+      "record-open-1",
+      "record-open-2",
+    ]);
+    const { createWindowService } = await import(
+      "@main/services/window-service.ts"
+    );
+
+    const service = createWindowService();
+    const result = await service.restoreOpenWindows();
+
+    expect(result).toEqual([
+      { recordId: "record-open-1", windowId: "w-1" },
+      { recordId: "record-open-2", windowId: "w-1" },
+    ]);
+    expect(mocks.create).toHaveBeenCalledWith({
+      id: "main",
+      mode: "restore",
+      recordId: "record-open-1",
+    });
+    expect(mocks.create).toHaveBeenCalledWith({
+      mode: "restore",
+      recordId: "record-open-2",
+    });
+  });
+});

--- a/tests/unit/main/workspace-ipc.test.ts
+++ b/tests/unit/main/workspace-ipc.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  clearLayout: vi.fn(async () => undefined),
+  handle: vi.fn(),
+  readLayout: vi.fn(async () => ({ layout: "record" })),
+  saveLayout: vi.fn(async () => undefined),
+}));
+
+vi.mock("@main/app-core/app-core.ts", () => ({
+  appCore: {
+    services: {
+      workspace: {
+        clearLayout: mocks.clearLayout,
+        readLayout: mocks.readLayout,
+        saveLayout: mocks.saveLayout,
+      },
+    },
+  },
+}));
+
+function ipcMainMock() {
+  const handlers = new Map<string, (...args: unknown[]) => unknown>();
+  mocks.handle.mockImplementation(
+    (channel: string, handler: (...args: unknown[]) => unknown) => {
+      handlers.set(channel, handler);
+    }
+  );
+  return { handle: mocks.handle, handlers };
+}
+
+describe("registerWorkspaceIpc", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("requires a window record id for layout reads", async () => {
+    const { registerWorkspaceIpc } = await import("@main/ipc/workspace.ts");
+    const ipcMain = ipcMainMock();
+
+    registerWorkspaceIpc(ipcMain as never);
+
+    await expect(
+      ipcMain.handlers.get("pier:workspace:load-layout")?.({})
+    ).rejects.toThrow("workspace layout recordId required");
+    expect(mocks.readLayout).not.toHaveBeenCalled();
+  });
+
+  it("passes the record id through for layout operations", async () => {
+    const { registerWorkspaceIpc } = await import("@main/ipc/workspace.ts");
+    const ipcMain = ipcMainMock();
+
+    registerWorkspaceIpc(ipcMain as never);
+
+    await expect(
+      ipcMain.handlers.get("pier:workspace:load-layout")?.({}, "record-1")
+    ).resolves.toEqual({ layout: "record" });
+    await ipcMain.handlers.get("pier:workspace:save-layout")?.(
+      {},
+      { grid: "layout" },
+      "record-1"
+    );
+    await ipcMain.handlers.get("pier:workspace:clear-layout")?.({}, "record-1");
+
+    expect(mocks.readLayout).toHaveBeenCalledWith("record-1");
+    expect(mocks.saveLayout).toHaveBeenCalledWith(
+      { grid: "layout" },
+      "record-1"
+    );
+    expect(mocks.clearLayout).toHaveBeenCalledWith("record-1");
+  });
+});

--- a/tests/unit/renderer/panel-actions-window.test.ts
+++ b/tests/unit/renderer/panel-actions-window.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { actionRegistry } from "@/lib/actions/registry.ts";
+
+const createWindow = vi.fn(async () => ({
+  recordId: "record-new",
+  windowId: "w-1",
+}));
+
+vi.mock("@/lib/ipc/window-ipc.ts", () => ({
+  createWindow,
+}));
+
+describe("panel window actions", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates Cmd+N windows through the public fresh-window entrypoint", async () => {
+    const { registerPanelActions } = await import(
+      "@/lib/actions/panel-actions.ts"
+    );
+
+    const dispose = registerPanelActions();
+    try {
+      actionRegistry.get("pier.window.newWindow")?.handler();
+      await Promise.resolve();
+
+      expect(createWindow).toHaveBeenCalledWith();
+    } finally {
+      dispose();
+    }
+  });
+});

--- a/tests/unit/renderer/stores/workspace-store-terminal-close.test.ts
+++ b/tests/unit/renderer/stores/workspace-store-terminal-close.test.ts
@@ -15,6 +15,14 @@ describe("workspace terminal close lifecycle", () => {
     Object.defineProperty(window, "pier", {
       configurable: true,
       value: {
+        closeCurrentWindow: vi.fn(async () => undefined),
+        getWindowContext: vi.fn(async () => ({
+          mode: "restore",
+          recordId: "record-current",
+          sessionId: "record-current",
+          windowId: "main",
+        })),
+        workspace: { clearLayout: vi.fn(async () => undefined) },
         terminal: { close: vi.fn() },
       },
     });
@@ -36,5 +44,80 @@ describe("workspace terminal close lifecycle", () => {
 
     expect(window.pier.terminal.close).toHaveBeenCalledWith("terminal-1");
     expect(api.removePanel).toHaveBeenCalledWith(panel);
+  });
+
+  it("Cmd+W closes the active terminal panel when more than one panel exists", () => {
+    const panel = terminalPanel("terminal-1");
+    const api = {
+      activePanel: panel,
+      panels: [panel, { ...terminalPanel("terminal-2"), id: "terminal-2" }],
+      removePanel: vi.fn(),
+      totalPanels: 2,
+    };
+
+    useWorkspaceStore.getState().setApi(api as never);
+
+    useWorkspaceStore.getState().closeActivePanel();
+
+    expect(window.pier.terminal.close).toHaveBeenCalledWith("terminal-1");
+    expect(api.removePanel).toHaveBeenCalledWith(panel);
+    expect(window.pier.closeCurrentWindow).not.toHaveBeenCalled();
+  });
+
+  it("Cmd+W closes the current window instead of removing the last panel", () => {
+    const panel = terminalPanel("terminal-1");
+    const api = {
+      activePanel: panel,
+      panels: [panel],
+      removePanel: vi.fn(),
+      totalPanels: 1,
+    };
+
+    useWorkspaceStore.getState().setApi(api as never);
+
+    useWorkspaceStore.getState().closeActivePanel();
+
+    expect(window.pier.closeCurrentWindow).toHaveBeenCalled();
+    expect(window.pier.terminal.close).not.toHaveBeenCalled();
+    expect(api.removePanel).not.toHaveBeenCalled();
+  });
+
+  it("clears closeAll layout from the current window record", async () => {
+    const panel = terminalPanel("terminal-1");
+    const api = {
+      activePanel: panel,
+      panels: [panel],
+      removePanel: vi.fn(),
+      totalPanels: 1,
+    };
+
+    useWorkspaceStore.getState().setApi(api as never);
+
+    await useWorkspaceStore.getState().closeAll();
+
+    expect(window.pier.getWindowContext).toHaveBeenCalled();
+    expect(window.pier.workspace.clearLayout).toHaveBeenCalledWith(
+      "record-current"
+    );
+  });
+
+  it("clears resetLayout from the current window record", async () => {
+    const panel = terminalPanel("terminal-1");
+    const api = {
+      activePanel: panel,
+      addPanel: vi.fn(),
+      panels: [panel],
+      removePanel: vi.fn(),
+      totalPanels: 1,
+    };
+
+    useWorkspaceStore.getState().setApi(api as never);
+
+    await useWorkspaceStore.getState().resetLayout();
+
+    expect(window.pier.getWindowContext).toHaveBeenCalled();
+    expect(window.pier.workspace.clearLayout).toHaveBeenCalledWith(
+      "record-current"
+    );
   });
 });

--- a/tests/unit/renderer/workspace-host-invariants.test.ts
+++ b/tests/unit/renderer/workspace-host-invariants.test.ts
@@ -31,6 +31,22 @@ const SET_ACTIVE_PANEL_KIND_FOR_WEB_NULL_RE =
 
 const RECONCILE_CALL_RE =
   /window\.pier\?\.terminal\?\.reconcile\?\.\(terminalPanelIds\)/;
+const READS_WINDOW_CONTEXT_RE = /window\.pier\.getWindowContext\(\)/;
+const SAVES_LAYOUT_BY_WINDOW_RECORD_RE =
+  /const windowContext = await windowContextPromise[\s\S]{0,500}?\.saveLayout\(\s*json,\s*windowContext\.recordId\s*\)/;
+const LOADS_LAYOUT_BY_WINDOW_RECORD_RE =
+  /window\.pier\.workspace\.loadLayout\(\s*windowContext\.recordId\s*\)/;
+const FRESH_MODE_SKIP_RE = /windowContext\.mode !== "fresh"/;
+const FLUSH_LAYOUT_COMMAND_RE = /case "workspace\.flushLayout"/;
+const FLUSH_SAVES_CURRENT_LAYOUT_RE =
+  /window\.pier\.workspace[\s\S]{0,80}?\.saveLayout\(\s*event\.api\.toJSON\(\),\s*windowContext\.recordId\s*\)/;
+const WRITABLE_MAIN_FALLBACK_RE = /recordId: "main"/;
+const WINDOW_CONTEXT_PROMISE_RE =
+  /const windowContextPromise = window\.pier\.getWindowContext\(\)/;
+const AWAITS_WINDOW_CONTEXT_FOR_SAVE_RE =
+  /const windowContext = await windowContextPromise[\s\S]{0,500}?\.saveLayout\(\s*json,\s*windowContext\.recordId\s*\)/;
+const FLUSH_EMPTY_LAYOUT_CLEARS_RECORD_RE =
+  /if \(event\.api\.totalPanels === 0\)[\s\S]{0,160}?\.clearLayout\(windowContext\.recordId\)/;
 
 describe("workspace-host invariants (#17 #19)", () => {
   it("declares userTouched flag and uses it to gate fromJSON (防 user 操作被 saved layout 覆盖)", () => {
@@ -65,5 +81,41 @@ describe("workspace-host invariants (#17 #19)", () => {
     // C 方案 reload 零销毁:layout 应用后报告"我现在还需要这些 panelId", swift 把
     // 不在集合的孤儿清掉. 缺这条 reload 后旧 NSView 永久挂在 contentView.subviews.
     expect(SOURCE).toMatch(RECONCILE_CALL_RE);
+  });
+
+  it("loads persisted layout from the current durable window record", () => {
+    // Cmd+N 是新建新 record, 所以首次自然为空; 同一 record 后续 reload / restore
+    // 仍必须能读回自己的 layout, 不能用 fresh mode 永久跳过恢复.
+    expect(SOURCE).toMatch(READS_WINDOW_CONTEXT_RE);
+    expect(SOURCE).toMatch(LOADS_LAYOUT_BY_WINDOW_RECORD_RE);
+    expect(SOURCE).not.toMatch(FRESH_MODE_SKIP_RE);
+  });
+
+  it("persists and restores layouts by durable window record", () => {
+    // 新窗口不继承旧窗口, 但它自己的 layout 仍要能在 Cmd+Q 或重新激活后恢复.
+    // 因此读写都必须带 window record scope, 不能再写全局 workspace-layout.json.
+    expect(SOURCE).toMatch(SAVES_LAYOUT_BY_WINDOW_RECORD_RE);
+    expect(SOURCE).toMatch(LOADS_LAYOUT_BY_WINDOW_RECORD_RE);
+  });
+
+  it("does not use main as a writable fallback before window context resolves", () => {
+    // 二号窗口刚 ready 但 getWindowContext 尚未返回时, close/Cmd+Q flush
+    // 不能把该窗口布局写进 main record.
+    expect(SOURCE).toMatch(WINDOW_CONTEXT_PROMISE_RE);
+    expect(SOURCE).toMatch(AWAITS_WINDOW_CONTEXT_FOR_SAVE_RE);
+    expect(SOURCE).not.toMatch(WRITABLE_MAIN_FALLBACK_RE);
+  });
+
+  it("handles renderer flushLayout command by saving the current dockview layout", () => {
+    // window close / Cmd+Q 不能等 debounced save, main 会请求 renderer 立刻把
+    // 当前 dockview 布局写入当前 window record.
+    expect(SOURCE).toMatch(FLUSH_LAYOUT_COMMAND_RE);
+    expect(SOURCE).toMatch(FLUSH_SAVES_CURRENT_LAYOUT_RE);
+  });
+
+  it("keeps closeAll from re-saving an empty dockview layout", () => {
+    // closeAll 会先清 record layout 再关闭窗口; close-before-flush 看到 0 panels
+    // 时必须保持 cleared state, 不能把空 dockview JSON 写回 record.
+    expect(SOURCE).toMatch(FLUSH_EMPTY_LAYOUT_CLEARS_RECORD_RE);
   });
 });


### PR DESCRIPTION
## Summary

- Add durable window records and route workspace layout persistence through recordId.
- Separate fresh window creation from restore paths so Cmd+N creates a clean persistent window while app lifecycle restores the intended records.
- Scope terminal/layout restore flows to the active window record and harden renderer/main IPC contracts.
- Add regression coverage for Cmd+T/Cmd+N/Cmd+W, workspace layout IPC, window record lifecycle, and terminal restore scoping.

## Validation

- pnpm vitest run tests/unit/renderer/workspace-host-invariants.test.ts tests/unit/renderer/stores/workspace-store-terminal-close.test.ts tests/unit/main/window-service.test.ts tests/unit/renderer/panel-actions-window.test.ts tests/unit/main/workspace-ipc.test.ts
- pnpm check
- pnpm test:unit
- pnpm test:component
- pnpm build
- git diff --check

## Notes

Manual Electron lifecycle validation for Cmd+Q restart and red-close reactivation is still recommended before merge.