### PR TITLE
[codex] Add configurable keybindings

### DIFF
--- a/native/Sources/GhosttyBridge/GhosttyBridge.swift
+++ b/native/Sources/GhosttyBridge/GhosttyBridge.swift
@@ -70,7 +70,7 @@ final class EventRouterView: NSView {
     /// 用它告诉 main 这个 key event 来自哪个 window.
     private var browserWindowId: Int = -1
 
-    private static let terminalAppShortcutKeys: Set<String> = [
+    private static var terminalAppShortcutKeys: Set<String> = [
         "Ctrl+Shift+ArrowDown",
         "Ctrl+Shift+ArrowLeft",
         "Ctrl+Shift+ArrowRight",
@@ -84,6 +84,10 @@ final class EventRouterView: NSView {
         "Mod+Shift+KeyD",
         "Mod+Shift+KeyP",
     ]
+
+    static func setTerminalAppShortcutKeys(_ keys: Set<String>) {
+        terminalAppShortcutKeys = keys
+    }
 
     override var isOpaque: Bool { false }
     override var isFlipped: Bool { true }  // 对齐 Electron contentView 的 top-left 坐标系
@@ -217,16 +221,10 @@ final class EventRouterView: NSView {
         let state = GhosttyBridgeImpl.shared.stateFor(window: window)
         guard state.inTerminalMode else { return event }
 
-        // Terminal mode: 拦截 Cmd+key 或 Ctrl+Shift+key forward 给 web (路径 2 IPC),
-        // 其他 pass through 给 Ghostty. Ctrl+Shift+ 是为 web 层 focus 方向导航等 binding
-        // 留的口子 — 单 Ctrl 留给 Ghostty 不动 (shell Ctrl+C 等).
+        // Terminal mode: 只把运行时 allowlist 内的 Pier app 快捷键 forward 给 web
+        // (路径 2 IPC), 其他组合全部 pass through 给 Ghostty.
         let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
         let isCmd = mods.contains(.command)
-        let isCtrlShift = mods.contains(.control) && mods.contains(.shift)
-
-        guard isCmd || isCtrlShift else {
-            return passThroughToTerminal(window: window, event: event)
-        }
 
         // macOS menu reserved keys (Cmd+Q/Cmd+H/Cmd+M/Cmd+Comma 等 role-bound items)
         // 必须先让 NSApp.mainMenu 处理. performKeyEquivalent 命中 menu item 后会调
@@ -1407,6 +1405,24 @@ public func ghosttyBridgeSetKeyboardForwardCallback(_ cb: KeyboardForwardCallbac
         } else {
             EventRouterView.forwardCmdKeyCallback = nil
         }
+    }
+}
+
+@_cdecl("ghostty_bridge_set_app_shortcut_keys")
+public func ghosttyBridgeSetAppShortcutKeys(
+    _ keysPtr: UnsafePointer<UnsafePointer<CChar>?>?,
+    _ count: Int
+) {
+    MainActor.assumeIsolated {
+        var keys: Set<String> = []
+        if let keysPtr {
+            for i in 0..<count {
+                if let ptr = keysPtr[i] {
+                    keys.insert(String(cString: ptr))
+                }
+            }
+        }
+        EventRouterView.setTerminalAppShortcutKeys(keys)
     }
 }
 

--- a/native/src/addon.mm
+++ b/native/src/addon.mm
@@ -33,6 +33,7 @@ extern "C" {
     // BrowserWindow.id, 让 main 端按 window id 路由 (多窗口下 getFocusedWindow 不准).
     typedef void (*KeyboardForwardFn)(long browserWindowId, unsigned long modifiers, const char* chars);
     void ghostty_bridge_set_keyboard_forward_callback(KeyboardForwardFn cb);
+    void ghostty_bridge_set_app_shortcut_keys(const char** keys, long count);
     // Mouse forward: swift NSEvent monitor 命中 terminal 区域 rightMouseDown → JS.
     // 签名 (browserWindowId, panelId UTF-8, x, y). 用于触发 native 右键菜单.
     typedef void (*MouseForwardFn)(long browserWindowId, const char* panelId, double x, double y);
@@ -276,6 +277,28 @@ static Napi::Value JsSetKeyboardForwardCallback(const Napi::CallbackInfo& info) 
                                 &g_keyForwardTrampoline);
 }
 
+static Napi::Value JsSetAppShortcutKeys(const Napi::CallbackInfo& info) {
+    Napi::Env env = info.Env();
+    if (info.Length() == 0 || !info[0].IsArray()) {
+        ghostty_bridge_set_app_shortcut_keys(nullptr, 0);
+        return env.Undefined();
+    }
+    Napi::Array arr = info[0].As<Napi::Array>();
+    std::vector<std::string> holders;
+    std::vector<const char*> ptrs;
+    holders.reserve(arr.Length());
+    ptrs.reserve(arr.Length());
+    for (uint32_t i = 0; i < arr.Length(); i++) {
+        Napi::Value value = arr.Get(i);
+        if (!value.IsString()) continue;
+        holders.push_back(value.As<Napi::String>().Utf8Value());
+        ptrs.push_back(holders.back().c_str());
+    }
+    ghostty_bridge_set_app_shortcut_keys(ptrs.empty() ? nullptr : ptrs.data(),
+                                         static_cast<long>(ptrs.size()));
+    return env.Undefined();
+}
+
 // ---- Right-mouse forward (terminal 区域右键转 native menu trigger) ----
 struct MouseForwardPayload {
     long windowId;
@@ -485,6 +508,7 @@ static Napi::Object Init(Napi::Env env, Napi::Object exports) {
     exports.Set("reconcileTerminals", Napi::Function::New(env, JsReconcile));
     exports.Set("detachWindow",    Napi::Function::New(env, JsDetachWindow));
     exports.Set("setKeyboardForwardCallback", Napi::Function::New(env, JsSetKeyboardForwardCallback));
+    exports.Set("setAppShortcutKeys", Napi::Function::New(env, JsSetAppShortcutKeys));
     exports.Set("setPwdForwardCallback", Napi::Function::New(env, JsSetPwdForwardCallback));
     exports.Set("setTitleForwardCallback", Napi::Function::New(env, JsSetTitleForwardCallback));
     exports.Set("setActivePanelKind", Napi::Function::New(env, JsSetActivePanelKind));

--- a/src/main/ipc/terminal-native-addon.ts
+++ b/src/main/ipc/terminal-native-addon.ts
@@ -42,6 +42,7 @@ export interface NativeAddon {
     kindRaw: number,
     panelId: string | null
   ): void;
+  setAppShortcutKeys(keys: string[]): void;
   setFrame(panelId: string, frame: TerminalFrame): void;
   setKeyboardForwardCallback(
     cb:

--- a/src/main/ipc/terminal-shortcuts-ipc.ts
+++ b/src/main/ipc/terminal-shortcuts-ipc.ts
@@ -1,0 +1,22 @@
+import type { IpcMain } from "electron";
+import type { NativeAddon } from "./terminal-native-addon.ts";
+
+function normalizeShortcutKeys(keys: unknown): string[] {
+  if (!Array.isArray(keys)) {
+    return [];
+  }
+  return keys.filter((key): key is string => typeof key === "string");
+}
+
+export function registerTerminalShortcutIpc(
+  ipcMain: IpcMain,
+  addon: NativeAddon | null
+): void {
+  ipcMain.on("pier:terminal:set-app-shortcut-keys", (_event, keys) => {
+    try {
+      addon?.setAppShortcutKeys(normalizeShortcutKeys(keys));
+    } catch (err) {
+      console.error("[pier-terminal-set-app-shortcut-keys] failed:", err);
+    }
+  });
+}

--- a/src/main/ipc/terminal.ts
+++ b/src/main/ipc/terminal.ts
@@ -27,6 +27,7 @@ import {
 } from "../windows/window-identity.ts";
 import type { NativeAddon } from "./terminal-native-addon.ts";
 import { scopePanelId, unscopePanelId } from "./terminal-panel-id.ts";
+import { registerTerminalShortcutIpc } from "./terminal-shortcuts-ipc.ts";
 
 /** 暴露给 window-manager 在 renderer reload/crash 时调用清理. */
 export function getTerminalAddon(): NativeAddon | null {
@@ -432,6 +433,8 @@ export function registerTerminalIpc(ipcMain: IpcMain): void {
       }
     }
   );
+
+  registerTerminalShortcutIpc(ipcMain, addon);
 
   ipcMain.on(
     "pier:terminal:set-font",

--- a/src/main/services/preferences-service.ts
+++ b/src/main/services/preferences-service.ts
@@ -56,6 +56,9 @@ function stripUndefinedPatch(
     ...(patch.uiFontFamily !== undefined && {
       uiFontFamily: patch.uiFontFamily,
     }),
+    ...(patch.userKeymap !== undefined && {
+      userKeymap: patch.userKeymap,
+    }),
   };
 }
 

--- a/src/main/state/preferences.ts
+++ b/src/main/state/preferences.ts
@@ -32,6 +32,7 @@ const DEFAULTS: ProjectPreferences = {
   terminalScrollbackMb: DEFAULT_TERMINAL_SCROLLBACK_MB,
   terminalPasteProtection: DEFAULT_TERMINAL_PASTE_PROTECTION,
   terminalNewCwdPolicy: DEFAULT_TERMINAL_NEW_CWD_POLICY,
+  userKeymap: [],
 };
 
 let store: DebouncedJsonStore<ProjectPreferences> | undefined;

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -4,6 +4,7 @@ import type {
   MenuPopupResult,
   MenuTemplate,
 } from "@shared/contracts/menu.ts";
+import type { ProjectPreferences } from "@shared/contracts/preferences.ts";
 import type {
   RendererCommandEnvelope,
   RendererCommandResult,
@@ -26,19 +27,7 @@ export interface WindowInfo {
   recordId: string;
 }
 
-interface PreferencesSnapshot {
-  language: string;
-  monoFontFamily: string;
-  monoFontSize: number;
-  stylePresetId: string;
-  terminalCursorBlink: boolean;
-  terminalCursorStyle: "block" | "bar" | "underline";
-  terminalNewCwdPolicy: "activeTerminal" | "shellDefault";
-  terminalPasteProtection: boolean;
-  terminalScrollbackMb: number;
-  theme: string;
-  uiFontFamily: string;
-}
+export type PreferencesSnapshot = ProjectPreferences;
 
 export interface PierPreferencesAPI {
   /**
@@ -171,6 +160,8 @@ const terminalApi: TerminalAPI = {
     ipcRenderer.invoke("pier:terminal:read-session", panelId),
   setActivePanelKind: (kind, panelId) =>
     ipcRenderer.send("pier:terminal:set-active-panel-kind", kind, panelId),
+  setAppShortcutKeys: (keys) =>
+    ipcRenderer.send("pier:terminal:set-app-shortcut-keys", keys),
   setConfig: (config) => ipcRenderer.send("pier:terminal:set-config", config),
   setFont: (panelId, font) =>
     ipcRenderer.send("pier:terminal:set-font", panelId, font),

--- a/src/renderer/components/primitives/shortcut-input.tsx
+++ b/src/renderer/components/primitives/shortcut-input.tsx
@@ -1,0 +1,137 @@
+import { Keyboard, RotateCcw, X } from "lucide-react";
+import { Button } from "@/components/primitives/button.tsx";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+} from "@/components/primitives/input-group.tsx";
+import { Kbd, KbdGroup } from "@/components/primitives/kbd.tsx";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/primitives/tooltip.tsx";
+import { cn } from "@/utils/index.ts";
+
+interface ShortcutInputProps {
+  canClear?: boolean;
+  canReset?: boolean;
+  className?: string;
+  clearLabel: string;
+  isRecording?: boolean;
+  keyParts?: readonly string[];
+  onClear: () => void;
+  onRecord: () => void;
+  onReset: () => void;
+  placeholder: string;
+  recordingLabel: string;
+  recordLabel: string;
+  resetLabel: string;
+  tooltipLabel: string;
+}
+
+export function ShortcutInput({
+  canClear = true,
+  canReset = true,
+  className,
+  clearLabel,
+  isRecording = false,
+  keyParts = [],
+  onClear,
+  onRecord,
+  onReset,
+  placeholder,
+  recordLabel,
+  recordingLabel,
+  resetLabel,
+  tooltipLabel,
+}: ShortcutInputProps) {
+  if (isRecording) {
+    return (
+      <Button
+        aria-label={recordLabel}
+        aria-pressed="true"
+        className={cn(
+          "h-8 w-44 rounded-2xl border-1 border-muted-foreground/40 bg-background px-4 text-muted-foreground shadow-[0_0_0_4px_var(--muted)] hover:bg-background hover:text-muted-foreground",
+          className
+        )}
+        data-recording="true"
+        data-slot="shortcut-input"
+        data-testid="shortcut-input"
+        onClick={onRecord}
+        type="button"
+        variant="outline"
+      >
+        {recordingLabel}
+      </Button>
+    );
+  }
+
+  return (
+    <InputGroup
+      className={cn(
+        "h-8 w-56 rounded-2xl border-input bg-background/90 p-1 shadow-xs",
+        className
+      )}
+      data-testid="shortcut-input"
+    >
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              aria-label={recordLabel}
+              aria-pressed="false"
+              className="h-full min-w-0 flex-1 shrink justify-between rounded-xl px-2 text-left font-normal shadow-none hover:bg-muted/70 active:translate-y-0"
+              data-slot="shortcut-input-trigger"
+              onClick={onRecord}
+              type="button"
+              variant="ghost"
+            >
+              {keyParts.length > 0 ? (
+                <KbdGroup className="min-w-0">
+                  {keyParts.map((part, index) => (
+                    <Kbd
+                      className="h-5 min-w-5 rounded-md border border-border bg-muted/70 px-2 text-xs shadow-xs"
+                      data-testid="shortcut-input-key"
+                      key={`${part}-${index}`}
+                    >
+                      {part}
+                    </Kbd>
+                  ))}
+                </KbdGroup>
+              ) : (
+                <span className="min-w-0 truncate text-muted-foreground">
+                  {placeholder}
+                </span>
+              )}
+              <Keyboard data-icon="inline-end" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="top">{tooltipLabel}</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+      <InputGroupAddon
+        align="inline-end"
+        className="gap-0 p-0 pr-0 has-[>button]:mr-0"
+      >
+        <InputGroupButton
+          aria-label={clearLabel}
+          disabled={!canClear}
+          onClick={onClear}
+          size="icon-sm"
+        >
+          <X />
+        </InputGroupButton>
+        <InputGroupButton
+          aria-label={resetLabel}
+          disabled={!canReset}
+          onClick={onReset}
+          size="icon-sm"
+        >
+          <RotateCcw />
+        </InputGroupButton>
+      </InputGroupAddon>
+    </InputGroup>
+  );
+}

--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -4,11 +4,13 @@ export const en = {
     description: "Manage application preferences",
     nav: {
       appearance: "Appearance",
+      keybindings: "Keyboard",
       terminal: "Terminal",
     },
     section: {
       appearance: "Appearance",
       font: "Font",
+      keybindings: "Keyboard Shortcuts",
       terminal: "Terminal",
     },
     row: {
@@ -52,6 +54,62 @@ export const en = {
         activeTerminal: "Inherit active terminal",
         shellDefault: "Use shell default",
       },
+    },
+    keybindings: {
+      change: "Change Shortcut",
+      clear: "Clear",
+      descriptionDefault: "{{category}} command.",
+      description: {
+        commandPalette: {
+          clearRecent: "Clear command palette history.",
+          toggle: "Open or close the command palette.",
+        },
+        config: {
+          locale: "Choose the display language.",
+          stylePreset: "Choose the interface color style.",
+          theme: "Choose the interface color mode.",
+        },
+        panel: {
+          close: "Close the current panel.",
+          closeActive: "Close the active panel.",
+          closeAll: "Close all panels.",
+          closeOthers: "Close every panel except the current one.",
+          focusDown: "Focus the panel group below.",
+          focusLeft: "Focus the panel group on the left.",
+          focusRight: "Focus the panel group on the right.",
+          focusUp: "Focus the panel group above.",
+          newTab: "Create a new panel tab.",
+          newTerminal: "Create a new terminal panel.",
+          splitDown: "Split the current panel downward.",
+          splitLeft: "Split the current panel to the left.",
+          splitRight: "Split the current panel to the right.",
+          splitUp: "Split the current panel upward.",
+        },
+        run: {
+          task: "Open the task runner entry.",
+          terminalList: "Open the terminal list.",
+        },
+        settings: {
+          open: "Open settings.",
+        },
+        terminal: {
+          close: "Close the current terminal panel.",
+        },
+        window: {
+          newWindow: "Open a new Pier window.",
+        },
+        workspace: {
+          resetLayout: "Clear and restore the default workspace layout.",
+        },
+      },
+      errorConflict: 'Already used by "{{command}}".',
+      errorNeedsModifier: "Shortcut must include at least one modifier.",
+      errorUnknown: "Unable to save shortcut.",
+      record: "Record",
+      recording: "Press keys...",
+      reset: "Reset",
+      resetAll: "Reset All",
+      unassigned: "Unassigned",
     },
     theme: {
       light: "Light",
@@ -103,11 +161,15 @@ export const en = {
       workspace: "Workspace",
       run: "Run",
       panel: "Panel",
+      terminal: "Terminal",
       window: "Window",
     },
     action: {
       toggleCommandPalette: "Show Command Palette",
       openSettings: "Open Settings",
+      closeActivePanel: "Close Active Panel",
+      newTab: "New Tab",
+      newWindow: "New Window",
       runTask: "Run Task...",
       terminalList: "Terminal List...",
       switchTerminal: "Switch Terminal...",
@@ -155,9 +217,9 @@ export const en = {
   },
   contextMenu: {
     action: {
-      closeAll: "Close All",
-      closeOthers: "Close Others",
-      closePanel: "Close",
+      closeAll: "Close All Panels",
+      closeOthers: "Close Other Panels",
+      closePanel: "Close Panel",
       closeTerminal: "Close Terminal",
       focusDown: "Focus Down",
       focusLeft: "Focus Left",

--- a/src/renderer/i18n/locales/zh-cn.ts
+++ b/src/renderer/i18n/locales/zh-cn.ts
@@ -4,11 +4,13 @@ export const zhCN = {
     description: "管理应用偏好设置",
     nav: {
       appearance: "外观",
+      keybindings: "快捷键",
       terminal: "终端",
     },
     section: {
       appearance: "外观",
       font: "字体",
+      keybindings: "快捷键",
       terminal: "终端",
     },
     row: {
@@ -49,6 +51,62 @@ export const zhCN = {
         activeTerminal: "继承当前终端",
         shellDefault: "使用 shell 默认目录",
       },
+    },
+    keybindings: {
+      change: "更改快捷键",
+      clear: "清除",
+      descriptionDefault: "{{category}}命令。",
+      description: {
+        commandPalette: {
+          clearRecent: "清空命令面板的使用记录。",
+          toggle: "打开或关闭命令面板。",
+        },
+        config: {
+          locale: "选择界面显示语言。",
+          stylePreset: "选择界面配色风格。",
+          theme: "选择界面颜色模式。",
+        },
+        panel: {
+          close: "关闭当前面板。",
+          closeActive: "关闭当前活动面板。",
+          closeAll: "关闭所有面板。",
+          closeOthers: "关闭除当前面板外的其他面板。",
+          focusDown: "聚焦下方的面板组。",
+          focusLeft: "聚焦左侧的面板组。",
+          focusRight: "聚焦右侧的面板组。",
+          focusUp: "聚焦上方的面板组。",
+          newTab: "新建一个面板标签。",
+          newTerminal: "新建一个终端面板。",
+          splitDown: "向下拆分当前面板。",
+          splitLeft: "向左拆分当前面板。",
+          splitRight: "向右拆分当前面板。",
+          splitUp: "向上拆分当前面板。",
+        },
+        run: {
+          task: "打开任务运行入口。",
+          terminalList: "打开终端列表。",
+        },
+        settings: {
+          open: "打开设置。",
+        },
+        terminal: {
+          close: "关闭当前终端面板。",
+        },
+        window: {
+          newWindow: "打开一个新的 Pier 窗口。",
+        },
+        workspace: {
+          resetLayout: "清空并恢复默认工作区布局。",
+        },
+      },
+      errorConflict: "已被“{{command}}”使用。",
+      errorNeedsModifier: "快捷键至少需要包含一个修饰键。",
+      errorUnknown: "无法保存快捷键。",
+      record: "录制",
+      recording: "按下按键...",
+      reset: "恢复默认",
+      resetAll: "全部重置",
+      unassigned: "未设置",
     },
     theme: {
       light: "浅色",
@@ -100,11 +158,15 @@ export const zhCN = {
       workspace: "工作区",
       run: "运行",
       panel: "面板",
+      terminal: "终端",
       window: "窗口",
     },
     action: {
       toggleCommandPalette: "显示命令面板",
       openSettings: "打开设置",
+      closeActivePanel: "关闭当前面板",
+      newTab: "新建标签",
+      newWindow: "新建窗口",
       runTask: "运行任务...",
       terminalList: "终端列表...",
       switchTerminal: "切换终端...",
@@ -152,9 +214,9 @@ export const zhCN = {
   },
   contextMenu: {
     action: {
-      closeAll: "关闭所有",
-      closeOthers: "关闭其他",
-      closePanel: "关闭",
+      closeAll: "关闭所有面板",
+      closeOthers: "关闭其他面板",
+      closePanel: "关闭面板",
       closeTerminal: "关闭终端",
       focusDown: "向下聚焦",
       focusLeft: "向左聚焦",

--- a/src/renderer/lib/actions/panel-actions.ts
+++ b/src/renderer/lib/actions/panel-actions.ts
@@ -35,7 +35,7 @@ export function registerPanelActions(): () => void {
       id: "pier.panel.closeActive",
       metadata: { group: "9_close" },
       surfaces: [],
-      title: () => "Close Active Panel",
+      title: () => i18next.t("commandPalette.action.closeActivePanel"),
     })
   );
 
@@ -47,7 +47,7 @@ export function registerPanelActions(): () => void {
       id: "pier.panel.newTab",
       metadata: { group: "1_new" },
       surfaces: [],
-      title: () => "New Tab",
+      title: () => i18next.t("commandPalette.action.newTab"),
     })
   );
 
@@ -76,7 +76,7 @@ export function registerPanelActions(): () => void {
       id: "pier.window.newWindow",
       metadata: { group: "1_new" },
       surfaces: [],
-      title: () => "New Window",
+      title: () => i18next.t("commandPalette.action.newWindow"),
     })
   );
 

--- a/src/renderer/lib/keybindings/formatter.ts
+++ b/src/renderer/lib/keybindings/formatter.ts
@@ -40,6 +40,11 @@ function codeLabel(code: string): string {
 }
 
 export function formatChord(chord: KeyChord): string {
+  const parts = formatChordParts(chord);
+  return isMac() ? parts.join("") : parts.join("+");
+}
+
+export function formatChordParts(chord: KeyChord): string[] {
   const mac = isMac();
   const parts: string[] = [];
   if (chord.cmdOrCtrl) {
@@ -57,5 +62,23 @@ export function formatChord(chord: KeyChord): string {
     parts.push(mac ? "⇧" : "Shift");
   }
   parts.push(codeLabel(chord.code));
-  return mac ? parts.join("") : parts.join("+");
+  return parts;
+}
+
+export function stringifyChord(chord: KeyChord): string {
+  const parts: string[] = [];
+  if (chord.cmdOrCtrl) {
+    parts.push("Mod");
+  }
+  if (chord.ctrl) {
+    parts.push("Ctrl");
+  }
+  if (chord.alt) {
+    parts.push("Alt");
+  }
+  if (chord.shift) {
+    parts.push("Shift");
+  }
+  parts.push(chord.code);
+  return parts.join("+");
 }

--- a/src/renderer/lib/keybindings/registry.ts
+++ b/src/renderer/lib/keybindings/registry.ts
@@ -20,6 +20,12 @@ import type {
   ResolveScopeState,
 } from "./types.ts";
 
+export interface KeybindingConflict {
+  readonly binding: Keybinding;
+  readonly commandId: string;
+  readonly scope: KeybindingScope;
+}
+
 class KeybindingRegistry extends Notifier {
   private readonly defaults = new Map<string, Keybinding[]>();
   private readonly userOverrides = new Map<string, Keybinding[]>();
@@ -66,6 +72,38 @@ class KeybindingRegistry extends Notifier {
       return [];
     }
     return this.defaults.get(commandId) ?? [];
+  }
+
+  getUserBindings(): readonly Keybinding[] {
+    return Array.from(this.userOverrides.values()).flat();
+  }
+
+  findConflict(
+    chord: KeyChord,
+    scope: KeybindingScope,
+    ignoredCommandId?: string
+  ): KeybindingConflict | null {
+    for (const [commandId, list] of this.userOverrides) {
+      if (commandId === ignoredCommandId) {
+        continue;
+      }
+      for (const binding of list) {
+        if (binding.scope === scope && chordEquals(binding.chord, chord)) {
+          return { binding, commandId, scope };
+        }
+      }
+    }
+    for (const [commandId, list] of this.defaults) {
+      if (commandId === ignoredCommandId || this.userUnbinds.has(commandId)) {
+        continue;
+      }
+      for (const binding of list) {
+        if (binding.scope === scope && chordEquals(binding.chord, chord)) {
+          return { binding, commandId, scope };
+        }
+      }
+    }
+    return null;
   }
 
   /**

--- a/src/renderer/lib/keybindings/terminal-app-shortcuts.ts
+++ b/src/renderer/lib/keybindings/terminal-app-shortcuts.ts
@@ -1,0 +1,23 @@
+import { DEFAULT_KEYMAP } from "./defaults.ts";
+import { stringifyChord } from "./formatter.ts";
+import { keybindingRegistry } from "./registry.ts";
+
+export function terminalAppShortcutKeys(): string[] {
+  const commandIds = new Set(
+    DEFAULT_KEYMAP.filter((binding) => binding.nativeTerminal === "app").map(
+      (binding) => binding.commandId
+    )
+  );
+  const keys = new Set<string>();
+  for (const commandId of commandIds) {
+    for (const binding of keybindingRegistry.getBindingsFor(commandId)) {
+      keys.add(stringifyChord(binding.chord));
+    }
+  }
+  for (const binding of keybindingRegistry.getUserBindings()) {
+    if (binding.scope === "global") {
+      keys.add(stringifyChord(binding.chord));
+    }
+  }
+  return Array.from(keys).sort();
+}

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -13,6 +13,7 @@ import { keybindingRegistry } from "./lib/keybindings/registry.ts";
 import { registerTerminalActions } from "./panel-kits/terminal/register-actions.ts";
 import { initCommandPaletteMru } from "./stores/command-palette-mru.store.ts";
 import { initFont } from "./stores/font.store.ts";
+import { initKeybindingPreferences } from "./stores/keybinding-preferences.store.ts";
 import { initLocale } from "./stores/locale.store.ts";
 import { installDragWatcher } from "./stores/terminal-overlay.store.ts";
 import { initTerminalPreferences } from "./stores/terminal-preferences.store.ts";
@@ -47,6 +48,7 @@ async function bootstrap() {
   registerCommandPaletteMruAction();
   registerTerminalActions();
   keybindingRegistry.registerDefaults(DEFAULT_KEYMAP);
+  await initKeybindingPreferences();
 
   const rootEl = document.getElementById("root");
   if (rootEl) {

--- a/src/renderer/pages/settings/components/keybindings-section.tsx
+++ b/src/renderer/pages/settings/components/keybindings-section.tsx
@@ -1,0 +1,270 @@
+import {
+  Fragment,
+  useEffect,
+  useMemo,
+  useState,
+  useSyncExternalStore,
+} from "react";
+import { Button } from "@/components/primitives/button.tsx";
+import {
+  Card,
+  CardContent,
+  CardFooter,
+} from "@/components/primitives/card.tsx";
+import {
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldError,
+  FieldLabel,
+} from "@/components/primitives/field.tsx";
+import { Separator } from "@/components/primitives/separator.tsx";
+import { ShortcutInput } from "@/components/primitives/shortcut-input.tsx";
+import { useT } from "@/i18n/use-t.ts";
+import { actionRegistry } from "@/lib/actions/registry.ts";
+import type { Action } from "@/lib/actions/types.ts";
+import {
+  formatChordParts,
+  stringifyChord,
+} from "@/lib/keybindings/formatter.ts";
+import { chordFromEvent } from "@/lib/keybindings/matcher.ts";
+import { keybindingRegistry } from "@/lib/keybindings/registry.ts";
+import { useKeybindingPreferencesStore } from "@/stores/keybinding-preferences.store.ts";
+
+const MODIFIER_CODES = new Set([
+  "AltLeft",
+  "AltRight",
+  "ControlLeft",
+  "ControlRight",
+  "MetaLeft",
+  "MetaRight",
+  "ShiftLeft",
+  "ShiftRight",
+]);
+
+const CONFLICT_PREFIX = "Shortcut already used by ";
+const PIER_ACTION_ID_PREFIX = /^pier\./;
+
+function hasModifier(chord: ReturnType<typeof chordFromEvent>): boolean {
+  return chord.cmdOrCtrl || chord.ctrl || chord.alt || chord.shift;
+}
+
+function useActions(): readonly Action[] {
+  useSyncExternalStore(
+    (cb) => actionRegistry.subscribe(cb),
+    () => actionRegistry.getVersion(),
+    () => 0
+  );
+  useSyncExternalStore(
+    (cb) => keybindingRegistry.subscribe(cb),
+    () => keybindingRegistry.getVersion(),
+    () => 0
+  );
+  return actionRegistry
+    .list()
+    .filter((action) => action.id.startsWith("pier."))
+    .sort(
+      (a, b) =>
+        a.category.localeCompare(b.category) ||
+        a.title().localeCompare(b.title()) ||
+        a.id.localeCompare(b.id)
+    );
+}
+
+function currentShortcutParts(actionId: string): readonly string[] {
+  const binding = keybindingRegistry.getBindingsFor(actionId)[0];
+  return binding ? formatChordParts(binding.chord) : [];
+}
+
+function localizedDescription(
+  action: Action,
+  t: ReturnType<typeof useT>
+): string {
+  const key = `settings.keybindings.description.${action.id.replace(
+    PIER_ACTION_ID_PREFIX,
+    ""
+  )}`;
+  const label = t(key);
+  if (label !== key) {
+    return label;
+  }
+  const categoryKey = `commandPalette.category.${action.category.toLowerCase()}`;
+  const category = t(categoryKey);
+  return t("settings.keybindings.descriptionDefault", {
+    category: category === categoryKey ? action.category : category,
+  });
+}
+
+function localizedError(
+  raw: string,
+  actionsById: ReadonlyMap<string, Action>,
+  t: ReturnType<typeof useT>
+): string {
+  if (raw.startsWith(CONFLICT_PREFIX)) {
+    const commandId = raw.slice(CONFLICT_PREFIX.length);
+    return t("settings.keybindings.errorConflict", {
+      command: actionsById.get(commandId)?.title() ?? commandId,
+    });
+  }
+  return raw;
+}
+
+export function KeybindingsSection() {
+  const t = useT();
+  const actions = useActions();
+  const actionsById = useMemo(
+    () => new Map(actions.map((action) => [action.id, action])),
+    [actions]
+  );
+  const [rowError, setRowError] = useState<{
+    commandId: string;
+    message: string;
+  } | null>(null);
+  const recordingCommandId = useKeybindingPreferencesStore(
+    (s) => s.recordingCommandId
+  );
+  const startRecording = useKeybindingPreferencesStore((s) => s.startRecording);
+  const cancelRecording = useKeybindingPreferencesStore(
+    (s) => s.cancelRecording
+  );
+  const clearBinding = useKeybindingPreferencesStore((s) => s.clearBinding);
+  const resetBinding = useKeybindingPreferencesStore((s) => s.resetBinding);
+  const resetAllBindings = useKeybindingPreferencesStore(
+    (s) => s.resetAllBindings
+  );
+  const setBinding = useKeybindingPreferencesStore((s) => s.setBinding);
+  const hasUserEntry = useKeybindingPreferencesStore((s) => s.hasUserEntry);
+  const hasAnyUserEntry = useKeybindingPreferencesStore(
+    (s) => s.userKeymap.length > 0
+  );
+
+  useEffect(() => {
+    if (!recordingCommandId) {
+      return;
+    }
+    const onKeyDown = (event: KeyboardEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+      if (event.key === "Escape") {
+        setRowError(null);
+        cancelRecording();
+        return;
+      }
+      if (MODIFIER_CODES.has(event.code)) {
+        return;
+      }
+      const chord = chordFromEvent(event);
+      if (!hasModifier(chord)) {
+        setRowError({
+          commandId: recordingCommandId,
+          message: t("settings.keybindings.errorNeedsModifier"),
+        });
+        return;
+      }
+      setBinding(recordingCommandId, stringifyChord(chord), "global")
+        .then((result) => {
+          if (result.ok) {
+            setRowError(null);
+            return;
+          }
+          setRowError({
+            commandId: recordingCommandId,
+            message: localizedError(
+              result.error ?? t("settings.keybindings.errorUnknown"),
+              actionsById,
+              t
+            ),
+          });
+        })
+        .catch((err) => {
+          setRowError({
+            commandId: recordingCommandId,
+            message: err instanceof Error ? err.message : String(err),
+          });
+        });
+    };
+    window.addEventListener("keydown", onKeyDown, true);
+    return () => window.removeEventListener("keydown", onKeyDown, true);
+  }, [actionsById, cancelRecording, recordingCommandId, setBinding, t]);
+
+  return (
+    <div className="px-4 pb-4" id="keybindings">
+      <h1 className="mb-4 text-xl">{t("settings.section.keybindings")}</h1>
+      <Card size="sm">
+        <CardContent className="px-0">
+          <div>
+            {actions.map((action, index) => {
+              const title = action.title();
+              const isRecording = recordingCommandId === action.id;
+              const custom = hasUserEntry(action.id);
+              const hasBinding =
+                keybindingRegistry.getBindingsFor(action.id).length > 0;
+              const error =
+                rowError?.commandId === action.id ? rowError.message : null;
+              return (
+                <Fragment key={action.id}>
+                  {index > 0 ? <Separator className="bg-border/70" /> : null}
+                  <div
+                    className="px-4 py-3"
+                    data-testid={`keybinding-row-${action.id}`}
+                  >
+                    <Field
+                      className="items-start gap-4"
+                      data-invalid={error ? true : undefined}
+                      orientation="horizontal"
+                    >
+                      <FieldContent className="min-w-0 gap-1">
+                        <FieldLabel>{title}</FieldLabel>
+                        <FieldDescription className="text-xs">
+                          {localizedDescription(action, t)}
+                        </FieldDescription>
+                        {error ? <FieldError>{error}</FieldError> : null}
+                      </FieldContent>
+                      <ShortcutInput
+                        canClear={hasBinding}
+                        canReset={custom}
+                        clearLabel={`${t("settings.keybindings.clear")} ${title}`}
+                        isRecording={isRecording}
+                        keyParts={currentShortcutParts(action.id)}
+                        onClear={() => {
+                          setRowError(null);
+                          clearBinding(action.id).catch(() => undefined);
+                        }}
+                        onRecord={() => {
+                          setRowError(null);
+                          startRecording(action.id);
+                        }}
+                        onReset={() => {
+                          setRowError(null);
+                          resetBinding(action.id).catch(() => undefined);
+                        }}
+                        placeholder={t("settings.keybindings.unassigned")}
+                        recordingLabel={t("settings.keybindings.recording")}
+                        recordLabel={`${t("settings.keybindings.record")} ${title}`}
+                        resetLabel={`${t("settings.keybindings.reset")} ${title}`}
+                        tooltipLabel={t("settings.keybindings.change")}
+                      />
+                    </Field>
+                  </div>
+                </Fragment>
+              );
+            })}
+          </div>
+        </CardContent>
+        <CardFooter className="justify-end border-border/70 border-t px-4 py-3">
+          <Button
+            disabled={!hasAnyUserEntry}
+            onClick={() => {
+              setRowError(null);
+              resetAllBindings().catch(() => undefined);
+            }}
+            type="button"
+            variant="outline"
+          >
+            {t("settings.keybindings.resetAll")}
+          </Button>
+        </CardFooter>
+      </Card>
+    </div>
+  );
+}

--- a/src/renderer/pages/settings/data/appearance-nav.ts
+++ b/src/renderer/pages/settings/data/appearance-nav.ts
@@ -1,4 +1,4 @@
-import { type LucideIcon, Paintbrush, Terminal } from "lucide-react";
+import { Keyboard, type LucideIcon, Paintbrush, Terminal } from "lucide-react";
 
 export interface NavItem {
   icon: LucideIcon;
@@ -9,6 +9,7 @@ export interface NavItem {
 export const NAV_ITEMS: readonly NavItem[] = [
   { id: "appearance", label: "外观", icon: Paintbrush },
   { id: "terminal", label: "终端", icon: Terminal },
+  { id: "keybindings", label: "快捷键", icon: Keyboard },
 ] as const;
 
 export type SettingsSectionId = (typeof NAV_ITEMS)[number]["id"];

--- a/src/renderer/pages/settings/settings-dialog.tsx
+++ b/src/renderer/pages/settings/settings-dialog.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/components/primitives/sidebar.tsx";
 import { useT } from "@/i18n/use-t.ts";
 import { AppearanceSection } from "@/pages/settings/components/appearance-section.tsx";
+import { KeybindingsSection } from "@/pages/settings/components/keybindings-section.tsx";
 import { TerminalSection } from "@/pages/settings/components/terminal-section.tsx";
 import {
   NAV_ITEMS,
@@ -96,11 +97,9 @@ export function SettingsDialog() {
             className="relative -mr-6 flex h-full min-h-0 flex-1 flex-col overflow-y-auto"
             data-scrollbar="stable"
           >
-            {activeSection === "appearance" ? (
-              <AppearanceSection />
-            ) : (
-              <TerminalSection />
-            )}
+            {activeSection === "appearance" ? <AppearanceSection /> : null}
+            {activeSection === "terminal" ? <TerminalSection /> : null}
+            {activeSection === "keybindings" ? <KeybindingsSection /> : null}
           </main>
         </SidebarProvider>
       </DialogContent>

--- a/src/renderer/panel-kits/terminal/register-actions.ts
+++ b/src/renderer/panel-kits/terminal/register-actions.ts
@@ -19,7 +19,7 @@ export function registerTerminalActions(): () => void {
 
   disposers.push(
     actionRegistry.register({
-      category: "Panel",
+      category: "Terminal",
       enabled: () => useWorkspaceStore.getState().api?.activePanel != null,
       handler: () => {
         // alias: 把 close 行为统一委派给 pier.panel.close handler.

--- a/src/renderer/stores/keybinding-preferences.store.ts
+++ b/src/renderer/stores/keybinding-preferences.store.ts
@@ -1,0 +1,195 @@
+import type { UserKeymapEntry } from "@shared/contracts/preferences.ts";
+import { create } from "zustand";
+import { DEFAULT_KEYMAP } from "@/lib/keybindings/defaults.ts";
+import { stringifyChord } from "@/lib/keybindings/formatter.ts";
+import { isMac } from "@/lib/keybindings/matcher.ts";
+import { parseChord } from "@/lib/keybindings/parse.ts";
+import { keybindingRegistry } from "@/lib/keybindings/registry.ts";
+import { terminalAppShortcutKeys } from "@/lib/keybindings/terminal-app-shortcuts.ts";
+import type { KeybindingScope, KeyChord } from "@/lib/keybindings/types.ts";
+
+interface KeybindingUpdateResult {
+  error?: string;
+  ok: boolean;
+}
+
+interface KeybindingPreferencesState {
+  cancelRecording: () => void;
+  clearBinding: (commandId: string) => Promise<KeybindingUpdateResult>;
+  error: string | null;
+  hasUserEntry: (commandId: string) => boolean;
+  recordingCommandId: string | null;
+  resetAllBindings: () => Promise<KeybindingUpdateResult>;
+  resetBinding: (commandId: string) => Promise<KeybindingUpdateResult>;
+  setBinding: (
+    commandId: string,
+    keys: string,
+    scope?: KeybindingScope
+  ) => Promise<KeybindingUpdateResult>;
+  startRecording: (commandId: string) => void;
+  userKeymap: UserKeymapEntry[];
+}
+
+function hasDefaultBinding(commandId: string): boolean {
+  return DEFAULT_KEYMAP.some((binding) => binding.commandId === commandId);
+}
+
+function entriesWithoutCommand(
+  entries: readonly UserKeymapEntry[],
+  commandId: string
+): UserKeymapEntry[] {
+  const unbindId = `-${commandId}`;
+  return entries.filter(
+    (entry) => entry.commandId !== commandId && entry.commandId !== unbindId
+  );
+}
+
+function applyUserKeymap(entries: readonly UserKeymapEntry[]): void {
+  keybindingRegistry.loadUserKeymap(
+    entries.map((entry) => ({
+      ...entry,
+      scope: entry.scope as KeybindingScope,
+    }))
+  );
+  try {
+    window.pier?.terminal?.setAppShortcutKeys?.(terminalAppShortcutKeys());
+  } catch (err) {
+    console.error(
+      "[keybinding-preferences.store] setAppShortcutKeys failed:",
+      err
+    );
+  }
+}
+
+async function persistUserKeymap(
+  entries: UserKeymapEntry[]
+): Promise<KeybindingUpdateResult> {
+  try {
+    await window.pier.preferences.update({ userKeymap: entries });
+    applyUserKeymap(entries);
+    useKeybindingPreferencesStore.setState({
+      error: null,
+      recordingCommandId: null,
+      userKeymap: entries,
+    });
+    return { ok: true };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    useKeybindingPreferencesStore.setState({ error: message });
+    return { ok: false, error: message };
+  }
+}
+
+export const useKeybindingPreferencesStore = create<KeybindingPreferencesState>(
+  (set, get) => ({
+    error: null,
+    recordingCommandId: null,
+    userKeymap: [],
+
+    cancelRecording() {
+      set({ error: null, recordingCommandId: null });
+    },
+
+    clearBinding(commandId) {
+      const next: UserKeymapEntry[] = [
+        ...entriesWithoutCommand(get().userKeymap, commandId),
+        { commandId: `-${commandId}`, keys: "", scope: "global" },
+      ];
+      return persistUserKeymap(next);
+    },
+
+    hasUserEntry(commandId) {
+      const unbindId = `-${commandId}`;
+      return get().userKeymap.some(
+        (entry) => entry.commandId === commandId || entry.commandId === unbindId
+      );
+    },
+
+    resetBinding(commandId) {
+      return persistUserKeymap(
+        entriesWithoutCommand(get().userKeymap, commandId)
+      );
+    },
+
+    resetAllBindings() {
+      return persistUserKeymap([]);
+    },
+
+    setBinding(commandId, keys, scope = "global") {
+      let chord: KeyChord;
+      try {
+        chord = parseChord(keys, isMac());
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        set({ error: message });
+        return Promise.resolve({ ok: false, error: message });
+      }
+      const normalizedKeys = stringifyChord(chord);
+      const conflict = keybindingRegistry.findConflict(chord, scope, commandId);
+      if (conflict) {
+        const message = `Shortcut already used by ${conflict.commandId}`;
+        set({ error: message });
+        return Promise.resolve({ ok: false, error: message });
+      }
+      const next: UserKeymapEntry[] = [
+        ...entriesWithoutCommand(get().userKeymap, commandId),
+      ];
+      if (hasDefaultBinding(commandId)) {
+        next.push({ commandId: `-${commandId}`, keys: "", scope: "global" });
+      }
+      next.push({ commandId, keys: normalizedKeys, scope });
+      return persistUserKeymap(next);
+    },
+
+    startRecording(commandId) {
+      set({ error: null, recordingCommandId: commandId });
+    },
+  })
+);
+
+let preferencesListenerAttached = false;
+let detachPreferencesListener: (() => void) | null = null;
+
+function hydrate(entries: readonly UserKeymapEntry[]): void {
+  const next = [...entries];
+  applyUserKeymap(next);
+  useKeybindingPreferencesStore.setState({
+    error: null,
+    recordingCommandId: null,
+    userKeymap: next,
+  });
+}
+
+function attachPreferencesListener(): void {
+  if (preferencesListenerAttached || typeof window === "undefined") {
+    return;
+  }
+  const detach = window.pier?.preferences?.onChanged?.((next) => {
+    hydrate(next.userKeymap ?? []);
+  });
+  if (!detach) {
+    return;
+  }
+  detachPreferencesListener = detach;
+  preferencesListenerAttached = true;
+}
+
+export function detachKeybindingPreferencesListener(): void {
+  detachPreferencesListener?.();
+  detachPreferencesListener = null;
+  preferencesListenerAttached = false;
+}
+
+export async function initKeybindingPreferences(): Promise<void> {
+  attachPreferencesListener();
+  try {
+    const snapshot = await window.pier.preferences.read();
+    hydrate(snapshot.userKeymap ?? []);
+  } catch (err) {
+    console.error(
+      "[keybinding-preferences.store] init IPC failed; keeping defaults:",
+      err
+    );
+    hydrate([]);
+  }
+}

--- a/src/shared/contracts/preferences.ts
+++ b/src/shared/contracts/preferences.ts
@@ -10,6 +10,21 @@ export const terminalNewCwdPolicySchema = z.enum([
   "activeTerminal",
   "shellDefault",
 ]);
+export const keybindingScopeSchema = z.union([
+  z.literal("global"),
+  z.string().regex(/^(panel|overlay):[A-Za-z0-9._:-]+$/),
+]);
+
+export const userKeymapEntrySchema = z
+  .object({
+    commandId: z.string().min(1).max(128),
+    keys: z.string().max(128),
+    scope: keybindingScopeSchema.default("global"),
+  })
+  .refine((entry) => entry.commandId.startsWith("-") || entry.keys !== "", {
+    message: "keys is required for keybinding entries",
+    path: ["keys"],
+  });
 
 export const stylePresetIdSchema = z.enum([
   "pierre",
@@ -65,6 +80,7 @@ export const projectPreferencesSchema = z.object({
   terminalNewCwdPolicy: terminalNewCwdPolicySchema.default(
     DEFAULT_TERMINAL_NEW_CWD_POLICY
   ),
+  userKeymap: z.array(userKeymapEntrySchema).max(256).default([]),
 });
 
 export type ThemePreference = z.infer<typeof themePreferenceSchema>;
@@ -72,4 +88,6 @@ export type ResolvedTheme = z.infer<typeof resolvedThemeSchema>;
 export type StylePresetId = z.infer<typeof stylePresetIdSchema>;
 export type TerminalCursorStyle = z.infer<typeof terminalCursorStyleSchema>;
 export type TerminalNewCwdPolicy = z.infer<typeof terminalNewCwdPolicySchema>;
+export type KeybindingScopePreference = z.infer<typeof keybindingScopeSchema>;
+export type UserKeymapEntry = z.infer<typeof userKeymapEntrySchema>;
 export type ProjectPreferences = z.infer<typeof projectPreferencesSchema>;

--- a/src/shared/contracts/terminal.ts
+++ b/src/shared/contracts/terminal.ts
@@ -232,6 +232,7 @@ export interface TerminalAPI {
     kind: "terminal" | "web",
     panelId: string | null
   ) => void;
+  setAppShortcutKeys(keys: string[]): void;
   setConfig(config: TerminalRuntimeConfig): void;
   /**
    * 热更新已存在 terminal 的字体. 走 Ghostty TerminalController.setTerminalConfiguration

--- a/tests/component/keybindings-section.test.tsx
+++ b/tests/component/keybindings-section.test.tsx
@@ -1,0 +1,309 @@
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import i18next from "i18next";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { initI18n } from "@/i18n/index.ts";
+import { registerPanelActions } from "@/lib/actions/panel-actions.ts";
+import { actionRegistry } from "@/lib/actions/registry.ts";
+import { DEFAULT_KEYMAP } from "@/lib/keybindings/defaults.ts";
+import { keybindingRegistry } from "@/lib/keybindings/registry.ts";
+import { KeybindingsSection } from "@/pages/settings/components/keybindings-section.tsx";
+import { registerTerminalActions } from "@/panel-kits/terminal/register-actions.ts";
+
+const RAW_PANEL_METADATA_PATTERN = /Panel ·/;
+
+describe("KeybindingsSection", () => {
+  beforeAll(async () => {
+    await initI18n();
+  });
+
+  beforeEach(async () => {
+    await i18next.changeLanguage("zh-CN");
+    vi.clearAllMocks();
+    keybindingRegistry.loadUserKeymap([]);
+    keybindingRegistry.registerDefaults(DEFAULT_KEYMAP);
+    Object.defineProperty(window, "pier", {
+      configurable: true,
+      value: {
+        preferences: {
+          onChanged: vi.fn(),
+          read: vi.fn(),
+          update: vi.fn(),
+        },
+        terminal: { setAppShortcutKeys: vi.fn() },
+      },
+    });
+  });
+
+  afterEach(async () => {
+    await i18next.changeLanguage("en");
+  });
+
+  it("records a replacement shortcut from the keyboard", async () => {
+    const dispose = actionRegistry.register({
+      category: "Panel",
+      handler: vi.fn(),
+      id: "pier.panel.newTerminal",
+      surfaces: ["command-palette"],
+      title: () => "新建终端",
+    });
+
+    const { unmount } = render(<KeybindingsSection />);
+    fireEvent.click(screen.getByRole("button", { name: "录制 新建终端" }));
+    fireEvent.keyDown(window, {
+      code: "KeyX",
+      ctrlKey: true,
+      key: "X",
+      shiftKey: true,
+    });
+
+    await waitFor(() => {
+      expect(window.pier.preferences.update).toHaveBeenCalledWith({
+        userKeymap: [
+          { commandId: "-pier.panel.newTerminal", keys: "", scope: "global" },
+          {
+            commandId: "pier.panel.newTerminal",
+            keys: "Mod+Shift+KeyX",
+            scope: "global",
+          },
+        ],
+      });
+    });
+    unmount();
+    dispose();
+  });
+
+  it("uses localized descriptions instead of raw action metadata", () => {
+    const dispose = actionRegistry.register({
+      category: "Panel",
+      handler: vi.fn(),
+      id: "pier.panel.newTerminal",
+      surfaces: ["command-palette"],
+      title: () => "新建终端",
+    });
+
+    const { unmount } = render(<KeybindingsSection />);
+
+    expect(screen.getByText("新建一个终端面板。")).toBeInTheDocument();
+    expect(
+      screen.queryByText(RAW_PANEL_METADATA_PATTERN)
+    ).not.toBeInTheDocument();
+    unmount();
+    dispose();
+  });
+
+  it("uses descriptive localized action labels in the settings list", () => {
+    const disposers = [registerPanelActions(), registerTerminalActions()];
+
+    const { unmount } = render(<KeybindingsSection />);
+
+    expect(screen.getByText("关闭面板")).toBeInTheDocument();
+    expect(screen.getByText("关闭其他面板")).toBeInTheDocument();
+    expect(screen.getByText("关闭所有面板")).toBeInTheDocument();
+    expect(screen.getByText("关闭当前面板。")).toBeInTheDocument();
+    const terminalRow = screen.getByTestId(
+      "keybinding-row-pier.terminal.close"
+    );
+    expect(within(terminalRow).getByText("关闭终端")).toBeInTheDocument();
+    expect(
+      within(terminalRow).getByText("关闭当前终端面板。")
+    ).toBeInTheDocument();
+    unmount();
+    for (const dispose of disposers) {
+      dispose();
+    }
+  });
+
+  it("renders shortcut values as keycaps inside a single input control", () => {
+    const dispose = actionRegistry.register({
+      category: "Run",
+      handler: vi.fn(),
+      id: "pier.panel.newTerminal",
+      surfaces: ["command-palette"],
+      title: () => "新建终端",
+    });
+
+    const { unmount } = render(<KeybindingsSection />);
+
+    const row = screen.getByTestId("keybinding-row-pier.panel.newTerminal");
+    const input = within(row).getByTestId("shortcut-input");
+    expect(input).toBeInTheDocument();
+    expect(within(input).getAllByTestId("shortcut-input-key")).toHaveLength(2);
+    expect(within(input).getByText("Ctrl")).toBeInTheDocument();
+    expect(within(input).getByText("T")).toBeInTheDocument();
+    expect(
+      within(row).getByRole("button", { name: "录制 新建终端" })
+    ).toHaveAttribute("data-slot", "shortcut-input-trigger");
+    unmount();
+    dispose();
+  });
+
+  it("uses the recording input state from the reference", () => {
+    const dispose = actionRegistry.register({
+      category: "Panel",
+      handler: vi.fn(),
+      id: "pier.panel.closeOthers",
+      surfaces: ["command-palette"],
+      title: () => "关闭其他面板",
+    });
+
+    const { unmount } = render(<KeybindingsSection />);
+    fireEvent.click(screen.getByRole("button", { name: "录制 关闭其他面板" }));
+
+    const row = screen.getByTestId("keybinding-row-pier.panel.closeOthers");
+    const input = within(row).getByTestId("shortcut-input");
+    expect(input).toHaveAttribute("data-recording", "true");
+    expect(within(input).getByText("按下按键...")).toBeInTheDocument();
+    unmount();
+    dispose();
+  });
+
+  it("resets all customized shortcuts from the footer", async () => {
+    const dispose = actionRegistry.register({
+      category: "Panel",
+      handler: vi.fn(),
+      id: "pier.panel.newTerminal",
+      surfaces: ["command-palette"],
+      title: () => "新建终端",
+    });
+
+    const { unmount } = render(<KeybindingsSection />);
+    fireEvent.click(screen.getByRole("button", { name: "录制 新建终端" }));
+    fireEvent.keyDown(window, {
+      code: "KeyX",
+      ctrlKey: true,
+      key: "X",
+      shiftKey: true,
+    });
+    await waitFor(() => {
+      expect(window.pier.preferences.update).toHaveBeenCalledWith({
+        userKeymap: expect.arrayContaining([
+          {
+            commandId: "pier.panel.newTerminal",
+            keys: "Mod+Shift+KeyX",
+            scope: "global",
+          },
+        ]),
+      });
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "全部重置" }));
+
+    await waitFor(() => {
+      expect(window.pier.preferences.update).toHaveBeenLastCalledWith({
+        userKeymap: [],
+      });
+    });
+    unmount();
+    dispose();
+  });
+
+  it("shows modifier validation errors inside the active row", () => {
+    const dispose = actionRegistry.register({
+      category: "Panel",
+      handler: vi.fn(),
+      id: "pier.panel.newTerminal",
+      surfaces: ["command-palette"],
+      title: () => "新建终端",
+    });
+
+    const { unmount } = render(<KeybindingsSection />);
+    fireEvent.click(screen.getByRole("button", { name: "录制 新建终端" }));
+    fireEvent.keyDown(window, { code: "KeyX", key: "X" });
+
+    const row = screen.getByTestId("keybinding-row-pier.panel.newTerminal");
+    expect(within(row).getByRole("alert")).toHaveTextContent(
+      "快捷键至少需要包含一个修饰键。"
+    );
+    unmount();
+    dispose();
+  });
+
+  it("shows localized conflict errors inside the active row", async () => {
+    const disposers = [
+      actionRegistry.register({
+        category: "Panel",
+        handler: vi.fn(),
+        id: "pier.panel.newTerminal",
+        surfaces: ["command-palette"],
+        title: () => "新建终端",
+      }),
+      actionRegistry.register({
+        category: "Panel",
+        handler: vi.fn(),
+        id: "pier.panel.splitRight",
+        surfaces: ["command-palette"],
+        title: () => "向右拆分",
+      }),
+    ];
+
+    const { unmount } = render(<KeybindingsSection />);
+    fireEvent.click(screen.getByRole("button", { name: "录制 向右拆分" }));
+    fireEvent.keyDown(window, {
+      code: "KeyT",
+      ctrlKey: true,
+      key: "T",
+    });
+
+    const row = screen.getByTestId("keybinding-row-pier.panel.splitRight");
+    await waitFor(() => {
+      expect(within(row).getByRole("alert")).toHaveTextContent(
+        "已被“新建终端”使用。"
+      );
+    });
+    expect(window.pier.preferences.update).not.toHaveBeenCalled();
+    unmount();
+    for (const dispose of disposers) {
+      dispose();
+    }
+  });
+
+  it("shows conflicts and does not persist the conflicting shortcut", async () => {
+    const disposers = [
+      actionRegistry.register({
+        category: "Panel",
+        handler: vi.fn(),
+        id: "pier.panel.newTerminal",
+        surfaces: ["command-palette"],
+        title: () => "新建终端",
+      }),
+      actionRegistry.register({
+        category: "Panel",
+        handler: vi.fn(),
+        id: "pier.panel.splitRight",
+        surfaces: ["command-palette"],
+        title: () => "向右拆分",
+      }),
+    ];
+
+    const { unmount } = render(<KeybindingsSection />);
+    fireEvent.click(screen.getByRole("button", { name: "录制 向右拆分" }));
+    fireEvent.keyDown(window, {
+      code: "KeyT",
+      ctrlKey: true,
+      key: "T",
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent("新建终端");
+    });
+    expect(window.pier.preferences.update).not.toHaveBeenCalled();
+    unmount();
+    for (const dispose of disposers) {
+      dispose();
+    }
+  });
+});

--- a/tests/unit/app-core/command-router.test.ts
+++ b/tests/unit/app-core/command-router.test.ts
@@ -55,6 +55,7 @@ function services(rendererCommands: unknown[] = []): PierCoreServices {
         terminalScrollbackMb: 64,
         theme: "system",
         uiFontFamily: "",
+        userKeymap: [],
       }),
       update: async (patch) => ({
         language: "system",
@@ -68,6 +69,7 @@ function services(rendererCommands: unknown[] = []): PierCoreServices {
         terminalScrollbackMb: 64,
         theme: patch.theme ?? "system",
         uiFontFamily: "",
+        userKeymap: patch.userKeymap ?? [],
       }),
     },
     workspace: {

--- a/tests/unit/app-core/services.test.ts
+++ b/tests/unit/app-core/services.test.ts
@@ -17,6 +17,7 @@ const basePreferences: ProjectPreferences = {
   terminalScrollbackMb: 64,
   theme: "system",
   uiFontFamily: "",
+  userKeymap: [],
 };
 
 describe("createPreferencesService", () => {
@@ -75,6 +76,34 @@ describe("createPreferencesService", () => {
         terminalScrollbackMb: 128,
       },
     ]);
+  });
+
+  it("更新用户快捷键时不会被服务层过滤", async () => {
+    const patches: Partial<ProjectPreferences>[] = [];
+    const userKeymap = [
+      {
+        commandId: "-pier.panel.newTerminal",
+        keys: "",
+        scope: "global" as const,
+      },
+      {
+        commandId: "pier.panel.newTerminal",
+        keys: "Mod+Shift+KeyX",
+        scope: "global" as const,
+      },
+    ];
+    const service = createPreferencesService({
+      readPreferences: async () => basePreferences,
+      updatePreferences: (patch) => {
+        patches.push(patch);
+        return Promise.resolve({ ...basePreferences, ...patch });
+      },
+    });
+
+    await expect(service.update({ userKeymap })).resolves.toMatchObject({
+      userKeymap,
+    });
+    expect(patches).toEqual([{ userKeymap }]);
   });
 });
 

--- a/tests/unit/keybinding-preferences-store.test.ts
+++ b/tests/unit/keybinding-preferences-store.test.ts
@@ -1,0 +1,173 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("keybinding-preferences.store", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  function installPierApi(snapshot = {}) {
+    const read = vi.fn(async () => ({
+      theme: "system",
+      stylePresetId: "pierre",
+      language: "system",
+      uiFontFamily: "",
+      monoFontFamily: "",
+      monoFontSize: 13,
+      terminalCursorStyle: "block",
+      terminalCursorBlink: true,
+      terminalScrollbackMb: 64,
+      terminalPasteProtection: true,
+      terminalNewCwdPolicy: "activeTerminal",
+      userKeymap: [],
+      ...snapshot,
+    }));
+    const update = vi.fn(async (patch: Record<string, unknown>) => ({
+      ...(await read()),
+      ...patch,
+    }));
+    const onChanged = vi.fn();
+    const setAppShortcutKeys = vi.fn();
+    Object.defineProperty(window, "pier", {
+      configurable: true,
+      value: {
+        preferences: { onChanged, read, update },
+        terminal: { setAppShortcutKeys },
+      },
+    });
+    return { onChanged, read, setAppShortcutKeys, update };
+  }
+
+  it("loads persisted user keymap into the registry and syncs native shortcuts", async () => {
+    const pier = installPierApi({
+      userKeymap: [
+        { commandId: "-pier.panel.newTerminal", keys: "", scope: "global" },
+        {
+          commandId: "pier.panel.newTerminal",
+          keys: "Mod+Shift+KeyX",
+          scope: "global",
+        },
+      ],
+    });
+    const { DEFAULT_KEYMAP } = await import("@/lib/keybindings/defaults.ts");
+    const { parseChord } = await import("@/lib/keybindings/parse.ts");
+    const { keybindingRegistry } = await import(
+      "@/lib/keybindings/registry.ts"
+    );
+    const { initKeybindingPreferences } = await import(
+      "@/stores/keybinding-preferences.store.ts"
+    );
+
+    keybindingRegistry.registerDefaults(DEFAULT_KEYMAP);
+    await initKeybindingPreferences();
+
+    expect(
+      keybindingRegistry.resolve(parseChord("Mod+KeyT", false), {
+        activePanelComponent: null,
+        overlayStack: [],
+      })
+    ).toBeNull();
+    expect(
+      keybindingRegistry.resolve(parseChord("Mod+Shift+KeyX", false), {
+        activePanelComponent: null,
+        overlayStack: [],
+      })
+    ).toBe("pier.panel.newTerminal");
+    expect(pier.setAppShortcutKeys).toHaveBeenCalledWith(
+      expect.arrayContaining(["Mod+Shift+KeyX"])
+    );
+  });
+
+  it("writes replacement bindings as an unbind plus a single user binding", async () => {
+    const pier = installPierApi();
+    const { DEFAULT_KEYMAP } = await import("@/lib/keybindings/defaults.ts");
+    const { keybindingRegistry } = await import(
+      "@/lib/keybindings/registry.ts"
+    );
+    const { initKeybindingPreferences, useKeybindingPreferencesStore } =
+      await import("@/stores/keybinding-preferences.store.ts");
+
+    keybindingRegistry.registerDefaults(DEFAULT_KEYMAP);
+    await initKeybindingPreferences();
+    await useKeybindingPreferencesStore
+      .getState()
+      .setBinding("pier.panel.newTerminal", "Mod+Shift+KeyX", "global");
+
+    expect(pier.update).toHaveBeenCalledWith({
+      userKeymap: [
+        { commandId: "-pier.panel.newTerminal", keys: "", scope: "global" },
+        {
+          commandId: "pier.panel.newTerminal",
+          keys: "Mod+Shift+KeyX",
+          scope: "global",
+        },
+      ],
+    });
+  });
+
+  it("syncs explicitly configured shortcuts without defaults to native terminal routing", async () => {
+    const pier = installPierApi();
+    const { DEFAULT_KEYMAP } = await import("@/lib/keybindings/defaults.ts");
+    const { keybindingRegistry } = await import(
+      "@/lib/keybindings/registry.ts"
+    );
+    const { initKeybindingPreferences, useKeybindingPreferencesStore } =
+      await import("@/stores/keybinding-preferences.store.ts");
+
+    keybindingRegistry.registerDefaults(DEFAULT_KEYMAP);
+    await initKeybindingPreferences();
+    await useKeybindingPreferencesStore
+      .getState()
+      .setBinding("pier.panel.splitLeft", "Mod+Alt+ArrowLeft", "global");
+
+    expect(pier.setAppShortcutKeys).toHaveBeenLastCalledWith(
+      expect.arrayContaining(["Mod+Alt+ArrowLeft"])
+    );
+  });
+
+  it("resets all user keybindings", async () => {
+    const pier = installPierApi({
+      userKeymap: [
+        { commandId: "-pier.panel.newTerminal", keys: "", scope: "global" },
+        {
+          commandId: "pier.panel.newTerminal",
+          keys: "Mod+Shift+KeyX",
+          scope: "global",
+        },
+      ],
+    });
+    const { DEFAULT_KEYMAP } = await import("@/lib/keybindings/defaults.ts");
+    const { keybindingRegistry } = await import(
+      "@/lib/keybindings/registry.ts"
+    );
+    const { initKeybindingPreferences, useKeybindingPreferencesStore } =
+      await import("@/stores/keybinding-preferences.store.ts");
+
+    keybindingRegistry.registerDefaults(DEFAULT_KEYMAP);
+    await initKeybindingPreferences();
+    await useKeybindingPreferencesStore.getState().resetAllBindings();
+
+    expect(pier.update).toHaveBeenLastCalledWith({ userKeymap: [] });
+    expect(useKeybindingPreferencesStore.getState().userKeymap).toEqual([]);
+  });
+
+  it("blocks conflicting bindings before writing preferences", async () => {
+    const pier = installPierApi();
+    const { DEFAULT_KEYMAP } = await import("@/lib/keybindings/defaults.ts");
+    const { keybindingRegistry } = await import(
+      "@/lib/keybindings/registry.ts"
+    );
+    const { initKeybindingPreferences, useKeybindingPreferencesStore } =
+      await import("@/stores/keybinding-preferences.store.ts");
+
+    keybindingRegistry.registerDefaults(DEFAULT_KEYMAP);
+    await initKeybindingPreferences();
+    const result = await useKeybindingPreferencesStore
+      .getState()
+      .setBinding("pier.panel.splitRight", "Mod+KeyT", "global");
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("pier.panel.newTerminal");
+    expect(pier.update).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/keybindings.test.ts
+++ b/tests/unit/keybindings.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it } from "vitest";
+import { stringifyChord } from "@/lib/keybindings/formatter.ts";
 import { chordEquals } from "@/lib/keybindings/matcher.ts";
 import { parseChord } from "@/lib/keybindings/parse.ts";
 import { keybindingRegistry } from "@/lib/keybindings/registry.ts";
@@ -172,5 +173,43 @@ describe("keybinding engine", () => {
     expect(keybindingRegistry.getBindingsFor("pier.test.action")).toHaveLength(
       1
     );
+  });
+
+  it("stringifies chords back to the persisted keymap DSL", () => {
+    expect(stringifyChord(parseChord("Mod+Alt+Shift+KeyX", true))).toBe(
+      "Mod+Alt+Shift+KeyX"
+    );
+    expect(stringifyChord(parseChord("Ctrl+Shift+ArrowLeft", true))).toBe(
+      "Ctrl+Shift+ArrowLeft"
+    );
+  });
+
+  it("detects conflicts in the same scope and ignores the same command", () => {
+    keybindingRegistry.registerDefaults([
+      {
+        commandId: "pier.test.first",
+        keys: "Mod+KeyK",
+        scope: "global",
+      },
+      {
+        commandId: "pier.test.panel",
+        keys: "Mod+KeyK",
+        scope: "panel:terminal",
+      },
+    ]);
+    const chord = parseChord("Mod+KeyK", false);
+
+    expect(
+      keybindingRegistry.findConflict(chord, "global", "pier.test.second")
+    ).toMatchObject({
+      commandId: "pier.test.first",
+      scope: "global",
+    });
+    expect(
+      keybindingRegistry.findConflict(chord, "global", "pier.test.first")
+    ).toBeNull();
+    expect(
+      keybindingRegistry.findConflict(chord, "overlay:command-palette")
+    ).toBeNull();
   });
 });

--- a/tests/unit/native-terminal-key-routing.test.ts
+++ b/tests/unit/native-terminal-key-routing.test.ts
@@ -10,9 +10,14 @@ const GHOSTTY_BRIDGE_PATH = join(
   process.cwd(),
   "native/Sources/GhosttyBridge/GhosttyBridge.swift"
 );
+const NATIVE_ADDON_PATH = join(process.cwd(), "native/src/addon.mm");
 
 function readGhosttyBridgeSource(): string {
   return readFileSync(GHOSTTY_BRIDGE_PATH, "utf8");
+}
+
+function readNativeAddonSource(): string {
+  return readFileSync(NATIVE_ADDON_PATH, "utf8");
 }
 
 function swiftTerminalAppShortcuts(source: string): string[] {
@@ -73,5 +78,15 @@ describe("native terminal key routing", () => {
     );
     expect(allowlistCheckIndex).toBeGreaterThan(-1);
     expect(forwardIndex).toBeGreaterThan(allowlistCheckIndex);
+  });
+
+  it("exposes a runtime setter for customized terminal-mode Pier shortcuts", () => {
+    expect(readGhosttyBridgeSource()).toContain(
+      '@_cdecl("ghostty_bridge_set_app_shortcut_keys")'
+    );
+    expect(readNativeAddonSource()).toContain("JsSetAppShortcutKeys");
+    expect(readNativeAddonSource()).toContain(
+      'exports.Set("setAppShortcutKeys"'
+    );
   });
 });

--- a/tests/unit/preferences-schema.test.ts
+++ b/tests/unit/preferences-schema.test.ts
@@ -96,3 +96,59 @@ describe("projectPreferencesSchema — terminal preferences", () => {
     ).toThrow();
   });
 });
+
+describe("projectPreferencesSchema — user keymap", () => {
+  it("默认没有用户快捷键覆盖", () => {
+    const parsed = projectPreferencesSchema.parse({});
+    expect(parsed.userKeymap).toEqual([]);
+  });
+
+  it("接受普通绑定和解绑条目", () => {
+    expect(
+      projectPreferencesSchema.parse({
+        userKeymap: [
+          {
+            commandId: "-pier.panel.newTerminal",
+            keys: "",
+            scope: "global",
+          },
+          {
+            commandId: "pier.panel.newTerminal",
+            keys: "Mod+Shift+KeyX",
+            scope: "global",
+          },
+        ],
+      }).userKeymap
+    ).toEqual([
+      {
+        commandId: "-pier.panel.newTerminal",
+        keys: "",
+        scope: "global",
+      },
+      {
+        commandId: "pier.panel.newTerminal",
+        keys: "Mod+Shift+KeyX",
+        scope: "global",
+      },
+    ]);
+  });
+
+  it("拒绝缺少 keys 的普通绑定和非法 scope", () => {
+    expect(() =>
+      projectPreferencesSchema.parse({
+        userKeymap: [{ commandId: "pier.panel.newTerminal", keys: "" }],
+      })
+    ).toThrow();
+    expect(() =>
+      projectPreferencesSchema.parse({
+        userKeymap: [
+          {
+            commandId: "pier.panel.newTerminal",
+            keys: "Mod+KeyT",
+            scope: "bad scope",
+          },
+        ],
+      })
+    ).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- Add persisted `userKeymap` preferences and load them into the existing keybinding registry.
- Add the Keyboard settings section with recording, clear, restore default, reset all, conflict handling, and localized descriptions.
- Add runtime native terminal app-shortcut allowlist updates so terminal focus keeps the app-command-only routing policy.

## Validation
- `./node_modules/.bin/lint-staged`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/vitest run tests/unit/keybindings.test.ts tests/unit/keybinding-preferences-store.test.ts tests/component/keybindings-section.test.tsx tests/unit/native-terminal-key-routing.test.ts tests/unit/preferences-schema.test.ts tests/unit/app-core/services.test.ts`
- `./node_modules/.bin/depcruise --config dependency-cruiser.config.cjs src`
- `bash scripts/check-file-size.sh`
- `./node_modules/.bin/electron-vite build`

## Notes
- `pnpm`-based husky hooks are currently blocked in this non-interactive worktree by pnpm attempting to purge `node_modules`; the equivalent hook commands above were run directly with local binaries.