### PR TITLE
[codex] unify child process environment resolution

### DIFF
--- a/bin/pier-cli-parser.d.ts
+++ b/bin/pier-cli-parser.d.ts
@@ -1,6 +1,7 @@
 import type { PierCommandEnvelope } from "../src/shared/contracts/commands.ts";
 
 export interface ParsePierCliArgsOptions {
+  clientEnv?: Record<string, string>;
   clientId?: string;
   cwd?: string;
   requestId?: string;

--- a/bin/pier-cli-parser.js
+++ b/bin/pier-cli-parser.js
@@ -418,10 +418,16 @@ function parseCommand(args, cwd) {
 
 export function parsePierCliArgs(
   argv,
-  { clientId = "cli-local", cwd = process.cwd(), requestId = randomUUID() } = {}
+  {
+    clientEnv,
+    clientId = "cli-local",
+    cwd = process.cwd(),
+    requestId = randomUUID(),
+  } = {}
 ) {
   return {
     envelope: {
+      ...(clientEnv && Object.keys(clientEnv).length > 0 ? { clientEnv } : {}),
       clientId,
       command: parseCommand(argv, cwd),
       protocolVersion: 1,

--- a/bin/pier.mjs
+++ b/bin/pier.mjs
@@ -11,6 +11,8 @@ import {
   usage,
 } from "./pier-cli-parser.js";
 
+const ENV_KEY_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
 function shortHash(input) {
   return createHash("sha256").update(input).digest("hex").slice(0, 16);
 }
@@ -105,6 +107,14 @@ function request(socketPath, envelope, timeoutMs = 5000) {
 
 function asObject(value) {
   return value && typeof value === "object" ? value : null;
+}
+
+function safeClientEnv(env) {
+  return Object.fromEntries(
+    Object.entries(env).filter(
+      ([key, value]) => ENV_KEY_PATTERN.test(key) && typeof value === "string"
+    )
+  );
 }
 
 function panelWindowOrdinals(panels) {
@@ -234,16 +244,20 @@ function formatTerminalProfile(profileId, data) {
   return `${profileId}\n${profileDetailLines(data).join("\n")}\n`;
 }
 
-function parseArgs(argv) {
+function parseArgs(argv, { includeClientEnv = true } = {}) {
   return {
-    ...parsePierCliArgs(argv),
+    ...parsePierCliArgs(argv, {
+      ...(includeClientEnv ? { clientEnv: safeClientEnv(process.env) } : {}),
+    }),
     printEnvelope: hasPierCliOption(argv, "--print-envelope"),
   };
 }
 
 try {
   const rawArgv = process.argv.slice(2);
-  const parsed = parseArgs(rawArgv[0] === "--" ? rawArgv.slice(1) : rawArgv);
+  const argv = rawArgv[0] === "--" ? rawArgv.slice(1) : rawArgv;
+  const printEnvelope = hasPierCliOption(argv, "--print-envelope");
+  const parsed = parseArgs(argv, { includeClientEnv: !printEnvelope });
   if (parsed.printEnvelope) {
     console.log(
       JSON.stringify({ envelope: parsed.envelope, json: parsed.json }, null, 2)

--- a/src/main/app-core/app-core.ts
+++ b/src/main/app-core/app-core.ts
@@ -10,6 +10,7 @@ import { createPanelContextService } from "../services/panel-context-service.ts"
 import { createPluginService } from "../services/plugin-service.ts";
 import { createDefaultPluginSources } from "../services/plugin-sources.ts";
 import { createPreferencesService } from "../services/preferences-service.ts";
+import { createProcessEnvironmentService } from "../services/process-environment-service.ts";
 import { createRendererCommandService } from "../services/renderer-command-service.ts";
 import { createTaskService } from "../services/tasks/task-service.ts";
 import { createTerminalProfileService } from "../services/terminal-profile-service.ts";
@@ -101,6 +102,7 @@ function createPierAppCore(): PierAppCore {
       broadcast: broadcastMruState,
     }),
     preferences: createPreferencesService({ eventBus }),
+    processEnvironment: createProcessEnvironmentService(),
     plugins: pluginHost.plugins,
     panelContexts: createPanelContextService(),
     rendererCommand,

--- a/src/main/app-core/command-router.ts
+++ b/src/main/app-core/command-router.ts
@@ -22,6 +22,7 @@ import {
   type PluginService,
   PluginServiceError,
 } from "../services/plugin-service.ts";
+import type { ProcessEnvironmentService } from "../services/process-environment-service.ts";
 import type { RendererCommandService } from "../services/renderer-command-service.ts";
 import {
   type WorktreeService,
@@ -61,6 +62,7 @@ export interface PierCoreServices {
     read(): Promise<ProjectPreferences>;
     update(patch: ProjectPreferencesPatch): Promise<ProjectPreferences>;
   };
+  processEnvironment: ProcessEnvironmentService;
   rendererCommand: RendererCommandService;
   tasks: {
     list(args: { projectRoot: string }): Promise<TaskListResult>;
@@ -142,6 +144,10 @@ export interface CommandRouter {
 export interface CreateCommandRouterArgs {
   clients: PierClientRegistry;
   services: PierCoreServices;
+}
+
+export interface CommandExecutionContext {
+  clientEnv?: Record<string, string> | undefined;
 }
 
 function requestIdOf(rawEnvelope: unknown): string {
@@ -334,13 +340,16 @@ async function executePanelCommand(
 async function executeRunCommand(
   requestId: string,
   command: PierCommand,
-  services: PierCoreServices
+  services: PierCoreServices,
+  context: CommandExecutionContext
 ): Promise<PierCommandResult | null> {
   switch (command.type) {
     case "run.list":
       return await executeRunListCommand(requestId, command, services);
     case "run.spawn":
-      return await executeRunSpawnCommand(requestId, command, services);
+      return await executeRunSpawnCommand(requestId, command, services, {
+        clientEnv: context.clientEnv,
+      });
     default:
       return null;
   }
@@ -349,11 +358,14 @@ async function executeRunCommand(
 async function executeTerminalCommand(
   requestId: string,
   command: PierCommand,
-  services: PierCoreServices
+  services: PierCoreServices,
+  context: CommandExecutionContext
 ): Promise<PierCommandResult | null> {
   switch (command.type) {
     case "terminal.open":
-      return await executeTerminalOpenCommand(requestId, command, services);
+      return await executeTerminalOpenCommand(requestId, command, services, {
+        clientEnv: context.clientEnv,
+      });
     case "terminal.profile.delete":
       return success(
         requestId,
@@ -383,14 +395,17 @@ async function executeKnownCommand(
   requestId: string,
   command: PierCommand,
   clients: PierClientRegistry,
-  services: PierCoreServices
+  services: PierCoreServices,
+  context: CommandExecutionContext = {}
 ): Promise<PierCommandResult> {
   try {
     const executors = [
       (cmd: PierCommand) => executePluginCommand(requestId, cmd, services),
       (cmd: PierCommand) => executeWorktreeCommand(requestId, cmd, services),
-      (cmd: PierCommand) => executeRunCommand(requestId, cmd, services),
-      (cmd: PierCommand) => executeTerminalCommand(requestId, cmd, services),
+      (cmd: PierCommand) =>
+        executeRunCommand(requestId, cmd, services, context),
+      (cmd: PierCommand) =>
+        executeTerminalCommand(requestId, cmd, services, context),
       (cmd: PierCommand) =>
         executeAppStateCommand(requestId, cmd, clients, services),
       (cmd: PierCommand) =>
@@ -437,7 +452,7 @@ export function createCommandRouter({
         return failure(requestId, "invalid_command", "invalid command");
       }
 
-      const { clientId, command } = parsed.data;
+      const { clientEnv, clientId, command } = parsed.data;
       const client = clients.get(clientId);
       if (!client) {
         return failure(requestId, "permission_denied", "unknown client");
@@ -448,7 +463,9 @@ export function createCommandRouter({
         return failure(requestId, "permission_denied", auth.reason);
       }
 
-      return await executeKnownCommand(requestId, command, clients, services);
+      return await executeKnownCommand(requestId, command, clients, services, {
+        clientEnv,
+      });
     },
   };
 }

--- a/src/main/app-core/panel-commands.ts
+++ b/src/main/app-core/panel-commands.ts
@@ -15,6 +15,11 @@ import type {
   ResolvedTerminalLaunchOptions,
   TerminalLaunchOptions,
 } from "@shared/contracts/terminal-launch.ts";
+import type {
+  ProcessEnvironmentResolveRequest,
+  ProcessEnvironmentService,
+  ProcessEnvironmentSource,
+} from "../services/process-environment-service.ts";
 import type { RendererCommandService } from "../services/renderer-command-service.ts";
 import { commandFailure, commandSuccess } from "./command-results.ts";
 import {
@@ -30,6 +35,7 @@ export interface PanelCommandServices {
     recordRecent(context: PanelContext): Promise<void>;
     resolveForPath(path: string): Promise<PanelContext>;
   };
+  processEnvironment: ProcessEnvironmentService;
   rendererCommand: RendererCommandService;
   terminalLaunches: {
     consume(
@@ -112,21 +118,22 @@ function normalizePanelSnapshot(
   };
 }
 
-function mergeTerminalLaunchProfile(
+function mergeTerminalLaunchCommandAndCwd(
   launch: TerminalLaunchOptions,
   profile: ResolvedTerminalLaunchOptions | null
 ): ResolvedTerminalLaunchOptions {
-  const env =
-    profile?.env || launch.env
-      ? { ...(profile?.env ?? {}), ...(launch.env ?? {}) }
-      : undefined;
   return {
     ...(profile?.command && { command: profile.command }),
     ...(profile?.cwd && { cwd: profile.cwd }),
-    ...(env && { env }),
     ...(launch.command && { command: launch.command }),
     ...(launch.cwd && { cwd: launch.cwd }),
   };
+}
+
+function optionalEnv(
+  env: Record<string, string>
+): Pick<ResolvedTerminalLaunchOptions, "env"> | Record<string, never> {
+  return Object.keys(env).length > 0 ? { env } : {};
 }
 
 async function listPanels(
@@ -245,7 +252,11 @@ export async function executeTerminalOpenCommand(
   requestId: string,
   command: Extract<PierCommand, { type: "terminal.open" }>,
   services: PanelCommandServices,
-  options: { tab?: PanelTabChrome } = {}
+  options: {
+    clientEnv?: Record<string, string> | undefined;
+    source?: ProcessEnvironmentSource | undefined;
+    tab?: PanelTabChrome;
+  } = {}
 ): Promise<PierCommandResult> {
   const target = resolveCommandWindow(command.windowId, services, {
     requireStableDefault: !command.windowId,
@@ -269,7 +280,20 @@ export async function executeTerminalOpenCommand(
       `unknown terminal profile: ${rawLaunch.profileId}`
     );
   }
-  const launch = mergeTerminalLaunchProfile(rawLaunch, profile);
+  const launchBase = mergeTerminalLaunchCommandAndCwd(rawLaunch, profile);
+  const environmentRequest: ProcessEnvironmentResolveRequest = {
+    cwd: launchBase.cwd,
+    ...(options.clientEnv ? { clientEnv: options.clientEnv } : {}),
+    ...(rawLaunch.env ? { explicitEnv: rawLaunch.env } : {}),
+    ...(profile?.env ? { profileEnv: profile.env } : {}),
+    source: options.source ?? "terminal",
+  };
+  const resolvedEnvironment =
+    await services.processEnvironment.resolve(environmentRequest);
+  const launch: ResolvedTerminalLaunchOptions = {
+    ...launchBase,
+    ...optionalEnv(resolvedEnvironment.env),
+  };
   const context = launch.cwd
     ? await services.panelContexts.resolveForPath(launch.cwd)
     : undefined;

--- a/src/main/app-core/run-commands.ts
+++ b/src/main/app-core/run-commands.ts
@@ -49,7 +49,8 @@ export async function executeRunListCommand(
 export async function executeRunSpawnCommand(
   requestId: string,
   command: Extract<PierCommand, { type: "run.spawn" }>,
-  services: PierCoreServices
+  services: PierCoreServices,
+  options: { clientEnv?: Record<string, string> | undefined } = {}
 ): Promise<PierCommandResult> {
   const preparation = await services.tasks.prepareSpawn({
     inputs: command.inputs,
@@ -86,7 +87,7 @@ export async function executeRunSpawnCommand(
         type: "terminal.open",
       },
       services,
-      { tab: launch.tab }
+      { clientEnv: options.clientEnv, source: "task", tab: launch.tab }
     );
     if (!result.ok) {
       return result;

--- a/src/main/services/process-environment-service.ts
+++ b/src/main/services/process-environment-service.ts
@@ -1,0 +1,299 @@
+import { spawn } from "node:child_process";
+import { userInfo } from "node:os";
+
+export type ProcessEnvironmentSource = "agent" | "plugin" | "task" | "terminal";
+type Environment = Record<string, string>;
+type RawEnvironment = NodeJS.ProcessEnv | Record<string, string | undefined>;
+
+export interface ProcessEnvironmentResolveRequest {
+  clientEnv?: Record<string, string> | undefined;
+  cwd?: string | undefined;
+  explicitEnv?: Record<string, string> | undefined;
+  profileEnv?: Record<string, string> | undefined;
+  source: ProcessEnvironmentSource;
+}
+
+export interface ProcessEnvironmentDiagnostics {
+  cacheHit: boolean;
+  cwd?: string | undefined;
+  error?: string | undefined;
+  pathChanged: boolean;
+  shell?: string | undefined;
+  shellEnvStatus: "cached" | "failed" | "resolved" | "skipped";
+  source: ProcessEnvironmentSource;
+}
+
+export interface ProcessEnvironmentResolveResult {
+  diagnostics: ProcessEnvironmentDiagnostics;
+  env: Environment;
+}
+
+export interface ShellEnvironmentLoadRequest {
+  cwd?: string | undefined;
+  shell: string;
+  source: ProcessEnvironmentSource;
+}
+
+export interface ShellEnvironmentLoadResult {
+  env: Environment;
+  status: "resolved" | "skipped";
+}
+
+export type ShellEnvironmentLoader = (
+  request: ShellEnvironmentLoadRequest
+) => Promise<ShellEnvironmentLoadResult>;
+
+export interface CreateProcessEnvironmentServiceOptions {
+  baseEnv?: RawEnvironment;
+  loadShellEnv?: ShellEnvironmentLoader;
+  platform?: NodeJS.Platform;
+  shell?: string | undefined;
+  timeoutMs?: number;
+}
+
+export interface ProcessEnvironmentService {
+  resolve(
+    request: ProcessEnvironmentResolveRequest
+  ): Promise<ProcessEnvironmentResolveResult>;
+}
+
+const ENV_KEY_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
+const SHELL_ENV_START = "__PIER_ENV_START__";
+const SHELL_ENV_END = "__PIER_ENV_END__";
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+function cleanEnv(env: RawEnvironment | undefined): Environment {
+  const entries = Object.entries(env ?? {}).filter(
+    (entry): entry is [string, string] =>
+      ENV_KEY_RE.test(entry[0]) && typeof entry[1] === "string"
+  );
+  return Object.fromEntries(entries);
+}
+
+function mergeEnv(...layers: Array<Environment | undefined>): Environment {
+  return Object.assign({}, ...layers.map((layer) => cleanEnv(layer)));
+}
+
+function cacheKey({ cwd, shell, source }: ShellEnvironmentLoadRequest): string {
+  return `${cwd ?? ""}\0${shell}\0${source}`;
+}
+
+function markerIndex(output: Buffer, marker: string, start = 0): number {
+  return output.indexOf(Buffer.from(marker), start);
+}
+
+export function parseShellEnvironmentOutput(output: Buffer): Environment {
+  const startMarkerIndex = markerIndex(output, SHELL_ENV_START);
+  if (startMarkerIndex < 0) {
+    throw new Error("shell environment start marker not found");
+  }
+  const envStart = startMarkerIndex + SHELL_ENV_START.length + 1;
+  const endMarkerIndex = markerIndex(output, `\n${SHELL_ENV_END}`, envStart);
+  if (endMarkerIndex < 0) {
+    throw new Error("shell environment end marker not found");
+  }
+  const envSection = output.subarray(envStart, endMarkerIndex);
+  const entries = envSection
+    .toString("utf8")
+    .split("\0")
+    .flatMap((entry): [string, string][] => {
+      if (entry.length === 0) {
+        return [];
+      }
+      const separator = entry.indexOf("=");
+      const key = separator >= 0 ? entry.slice(0, separator) : entry;
+      if (!(separator > 0 && ENV_KEY_RE.test(key))) {
+        return [];
+      }
+      return [[key, entry.slice(separator + 1)]];
+    });
+  return Object.fromEntries(entries);
+}
+
+function shellEnvCommand(): string {
+  return [
+    `printf '${SHELL_ENV_START}\\n'`,
+    "/usr/bin/env -0",
+    `printf '\\n${SHELL_ENV_END}\\n'`,
+  ].join("; ");
+}
+
+function loadShellEnvironment({
+  baseEnv,
+  timeoutMs,
+}: {
+  baseEnv: Record<string, string>;
+  timeoutMs: number;
+}): ShellEnvironmentLoader {
+  return ({ cwd, shell }) =>
+    new Promise((resolve, reject) => {
+      const child = spawn(shell, ["-lic", shellEnvCommand()], {
+        cwd,
+        env: baseEnv,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      const stdout: Buffer[] = [];
+      const stderr: Buffer[] = [];
+      let settled = false;
+      const finish = (value: ShellEnvironmentLoadResult) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(timer);
+        resolve(value);
+      };
+      const fail = (error: Error) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(timer);
+        reject(error);
+      };
+      const timer = setTimeout(() => {
+        child.kill();
+        fail(new Error(`shell environment timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+      child.stdout.on("data", (chunk: Buffer) => stdout.push(chunk));
+      child.stderr.on("data", (chunk: Buffer) => stderr.push(chunk));
+      child.on("error", fail);
+      child.on("close", (code) => {
+        if (settled) {
+          return;
+        }
+        if (code !== 0) {
+          const message = Buffer.concat(stderr).toString("utf8").trim();
+          fail(
+            new Error(
+              message
+                ? `shell environment exited with ${code}: ${message}`
+                : `shell environment exited with ${code}`
+            )
+          );
+          return;
+        }
+        finish({
+          env: parseShellEnvironmentOutput(Buffer.concat(stdout)),
+          status: "resolved",
+        });
+      });
+    });
+}
+
+function warnDiagnostics(diagnostics: ProcessEnvironmentDiagnostics): void {
+  if (diagnostics.shellEnvStatus !== "failed") {
+    return;
+  }
+  console.warn("[process-env] shell environment failed", {
+    cwd: diagnostics.cwd,
+    error: diagnostics.error,
+    pathChanged: diagnostics.pathChanged,
+    shell: diagnostics.shell,
+    source: diagnostics.source,
+  });
+}
+
+function defaultShell(platform: NodeJS.Platform): string | undefined {
+  if (process.env.SHELL) {
+    return process.env.SHELL;
+  }
+  try {
+    const shell = userInfo().shell;
+    if (shell) {
+      return shell;
+    }
+  } catch {
+    // 受限环境下 userInfo 可能失败，继续走平台兜底。
+  }
+  if (platform === "darwin") {
+    return "/bin/zsh";
+  }
+  if (platform === "linux") {
+    return "/bin/sh";
+  }
+}
+
+export function createProcessEnvironmentService({
+  baseEnv: rawBaseEnv = process.env,
+  loadShellEnv,
+  platform = process.platform,
+  shell = defaultShell(platform),
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+}: CreateProcessEnvironmentServiceOptions = {}): ProcessEnvironmentService {
+  const baseEnv = cleanEnv(rawBaseEnv);
+  const shellLoader =
+    loadShellEnv ?? loadShellEnvironment({ baseEnv, timeoutMs });
+  const cache = new Map<string, Record<string, string>>();
+  const inFlight = new Map<string, Promise<Record<string, string>>>();
+
+  async function resolveShellEnv(
+    request: ProcessEnvironmentResolveRequest
+  ): Promise<{
+    cacheHit: boolean;
+    env: Record<string, string>;
+    error?: string | undefined;
+    shellEnvStatus: ProcessEnvironmentDiagnostics["shellEnvStatus"];
+  }> {
+    if (platform === "win32" || !shell) {
+      return { cacheHit: false, env: {}, shellEnvStatus: "skipped" };
+    }
+    const key = cacheKey({ cwd: request.cwd, shell, source: request.source });
+    const cached = cache.get(key);
+    if (cached) {
+      return { cacheHit: true, env: cached, shellEnvStatus: "cached" };
+    }
+    let pending = inFlight.get(key);
+    if (!pending) {
+      pending = shellLoader({
+        cwd: request.cwd,
+        shell,
+        source: request.source,
+      }).then((result) => {
+        const env = result.status === "resolved" ? cleanEnv(result.env) : {};
+        if (result.status === "resolved") {
+          cache.set(key, env);
+        }
+        return env;
+      });
+      inFlight.set(key, pending);
+    }
+    try {
+      const env = await pending;
+      return { cacheHit: false, env, shellEnvStatus: "resolved" };
+    } catch (error) {
+      return {
+        cacheHit: false,
+        env: {},
+        error: error instanceof Error ? error.message : String(error),
+        shellEnvStatus: "failed",
+      };
+    } finally {
+      inFlight.delete(key);
+    }
+  }
+
+  return {
+    async resolve(request) {
+      const shellEnv = await resolveShellEnv(request);
+      const env = mergeEnv(
+        baseEnv,
+        shellEnv.env,
+        request.clientEnv,
+        request.profileEnv,
+        request.explicitEnv
+      );
+      const diagnostics: ProcessEnvironmentDiagnostics = {
+        cacheHit: shellEnv.cacheHit,
+        ...(request.cwd ? { cwd: request.cwd } : {}),
+        ...(shellEnv.error ? { error: shellEnv.error } : {}),
+        pathChanged: baseEnv.PATH !== env.PATH,
+        ...(shell ? { shell } : {}),
+        shellEnvStatus: shellEnv.shellEnvStatus,
+        source: request.source,
+      };
+      warnDiagnostics(diagnostics);
+      return { diagnostics, env };
+    },
+  };
+}

--- a/src/shared/contracts/commands.ts
+++ b/src/shared/contracts/commands.ts
@@ -3,6 +3,7 @@ import { pluginInspectRequestSchema } from "./plugin.ts";
 import { projectPreferencesSchema } from "./preferences.ts";
 import {
   resolvedTerminalLaunchOptionsSchema,
+  terminalLaunchEnvKeySchema,
   terminalLaunchOptionsSchema,
 } from "./terminal-launch.ts";
 import {
@@ -149,10 +150,16 @@ export const pierCommandSchema = z.discriminatedUnion("type", [
 
 export type PierCommand = z.infer<typeof pierCommandSchema>;
 
+export const pierCommandClientEnvSchema = z.record(
+  terminalLaunchEnvKeySchema,
+  z.string()
+);
+
 export const pierCommandEnvelopeSchema = z.object({
   protocolVersion: pierProtocolVersionSchema,
   requestId: z.string().min(1),
   clientId: z.string().min(1),
+  clientEnv: pierCommandClientEnvSchema.optional(),
   command: pierCommandSchema,
 });
 

--- a/tests/unit/app-core/cli-adapter.test.ts
+++ b/tests/unit/app-core/cli-adapter.test.ts
@@ -82,6 +82,39 @@ describe("createPierCliCommandClient", () => {
       },
     ]);
   });
+
+  it("把解析选项中的 clientEnv 放入命令信封", async () => {
+    const seen: unknown[] = [];
+    const client = createPierCliCommandClient({
+      parseOptions: {
+        clientEnv: { PATH: "/cli/bin", PIER_MODE: "dev" },
+        clientId: "cli-1",
+        requestId: "req-env",
+      },
+      transport: {
+        request(envelope) {
+          seen.push(envelope);
+          return Promise.resolve({
+            data: null,
+            ok: true,
+            requestId: "req-env",
+          });
+        },
+      },
+    });
+
+    await client.run(["status", "--json"]);
+
+    expect(seen).toEqual([
+      {
+        clientEnv: { PATH: "/cli/bin", PIER_MODE: "dev" },
+        clientId: "cli-1",
+        command: { type: "app.status" },
+        protocolVersion: 1,
+        requestId: "req-env",
+      },
+    ]);
+  });
 });
 
 describe("parsePierCliArgs", () => {
@@ -100,6 +133,22 @@ describe("parsePierCliArgs", () => {
       placement: "split-right",
       type: "panel.open",
       windowId: "main",
+    });
+  });
+
+  it("解析时保留 CLI 进程环境作为信封元数据", () => {
+    expect(
+      parsePierCliArgs(["status"], {
+        clientEnv: { PATH: "/cli/bin", PIER_MODE: "dev" },
+        clientId: "cli-1",
+        requestId: "req-client-env",
+      }).envelope
+    ).toEqual({
+      clientEnv: { PATH: "/cli/bin", PIER_MODE: "dev" },
+      clientId: "cli-1",
+      command: { type: "app.status" },
+      protocolVersion: 1,
+      requestId: "req-client-env",
     });
   });
 

--- a/tests/unit/app-core/cli-bin.test.ts
+++ b/tests/unit/app-core/cli-bin.test.ts
@@ -52,6 +52,7 @@ describe("bin/pier.mjs", () => {
       json: true,
     });
     expect(parsed.envelope.requestId).toEqual(expect.any(String));
+    expect(parsed.envelope).not.toHaveProperty("clientEnv");
   });
 
   it("忽略 pnpm 传入的前导 -- 分隔符", async () => {
@@ -378,6 +379,54 @@ describe("bin/pier.mjs", () => {
     });
 
     expect(stdout).toBe("");
+    await server.close();
+  });
+
+  it("真实 socket 请求携带 CLI 环境但 print-envelope 不输出", async () => {
+    const userDataDir = await makeTempDir();
+    const socketPath = resolveLocalControlSocketPath(userDataDir, "darwin");
+    let seenClientEnv: Record<string, string> | undefined;
+    const server = createPierLocalControlServer({
+      handleRequest: (envelope) => {
+        const parsed = pierCommandEnvelopeSchema.parse(envelope);
+        seenClientEnv = parsed.clientEnv;
+        return Promise.resolve({
+          data: null,
+          ok: true,
+          requestId: parsed.requestId,
+        });
+      },
+      socketPath,
+    });
+    await server.start();
+
+    await execFileAsync("node", ["bin/pier.mjs", "status", "--json"], {
+      env: {
+        ...process.env,
+        PATH: `/cli/bin:${process.env.PATH ?? ""}`,
+        PIER_CONTROL_SOCKET_PATH: socketPath,
+        PIER_TEST_CLIENT_ENV: "from-cli",
+      },
+    });
+
+    expect(seenClientEnv).toMatchObject({
+      PIER_TEST_CLIENT_ENV: "from-cli",
+    });
+    expect(seenClientEnv?.PATH).toContain("/cli/bin");
+
+    const { stdout } = await execFileAsync(
+      "node",
+      ["bin/pier.mjs", "status", "--json", "--print-envelope"],
+      {
+        env: {
+          ...process.env,
+          PATH: `/cli/bin:${process.env.PATH ?? ""}`,
+          PIER_TEST_CLIENT_ENV: "from-cli",
+        },
+      }
+    );
+    expect(JSON.parse(stdout).envelope).not.toHaveProperty("clientEnv");
+
     await server.close();
   });
 

--- a/tests/unit/app-core/command-router.test.ts
+++ b/tests/unit/app-core/command-router.test.ts
@@ -2,6 +2,10 @@ import { createClientRegistry } from "@main/app-core/client-registry.ts";
 import type { PierCoreServices } from "@main/app-core/command-router.ts";
 import { createCommandRouter } from "@main/app-core/command-router.ts";
 import { PluginServiceError } from "@main/services/plugin-service.ts";
+import type {
+  ProcessEnvironmentResolveRequest,
+  ProcessEnvironmentResolveResult,
+} from "@main/services/process-environment-service.ts";
 import { createTaskService } from "@main/services/tasks/task-service.ts";
 import { WorktreeServiceError } from "@main/services/worktree-service.ts";
 import type { PanelContext, PanelSnapshot } from "@shared/contracts/panel.ts";
@@ -107,7 +111,26 @@ function services(
       panelSnapshot("terminal-1", panelContext("/Users/xyz/ABC/pier"), true),
     ],
   },
-  terminalLaunches: unknown[] = []
+  terminalLaunches: unknown[] = [],
+  resolveEnvironment: (
+    request: ProcessEnvironmentResolveRequest
+  ) => Promise<ProcessEnvironmentResolveResult> = async (request) => ({
+    diagnostics: {
+      cacheHit: false,
+      pathChanged: Boolean(
+        request.clientEnv?.PATH ||
+          request.profileEnv?.PATH ||
+          request.explicitEnv?.PATH
+      ),
+      shellEnvStatus: "skipped",
+      source: request.source,
+    },
+    env: {
+      ...(request.clientEnv ?? {}),
+      ...(request.profileEnv ?? {}),
+      ...(request.explicitEnv ?? {}),
+    },
+  })
 ): PierCoreServices {
   let recentContexts: PanelContext[] = [];
 
@@ -148,6 +171,9 @@ function services(
         userKeymap: patch.userKeymap ?? [],
         windowZoomLevel: patch.windowZoomLevel ?? 0,
       }),
+    },
+    processEnvironment: {
+      resolve: resolveEnvironment,
     },
     plugins: {
       inspect: async (id) =>
@@ -489,6 +515,94 @@ describe("createCommandRouter", () => {
     ]);
   });
 
+  it("terminal.open 在注册 launch 前合并 shell、CLI、profile 和显式环境", async () => {
+    const rendererCommands: unknown[] = [];
+    const terminalLaunches: unknown[] = [];
+    const resolveEnvironment = vi.fn(
+      async (
+        request: ProcessEnvironmentResolveRequest
+      ): Promise<ProcessEnvironmentResolveResult> => ({
+        diagnostics: {
+          cacheHit: false,
+          pathChanged: true,
+          shellEnvStatus: "resolved",
+          source: request.source,
+        },
+        env: {
+          FROM_CLI: request.clientEnv?.FROM_CLI ?? "",
+          FROM_EXPLICIT: request.explicitEnv?.FROM_EXPLICIT ?? "",
+          FROM_PROFILE: request.profileEnv?.FROM_PROFILE ?? "",
+          FROM_SHELL: "shell",
+          PATH: request.explicitEnv?.PATH ?? "",
+        },
+      })
+    );
+    const fakeServices = services(
+      rendererCommands,
+      undefined,
+      terminalLaunches,
+      resolveEnvironment
+    );
+    Object.assign(fakeServices, {
+      terminalProfiles: {
+        resolve: vi.fn(async (profileId: string) =>
+          profileId === "codex"
+            ? {
+                command: "codex",
+                cwd: "/Users/xyz/ABC/profile-cwd",
+                env: { FROM_PROFILE: "profile", PATH: "/profile/bin" },
+              }
+            : null
+        ),
+      },
+    });
+    const router = createCommandRouter({
+      clients: registryWith(desktopClient),
+      services: fakeServices,
+    });
+
+    await expect(
+      router.execute({
+        clientEnv: { FROM_CLI: "cli", PATH: "/cli/bin" },
+        clientId: "desktop-1",
+        command: {
+          launch: {
+            cwd: "/tmp/pier",
+            env: { FROM_EXPLICIT: "explicit", PATH: "/explicit/bin" },
+            profileId: "codex",
+          },
+          type: "terminal.open",
+        },
+        protocolVersion: 1,
+        requestId: "req-terminal-open-env",
+      })
+    ).resolves.toMatchObject({
+      ok: true,
+      requestId: "req-terminal-open-env",
+    });
+
+    expect(resolveEnvironment).toHaveBeenCalledWith({
+      clientEnv: { FROM_CLI: "cli", PATH: "/cli/bin" },
+      cwd: "/tmp/pier",
+      explicitEnv: { FROM_EXPLICIT: "explicit", PATH: "/explicit/bin" },
+      profileEnv: { FROM_PROFILE: "profile", PATH: "/profile/bin" },
+      source: "terminal",
+    });
+    expect(terminalLaunches).toEqual([
+      {
+        command: "codex",
+        cwd: "/tmp/pier",
+        env: {
+          FROM_CLI: "cli",
+          FROM_EXPLICIT: "explicit",
+          FROM_PROFILE: "profile",
+          FROM_SHELL: "shell",
+          PATH: "/explicit/bin",
+        },
+      },
+    ]);
+  });
+
   it("terminal.open 在 renderer command 失败时清理已注册 launch", async () => {
     const rendererCommands: unknown[] = [];
     const terminalLaunches: unknown[] = [];
@@ -605,10 +719,28 @@ describe("createCommandRouter", () => {
   it("run.spawn 重新解析任务并复用 terminal.open", async () => {
     const rendererCommands: unknown[] = [];
     const terminalLaunches: unknown[] = [];
+    const resolveEnvironment = vi.fn(
+      async (
+        request: ProcessEnvironmentResolveRequest
+      ): Promise<ProcessEnvironmentResolveResult> => ({
+        diagnostics: {
+          cacheHit: false,
+          pathChanged: true,
+          shellEnvStatus: "resolved",
+          source: request.source,
+        },
+        env: {
+          FROM_CLI: request.clientEnv?.FROM_CLI ?? "",
+          FROM_SHELL: "shell",
+          ...(request.explicitEnv ?? {}),
+        },
+      })
+    );
     const fakeServices = services(
       rendererCommands,
       undefined,
-      terminalLaunches
+      terminalLaunches,
+      resolveEnvironment
     );
     const router = createCommandRouter({
       clients: registryWith(desktopClient),
@@ -628,6 +760,7 @@ describe("createCommandRouter", () => {
     expect(listResult).toMatchObject({ ok: true });
     await expect(
       router.execute({
+        clientEnv: { FROM_CLI: "cli" },
         clientId: "desktop-1",
         command: {
           focus: true,
@@ -652,8 +785,19 @@ describe("createCommandRouter", () => {
       expect.objectContaining({
         command: expect.stringContaining("pnpm run test"),
         cwd: process.cwd(),
+        env: expect.objectContaining({
+          FROM_CLI: "cli",
+          FROM_SHELL: "shell",
+        }),
       }),
     ]);
+    expect(resolveEnvironment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        clientEnv: { FROM_CLI: "cli" },
+        cwd: process.cwd(),
+        source: "task",
+      })
+    );
     expect(rendererCommands.at(-1)).toMatchObject({
       launchId: "launch-1",
       placement: "active-tab",

--- a/tests/unit/app-core/local-control.test.ts
+++ b/tests/unit/app-core/local-control.test.ts
@@ -148,6 +148,21 @@ function cliClientServices(): PierCoreServices {
         windowZoomLevel: patch.windowZoomLevel ?? 0,
       }),
     },
+    processEnvironment: {
+      resolve: async (request) => ({
+        diagnostics: {
+          cacheHit: false,
+          pathChanged: false,
+          shellEnvStatus: "skipped",
+          source: request.source,
+        },
+        env: {
+          ...(request.clientEnv ?? {}),
+          ...(request.profileEnv ?? {}),
+          ...(request.explicitEnv ?? {}),
+        },
+      }),
+    },
     rendererCommand: {
       execute: async () => ({
         error: {

--- a/tests/unit/main/process-environment-service.test.ts
+++ b/tests/unit/main/process-environment-service.test.ts
@@ -1,0 +1,145 @@
+import {
+  createProcessEnvironmentService,
+  parseShellEnvironmentOutput,
+} from "@main/services/process-environment-service.ts";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const ABSOLUTE_SHELL_RE = /^\//;
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("process environment service", () => {
+  it("merges process, shell, CLI, profile and explicit env by precedence", async () => {
+    const service = createProcessEnvironmentService({
+      baseEnv: {
+        BASE_ONLY: "base",
+        FROM_SHELL: "base",
+        PATH: "/app/bin",
+      },
+      loadShellEnv: async () => ({
+        env: {
+          FROM_CLI: "shell",
+          FROM_SHELL: "shell",
+          PATH: "/shell/bin",
+        },
+        status: "resolved",
+      }),
+      platform: "darwin",
+      shell: "/bin/zsh",
+    });
+
+    await expect(
+      service.resolve({
+        clientEnv: { FROM_CLI: "cli", PATH: "/cli/bin" },
+        cwd: "/Users/xyz/ABC/pier",
+        explicitEnv: { FROM_EXPLICIT: "explicit", PATH: "/explicit/bin" },
+        profileEnv: { FROM_PROFILE: "profile", PATH: "/profile/bin" },
+        source: "terminal",
+      })
+    ).resolves.toMatchObject({
+      diagnostics: {
+        cacheHit: false,
+        pathChanged: true,
+        shellEnvStatus: "resolved",
+        source: "terminal",
+      },
+      env: {
+        BASE_ONLY: "base",
+        FROM_CLI: "cli",
+        FROM_EXPLICIT: "explicit",
+        FROM_PROFILE: "profile",
+        FROM_SHELL: "shell",
+        PATH: "/explicit/bin",
+      },
+    });
+  });
+
+  it("caches shell env by cwd, shell and source", async () => {
+    const loadShellEnv = vi.fn(async () => ({
+      env: { PATH: "/shell/bin" },
+      status: "resolved" as const,
+    }));
+    const service = createProcessEnvironmentService({
+      baseEnv: { PATH: "/app/bin" },
+      loadShellEnv,
+      platform: "darwin",
+      shell: "/bin/zsh",
+    });
+
+    await service.resolve({ cwd: "/repo", source: "terminal" });
+    const second = await service.resolve({ cwd: "/repo", source: "terminal" });
+    await service.resolve({ cwd: "/repo", source: "task" });
+
+    expect(loadShellEnv).toHaveBeenCalledTimes(2);
+    expect(second.diagnostics).toMatchObject({
+      cacheHit: true,
+      shellEnvStatus: "cached",
+    });
+  });
+
+  it("uses an OS default shell when SHELL is missing", async () => {
+    vi.stubEnv("SHELL", "");
+    const loadShellEnv = vi.fn(async () => ({
+      env: { PATH: "/shell/bin" },
+      status: "resolved" as const,
+    }));
+    const service = createProcessEnvironmentService({
+      baseEnv: { PATH: "/app/bin" },
+      loadShellEnv,
+      platform: "darwin",
+    });
+
+    await service.resolve({ cwd: "/repo", source: "terminal" });
+
+    expect(loadShellEnv).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cwd: "/repo",
+        shell: expect.stringMatching(ABSOLUTE_SHELL_RE),
+        source: "terminal",
+      })
+    );
+  });
+
+  it("falls back to non-shell env when shell loading fails", async () => {
+    const service = createProcessEnvironmentService({
+      baseEnv: { BASE_ONLY: "base", PATH: "/app/bin" },
+      loadShellEnv: () => Promise.reject(new Error("shell failed")),
+      platform: "darwin",
+      shell: "/bin/zsh",
+    });
+
+    await expect(
+      service.resolve({
+        clientEnv: { FROM_CLI: "cli" },
+        explicitEnv: { FROM_EXPLICIT: "explicit" },
+        source: "task",
+      })
+    ).resolves.toMatchObject({
+      diagnostics: {
+        error: "shell failed",
+        shellEnvStatus: "failed",
+      },
+      env: {
+        BASE_ONLY: "base",
+        FROM_CLI: "cli",
+        FROM_EXPLICIT: "explicit",
+        PATH: "/app/bin",
+      },
+    });
+  });
+
+  it("parses null-separated env surrounded by shell startup noise", () => {
+    const output = Buffer.concat([
+      Buffer.from("startup noise\n__PIER_ENV_START__\n"),
+      Buffer.from("PATH=/shell/bin\0BUN_INSTALL=/Users/xyz/.bun\0"),
+      Buffer.from("\n__PIER_ENV_END__\nmore noise"),
+    ]);
+
+    expect(parseShellEnvironmentOutput(output)).toEqual({
+      BUN_INSTALL: "/Users/xyz/.bun",
+      PATH: "/shell/bin",
+    });
+  });
+});

--- a/tests/unit/shared/panel-contract.test.ts
+++ b/tests/unit/shared/panel-contract.test.ts
@@ -1,4 +1,7 @@
-import { pierCommandSchema } from "@shared/contracts/commands.ts";
+import {
+  pierCommandEnvelopeSchema,
+  pierCommandSchema,
+} from "@shared/contracts/commands.ts";
 import {
   panelContextSchema,
   panelDescriptorSchema,
@@ -169,6 +172,38 @@ describe("shared panel contract", () => {
       type: "terminal.open",
       windowId: "main",
     });
+  });
+
+  it("allows local command envelopes to carry CLI environment", () => {
+    expect(
+      pierCommandEnvelopeSchema.parse({
+        clientEnv: {
+          PATH: "/opt/homebrew/bin:/usr/bin",
+          PIER_MODE: "dev",
+        },
+        clientId: "cli-local",
+        command: { type: "app.status" },
+        protocolVersion: 1,
+        requestId: "req-client-env",
+      })
+    ).toMatchObject({
+      clientEnv: {
+        PATH: "/opt/homebrew/bin:/usr/bin",
+        PIER_MODE: "dev",
+      },
+      clientId: "cli-local",
+      command: { type: "app.status" },
+    });
+
+    expect(() =>
+      pierCommandEnvelopeSchema.parse({
+        clientEnv: { "1BAD": "value" },
+        clientId: "cli-local",
+        command: { type: "app.status" },
+        protocolVersion: 1,
+        requestId: "req-invalid-client-env",
+      })
+    ).toThrow();
   });
 
   it("allows renderer terminal.open commands to carry launchId without raw env", () => {


### PR DESCRIPTION
## Summary
- Add a main-layer ProcessEnvironmentService for child process env resolution, shell probing, caching, fallback, and diagnostics.
- Carry safe CLI clientEnv through command envelopes while hiding it from --print-envelope output.
- Route terminal.open and run.spawn through the same environment merge path with focused contract and command-router coverage.

## Why
GUI-launched Pier can receive a different PATH from the user's interactive shell, so task terminals could fail to find tools such as Bun even when normal terminals can.

## Impact
Terminal launches, run tasks, and future direct agent/plugin process launches now have a single main-owned environment policy entry point. Renderer and native terminal code consume the final env only.

## Validation
- CI=true pnpm check
- CI=true pnpm test:unit
- push hook: typecheck, ultracite check, file-size check