### PR TITLE
[codex] Support clipboard image paste in terminal

### DIFF
--- a/native/Vendor/libghostty-spm/Sources/GhosttyTerminal/Controller/TerminalController+Callbacks.swift
+++ b/native/Vendor/libghostty-spm/Sources/GhosttyTerminal/Controller/TerminalController+Callbacks.swift
@@ -14,6 +14,9 @@ import GhosttyKit
 
 private enum TerminalCallbacks {
     #if canImport(AppKit)
+        private static let terminalPasteImageDirectoryName = "pier-terminal-pastes"
+        private static let terminalPasteImageRetentionInterval: TimeInterval = 24 * 60 * 60
+
         static func confirmUnsafePaste(text: String) -> Bool {
             if Thread.isMainThread {
                 return MainActor.assumeIsolated {
@@ -38,6 +41,100 @@ private enum TerminalCallbacks {
             alert.addButton(withTitle: "粘贴")
             alert.addButton(withTitle: "取消")
             return alert.runModal() == .alertFirstButtonReturn
+        }
+
+        private static func terminalPasteImagePathFromPasteboard(
+            _ pasteboard: NSPasteboard
+        ) -> String? {
+            guard let pngData = terminalPastePngData(from: pasteboard) else {
+                return nil
+            }
+
+            let fileManager = FileManager.default
+            let directory = fileManager.temporaryDirectory.appendingPathComponent(
+                terminalPasteImageDirectoryName,
+                isDirectory: true
+            )
+
+            do {
+                try fileManager.createDirectory(
+                    at: directory,
+                    withIntermediateDirectories: true
+                )
+                cleanupTerminalPasteImages(in: directory)
+
+                let url = directory.appendingPathComponent(
+                    "clipboard-\(UUID().uuidString).png"
+                )
+                try pngData.write(to: url, options: [.atomic])
+                TerminalDebugLog.log(
+                    .input,
+                    "clipboard image paste materialized path=\(url.path) bytes=\(pngData.count)"
+                )
+                return url.path
+            } catch {
+                TerminalDebugLog.log(
+                    .input,
+                    "clipboard image paste write failed: \(error.localizedDescription)"
+                )
+                return nil
+            }
+        }
+
+        private static func terminalPastePngData(from pasteboard: NSPasteboard) -> Data? {
+            if let data = pasteboard.data(forType: .png), !data.isEmpty {
+                return data
+            }
+
+            if let data = pasteboard.data(forType: .tiff),
+               let pngData = terminalPastePngData(fromTiffData: data)
+            {
+                return pngData
+            }
+
+            guard let images = pasteboard.readObjects(
+                forClasses: [NSImage.self],
+                options: nil
+            ) as? [NSImage] else {
+                return nil
+            }
+            return images.compactMap(terminalPastePngData(from:)).first
+        }
+
+        private static func terminalPastePngData(from image: NSImage) -> Data? {
+            guard let tiffData = image.tiffRepresentation else {
+                return nil
+            }
+            return terminalPastePngData(fromTiffData: tiffData)
+        }
+
+        private static func terminalPastePngData(fromTiffData data: Data) -> Data? {
+            guard let bitmap = NSBitmapImageRep(data: data) else {
+                return nil
+            }
+            return bitmap.representation(using: .png, properties: [:])
+        }
+
+        private static func cleanupTerminalPasteImages(in directory: URL) {
+            let fileManager = FileManager.default
+            guard let urls = try? fileManager.contentsOfDirectory(
+                at: directory,
+                includingPropertiesForKeys: [.contentModificationDateKey],
+                options: [.skipsHiddenFiles]
+            ) else {
+                return
+            }
+
+            let cutoff = Date().addingTimeInterval(-terminalPasteImageRetentionInterval)
+            for url in urls
+                where url.lastPathComponent.hasPrefix("clipboard-")
+                    && url.pathExtension.lowercased() == "png"
+            {
+                let values = try? url.resourceValues(forKeys: [.contentModificationDateKey])
+                if (values?.contentModificationDate ?? .distantPast) < cutoff {
+                    try? fileManager.removeItem(at: url)
+                }
+            }
         }
     #else
         static func confirmUnsafePaste(text _: String) -> Bool {
@@ -124,7 +221,10 @@ private enum TerminalCallbacks {
         #if canImport(UIKit)
             let string = UIPasteboard.general.string
         #elseif canImport(AppKit)
-            let string = NSPasteboard.general.string(forType: .string)
+            let pasteboard = NSPasteboard.general
+            let string =
+                pasteboard.string(forType: .string).flatMap { $0.isEmpty ? nil : $0 }
+                ?? terminalPasteImagePathFromPasteboard(pasteboard)
         #endif
 
         guard let string else {

--- a/tests/unit/native-terminal-clipboard-image-paste.test.ts
+++ b/tests/unit/native-terminal-clipboard-image-paste.test.ts
@@ -1,0 +1,63 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const CALLBACKS_PATH = join(
+  process.cwd(),
+  "native/Vendor/libghostty-spm/Sources/GhosttyTerminal/Controller/TerminalController+Callbacks.swift"
+);
+const APP_TERMINAL_INPUT_PATH = join(
+  process.cwd(),
+  "native/Vendor/libghostty-spm/Sources/GhosttyTerminal/Platform/AppKit/AppTerminalView+Input.swift"
+);
+
+function readCallbacksSource(): string {
+  return readFileSync(CALLBACKS_PATH, "utf8");
+}
+
+function readTerminalInputSource(): string {
+  return readFileSync(APP_TERMINAL_INPUT_PATH, "utf8");
+}
+
+describe("native terminal clipboard image paste", () => {
+  it("keeps text clipboard data as the first-class paste source", () => {
+    const source = readCallbacksSource();
+    const textReadIndex = source.indexOf("pasteboard.string(forType: .string)");
+    const imageFallbackIndex = source.indexOf(
+      "terminalPasteImagePathFromPasteboard(pasteboard)"
+    );
+
+    expect(textReadIndex).toBeGreaterThan(-1);
+    expect(imageFallbackIndex).toBeGreaterThan(textReadIndex);
+  });
+
+  it("materializes image-only clipboard data as a temporary PNG path", () => {
+    const source = readCallbacksSource();
+
+    expect(source).toContain("terminalPasteImagePathFromPasteboard");
+    expect(source).toContain("terminalPastePngData");
+    expect(source).toContain("pasteboard.data(forType: .png)");
+    expect(source).toContain("NSBitmapImageRep");
+    expect(source).toContain("representation(using: .png");
+    expect(source).toContain('"pier-terminal-pastes"');
+    expect(source).toContain("clipboard-\\(UUID().uuidString).png");
+  });
+
+  it("returns the materialized image path through Ghostty's normal clipboard request", () => {
+    const source = readCallbacksSource();
+
+    expect(source).toContain(
+      "ghostty_surface_complete_clipboard_request(surface, cString, opaquePtr, false)"
+    );
+    expect(source).toContain("clipboard image paste materialized path=");
+  });
+
+  it("continues to route Cmd+V and menu Paste through Ghostty paste binding", () => {
+    const source = readTerminalInputSource();
+
+    expect(source).toContain(
+      'surface?.performBindingAction("paste_from_clipboard")'
+    );
+    expect(source).not.toContain("terminalPasteImagePathFromPasteboard");
+  });
+});

--- a/tests/unit/native-terminal-key-routing.test.ts
+++ b/tests/unit/native-terminal-key-routing.test.ts
@@ -58,6 +58,7 @@ describe("native terminal key routing", () => {
     expect(shortcuts).not.toContain("Mod+Backspace");
     expect(shortcuts).not.toContain("Mod+Delete");
     expect(shortcuts).not.toContain("Mod+KeyK");
+    expect(shortcuts).not.toContain("Mod+KeyV");
     expect(shortcuts).not.toContain("Mod+ArrowLeft");
     expect(shortcuts).not.toContain("Mod+ArrowRight");
   });


### PR DESCRIPTION
## Summary
- add an AppKit clipboard image fallback to the native terminal paste callback
- materialize image-only clipboard data as temporary PNG files and paste the file path through Ghostty
- keep Cmd+V out of Pier app shortcut routing so terminal paste stays native

## Why
Terminal paste already used Ghostty `paste_from_clipboard`, but the clipboard callback only read plain text. When the clipboard contained only an image, paste completed as empty input.

## Impact
Text paste is unchanged and remains the first-class source. Image-only paste now gives terminal workflows a usable temporary image path without adding renderer UI, preload attachment APIs, or new panel behavior.

## Validation
- `pnpm build:native`
- `pnpm check`
- `pnpm test:unit`
- `pnpm test:component`