### PR TITLE
feat(git): 主体 Git 能力底座 + IPC + worktree 插件集成

### DIFF
--- a/dependency-cruiser.config.cjs
+++ b/dependency-cruiser.config.cjs
@@ -19,10 +19,15 @@ module.exports = {
     {
       name: "preload-narrow-imports",
       severity: "error",
-      comment: "preload 只能 import shared + electron",
+      comment: "preload 只能 import shared + electron + preload 内部",
       from: { path: "^src/preload" },
       to: {
-        pathNot: ["^src/shared", "node_modules/.*electron(/|$)", "^node:"],
+        pathNot: [
+          "^src/shared",
+          "^src/preload",
+          "node_modules/.*electron(/|$)",
+          "^node:",
+        ],
       },
     },
     {

--- a/src/main/app-core/app-core.ts
+++ b/src/main/app-core/app-core.ts
@@ -6,6 +6,8 @@ import {
   type MainPluginHostApi,
 } from "../plugins/host-api.ts";
 import { createCommandPaletteMruService } from "../services/command-palette-service.ts";
+import { createGitService } from "../services/git-service.ts";
+import { createGitWatchService } from "../services/git-watch-service.ts";
 import { createPanelContextService } from "../services/panel-context-service.ts";
 import { createPluginService } from "../services/plugin-service.ts";
 import { createDefaultPluginSources } from "../services/plugin-sources.ts";
@@ -122,6 +124,8 @@ function createPierAppCore(): PierAppCore {
     }),
     workspace: createWorkspaceService(),
     worktrees: createWorktreeService(),
+    git: createGitService(),
+    gitWatch: createGitWatchService(),
   };
   return {
     clients,

--- a/src/main/app-core/command-router.ts
+++ b/src/main/app-core/command-router.ts
@@ -18,6 +18,9 @@ import type {
 } from "@shared/contracts/tasks.ts";
 import type { ResolvedTerminalLaunchOptions } from "@shared/contracts/terminal-launch.ts";
 import type { WindowCreateOptions } from "@shared/contracts/window.ts";
+import { GitExecError } from "../services/git-exec.ts";
+import type { GitService } from "../services/git-service.ts";
+import type { GitWatchService } from "../services/git-watch-service.ts";
 import {
   type PluginService,
   PluginServiceError,
@@ -33,6 +36,7 @@ import {
   commandFailure as failure,
   commandSuccess as success,
 } from "./command-results.ts";
+import { executeGitCommand } from "./git-commands.ts";
 import {
   executePanelFocusCommand,
   executePanelListCommand,
@@ -52,6 +56,8 @@ export interface PierCoreServices {
     read(): Promise<MruState>;
     recordUse(actionId: string): Promise<void>;
   };
+  git: GitService;
+  gitWatch: GitWatchService;
   panelContexts: {
     listRecent(): Promise<PanelContext[]>;
     recordRecent(context: PanelContext): Promise<void>;
@@ -402,6 +408,7 @@ async function executeKnownCommand(
     const executors = [
       (cmd: PierCommand) => executePluginCommand(requestId, cmd, services),
       (cmd: PierCommand) => executeWorktreeCommand(requestId, cmd, services),
+      (cmd: PierCommand) => executeGitCommand(requestId, cmd, services),
       (cmd: PierCommand) =>
         executeRunCommand(requestId, cmd, services, context),
       (cmd: PierCommand) =>
@@ -431,6 +438,15 @@ async function executeKnownCommand(
       const code =
         err.code === "invalid_manifest" ? "invalid_command" : err.code;
       return failure(requestId, code, err.message);
+    }
+    if (err instanceof GitExecError) {
+      // 取 stderr 优先,空则 fallback stdout(git 把 "nothing to commit" 之类放 stdout)
+      // 前 3 行作摘要,让插件能按内容分类("already exists"/"not fully merged"/
+      // "dirty worktree"/"nothing to commit" 等)
+      const rawSummary = err.stderr.trim() || err.stdout.trim();
+      const summary = rawSummary.split("\n").slice(0, 3).join(" | ");
+      const detail = summary.length > 0 ? ` -- ${summary}` : "";
+      return failure(requestId, "git_error", `${err.message}${detail}`);
     }
     return failure(
       requestId,

--- a/src/main/app-core/git-commands.ts
+++ b/src/main/app-core/git-commands.ts
@@ -1,0 +1,119 @@
+import type {
+  PierCommand,
+  PierCommandResult,
+} from "@shared/contracts/commands.ts";
+import { commandSuccess as success } from "./command-results.ts";
+import type { PierCoreServices } from "./command-router.ts";
+
+/**
+ * 分发 git.* 命令到 main 进程的 GitService。
+ * 所有 git.* 命令均为只读,绑 git:read capability(权限校验在 permissions.ts)。
+ */
+export async function executeGitCommand(
+  requestId: string,
+  command: PierCommand,
+  services: PierCoreServices
+): Promise<PierCommandResult | null> {
+  switch (command.type) {
+    case "git.getStatus":
+      return success(requestId, await services.git.getStatus(command.cwd));
+    case "git.getRepoInfo":
+      return success(requestId, await services.git.getRepoInfo(command.cwd));
+    case "git.isWorkingTreeClean":
+      return success(
+        requestId,
+        await services.git.isWorkingTreeClean(command.cwd)
+      );
+    case "git.getDiffText":
+      return success(
+        requestId,
+        await services.git.getDiffText(command.cwd, command.options)
+      );
+    case "git.getDiffSummary":
+      return success(
+        requestId,
+        await services.git.getDiffSummary(command.cwd, command.options)
+      );
+    case "git.getDiffPatch":
+      return success(
+        requestId,
+        await services.git.getDiffPatch(command.cwd, command.options)
+      );
+    case "git.getLog":
+      return success(
+        requestId,
+        await services.git.getLog(command.cwd, command.options)
+      );
+    case "git.getCommit":
+      return success(
+        requestId,
+        await services.git.getCommit(command.cwd, command.oid)
+      );
+    case "git.getCommitPatch":
+      return success(
+        requestId,
+        await services.git.getCommitPatch(command.cwd, command.oid)
+      );
+    case "git.getFileContent":
+      return success(
+        requestId,
+        await services.git.getFileContent(command.cwd, command.options)
+      );
+    case "git.listBranches":
+      return success(
+        requestId,
+        await services.git.listBranches(command.cwd, command.options)
+      );
+    case "git.listTags":
+      return success(requestId, await services.git.listTags(command.cwd));
+    case "git.resolveRef":
+      return success(
+        requestId,
+        await services.git.resolveRef(command.cwd, command.ref)
+      );
+    case "git.validateBranchName":
+      return success(
+        requestId,
+        await services.git.validateBranchName(command.cwd, command.name)
+      );
+    case "git.stage":
+      await services.git.stage(command.cwd, { paths: command.paths });
+      return success(requestId, true);
+    case "git.unstage":
+      await services.git.unstage(command.cwd, { paths: command.paths });
+      return success(requestId, true);
+    case "git.discardChanges":
+      await services.git.discardChanges(command.cwd, {
+        paths: command.paths,
+      });
+      return success(requestId, true);
+    case "git.commit":
+      await services.git.commit(command.cwd, {
+        ...(command.allowEmpty !== undefined && {
+          allowEmpty: command.allowEmpty,
+        }),
+        message: command.message,
+        ...(command.signoff !== undefined && { signoff: command.signoff }),
+      });
+      return success(requestId, true);
+    case "git.createBranch":
+      await services.git.createBranch(command.cwd, {
+        name: command.name,
+        ...(command.startPoint !== undefined && {
+          startPoint: command.startPoint,
+        }),
+      });
+      return success(requestId, true);
+    case "git.deleteBranch":
+      await services.git.deleteBranch(command.cwd, {
+        ...(command.force !== undefined && { force: command.force }),
+        name: command.name,
+      });
+      return success(requestId, true);
+    case "git.checkoutBranch":
+      await services.git.checkoutBranch(command.cwd, command.name);
+      return success(requestId, true);
+    default:
+      return null;
+  }
+}

--- a/src/main/app-core/permissions.ts
+++ b/src/main/app-core/permissions.ts
@@ -42,6 +42,28 @@ const REQUIRED_CAPABILITIES_BY_COMMAND: Record<
   "workspace.layout.clear": ["workspace:write"],
   "workspace.layout.read": ["workspace:read"],
   "workspace.layout.save": ["workspace:write"],
+  // Git 全部只读,绑 git:read(写操作未来另加 git:write)
+  "git.getCommit": ["git:read"],
+  "git.getCommitPatch": ["git:read"],
+  "git.getDiffPatch": ["git:read"],
+  "git.getDiffSummary": ["git:read"],
+  "git.getDiffText": ["git:read"],
+  "git.getFileContent": ["git:read"],
+  "git.getLog": ["git:read"],
+  "git.getRepoInfo": ["git:read"],
+  "git.getStatus": ["git:read"],
+  "git.isWorkingTreeClean": ["git:read"],
+  "git.listBranches": ["git:read"],
+  "git.listTags": ["git:read"],
+  "git.resolveRef": ["git:read"],
+  "git.validateBranchName": ["git:read"],
+  "git.stage": ["git:write"],
+  "git.unstage": ["git:write"],
+  "git.discardChanges": ["git:write"],
+  "git.commit": ["git:write"],
+  "git.createBranch": ["git:write"],
+  "git.deleteBranch": ["git:write"],
+  "git.checkoutBranch": ["git:write"],
 };
 
 function terminalOpenCapabilities(

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -10,6 +10,7 @@ import { installAppMenu } from "./app-menu.ts";
 import { installCsp } from "./csp.ts";
 import { registerCommandIpc } from "./ipc/command.ts";
 import { registerCommandPaletteMruIpc } from "./ipc/command-palette-mru.ts";
+import { registerGitWatchIpc } from "./ipc/git-watch.ts";
 import { registerMenuIpc } from "./ipc/menu.ts";
 import { registerPreferencesIpc } from "./ipc/preferences.ts";
 import { registerRendererCommandIpc } from "./ipc/renderer-command.ts";
@@ -220,6 +221,7 @@ app.whenReady().then(async () => {
   registerThemeIpc(ipcMain);
   registerWorkspaceIpc(ipcMain);
   registerCommandPaletteMruIpc(ipcMain);
+  registerGitWatchIpc();
   setTerminalPanelClosedHandler((panelId) => {
     appCore.services.tasks.markPanelClosed(panelId);
   });

--- a/src/main/ipc/command.ts
+++ b/src/main/ipc/command.ts
@@ -17,6 +17,28 @@ const RENDERER_FACADE_COMMAND_TYPES = new Set<PierCommand["type"]>([
   "worktree.check",
   "worktree.list",
   "worktree.open",
+  // git 主体 21 个命令(读 14 + 写 7);capability 守门由 permissions.ts 配对
+  "git.checkoutBranch",
+  "git.commit",
+  "git.createBranch",
+  "git.deleteBranch",
+  "git.discardChanges",
+  "git.getCommit",
+  "git.getCommitPatch",
+  "git.getDiffPatch",
+  "git.getDiffSummary",
+  "git.getDiffText",
+  "git.getFileContent",
+  "git.getLog",
+  "git.getRepoInfo",
+  "git.getStatus",
+  "git.isWorkingTreeClean",
+  "git.listBranches",
+  "git.listTags",
+  "git.resolveRef",
+  "git.stage",
+  "git.unstage",
+  "git.validateBranchName",
 ]);
 
 function isRendererFacadeCommand(command: PierCommand): boolean {

--- a/src/main/ipc/git-watch.ts
+++ b/src/main/ipc/git-watch.ts
@@ -1,0 +1,113 @@
+import { DEFAULT_CAPABILITIES_BY_CLIENT_KIND } from "@shared/contracts/permissions.ts";
+import { PIER, PIER_BROADCAST } from "@shared/ipc-channels.ts";
+import { type IpcMainInvokeEvent, ipcMain, type WebContents } from "electron";
+import { appCore } from "../app-core/app-core.ts";
+import { windowManager } from "../windows/window-manager.ts";
+
+/**
+ * git 变更监听 IPC:
+ * - PIER.GIT_WATCH_START → 启动订阅,把变更经 PIER_BROADCAST.GIT_CHANGED 推回该 BrowserWindow
+ * - PIER.GIT_WATCH_STOP → 停止订阅
+ *
+ * 设计要点:
+ * - 按 (webContentsId, gitRoot) 引用计数:同 wc 同 gitRoot 多次 start 只算一份订阅
+ * - webContents 销毁时自动 unsubscribe 全部订阅(防泄漏)
+ * - WeakSet hookedWebContents 守护 `destroyed` 监听器**每 wc 只注册一次**
+ *   (避免同 wc 订阅多 gitRoot / start-stop-start 累积多个 destroyed listener
+ *    触发 Node MaxListenersExceededWarning)
+ * - capability 校验:sender 对应 client 必须有 `git:read` 才能订阅
+ *   (与命令链路同等待遇,防 watch 绕过权限系统)
+ */
+export function registerGitWatchIpc(): void {
+  const subscriptions = new Map<string, () => void>();
+  const hookedWebContents = new WeakSet<WebContents>();
+
+  function key(webContentsId: number, gitRoot: string): string {
+    return `${webContentsId}::${gitRoot}`;
+  }
+
+  function ensureClientHasGitRead(wc: WebContents): boolean {
+    const window = windowManager.fromWebContents(wc);
+    if (!window) {
+      return false;
+    }
+    const windowId = windowManager.findInternalIdByWindow(window);
+    if (!windowId) {
+      return false;
+    }
+    const clientId = `desktop-renderer:${windowId}`;
+    let client = appCore.clients.heartbeat(clientId);
+    if (!client) {
+      const now = Date.now();
+      appCore.clients.register({
+        capabilities: DEFAULT_CAPABILITIES_BY_CLIENT_KIND["desktop-renderer"],
+        createdAt: now,
+        id: clientId,
+        kind: "desktop-renderer",
+        lastSeenAt: now,
+      });
+      client = appCore.clients.heartbeat(clientId);
+    }
+    return client?.capabilities.includes("git:read") === true;
+  }
+
+  function hookDestroyOnce(wc: WebContents): void {
+    if (hookedWebContents.has(wc)) {
+      return;
+    }
+    hookedWebContents.add(wc);
+    wc.once("destroyed", () => {
+      const prefix = `${wc.id}::`;
+      for (const [storedKey, dispose] of subscriptions.entries()) {
+        if (storedKey.startsWith(prefix)) {
+          dispose();
+          subscriptions.delete(storedKey);
+        }
+      }
+    });
+  }
+
+  ipcMain.handle(
+    PIER.GIT_WATCH_START,
+    (event: IpcMainInvokeEvent, gitRoot: unknown) => {
+      if (typeof gitRoot !== "string" || gitRoot.length === 0) {
+        return false;
+      }
+      const wc = event.sender;
+      if (!ensureClientHasGitRead(wc)) {
+        return false;
+      }
+      const subKey = key(wc.id, gitRoot);
+      if (subscriptions.has(subKey)) {
+        return true;
+      }
+      const unsubscribe = appCore.services.gitWatch.watch(
+        gitRoot,
+        (changeEvent) => {
+          if (!wc.isDestroyed()) {
+            wc.send(PIER_BROADCAST.GIT_CHANGED, changeEvent);
+          }
+        }
+      );
+      subscriptions.set(subKey, unsubscribe);
+      hookDestroyOnce(wc);
+      return true;
+    }
+  );
+
+  ipcMain.handle(
+    PIER.GIT_WATCH_STOP,
+    (event: IpcMainInvokeEvent, gitRoot: unknown) => {
+      if (typeof gitRoot !== "string" || gitRoot.length === 0) {
+        return false;
+      }
+      const subKey = key(event.sender.id, gitRoot);
+      const unsubscribe = subscriptions.get(subKey);
+      if (unsubscribe) {
+        unsubscribe();
+        subscriptions.delete(subKey);
+      }
+      return true;
+    }
+  );
+}

--- a/src/main/services/git-exec.ts
+++ b/src/main/services/git-exec.ts
@@ -1,0 +1,234 @@
+import { spawn as nodeSpawn } from "node:child_process";
+import { StringDecoder } from "node:string_decoder";
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+const DEFAULT_MAX_OUTPUT_BYTES = 16 * 1024 * 1024;
+/**
+ * SIGTERM 后等待子进程退出的宽限时间。超时后强制 SIGKILL，
+ * 避免 git 在某些 lock 清理路径下忽略 SIGTERM 让 Promise 永挂。
+ */
+const SIGKILL_GRACE_MS = 1500;
+
+/** git 子进程执行失败时的统一异常。保留完整 stdout/stderr/exitCode 便于上层错误分类。 */
+export class GitExecError extends Error {
+  readonly args: readonly string[];
+  readonly cwd: string;
+  readonly exitCode: number | null;
+  readonly stderr: string;
+  readonly stdout: string;
+
+  constructor(options: {
+    args: readonly string[];
+    cwd: string;
+    exitCode: number | null;
+    message: string;
+    stderr: string;
+    stdout: string;
+  }) {
+    super(options.message);
+    this.name = "GitExecError";
+    this.args = options.args;
+    this.cwd = options.cwd;
+    this.exitCode = options.exitCode;
+    this.stderr = options.stderr;
+    this.stdout = options.stdout;
+  }
+}
+
+export interface GitExecOptions {
+  cwd: string;
+  /** stdout + stderr 累计字节上限（默认 16MB）。按 chunk byteLength 累加，非 string.length。 */
+  maxOutputBytes?: number;
+  timeoutMs?: number;
+}
+
+export interface CreateExecGitOptions {
+  /** spawn 替身。测试可注入 fake child 验证 SIGKILL fallback、stream error 等。 */
+  spawn?: typeof nodeSpawn;
+}
+
+const GIT_ENV: Readonly<Record<string, string>> = {
+  GIT_OPTIONAL_LOCKS: "0",
+  GIT_PAGER: "cat",
+  GIT_TERMINAL_PROMPT: "0",
+  LANG: "C",
+  LC_ALL: "C",
+};
+
+/**
+ * 工厂：返回与默认 `execGit` 同形态的函数，但 spawn 可注入用于测试。
+ * 生产侧请直接 import 默认导出的 `execGit`；本工厂主要给单测用。
+ */
+export function createExecGit({
+  spawn = nodeSpawn,
+}: CreateExecGitOptions = {}): (
+  args: readonly string[],
+  options: GitExecOptions
+) => Promise<string> {
+  /**
+   * 统一 spawn 原生 git 的底座。
+   * 应用：超时（默认 10s）、输出字节上限（默认 16MB）、统一环境变量；失败 throw GitExecError。
+   * 调用者拿到的是 stdout（保留原样，不 trim）。
+   *
+   * 实现要点：
+   * - 用 StringDecoder 累积 Buffer chunks，避免 chunk 边界切断多字节 UTF-8 字符
+   * - 字节计数按 chunk.length（== Buffer.byteLength），不按 string.length（code units）
+   * - 超时/超限触发 SIGTERM；SIGKILL_GRACE_MS 后未退出再升级 SIGKILL
+   * - stdout/stderr 的 "error" 事件累加到 streamErrors，settle 时合并进 GitExecError.message
+   *   （而非 noop 吞，确保 EPIPE 等诊断信息不丢失）
+   */
+  return function execGit(args, options): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+      const maxOutputBytes = options.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES;
+      const child = spawn("git", [...args], {
+        cwd: options.cwd,
+        env: { ...process.env, ...GIT_ENV },
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+
+      const stdoutDecoder = new StringDecoder("utf8");
+      const stderrDecoder = new StringDecoder("utf8");
+      const streamErrors: string[] = [];
+      let stdout = "";
+      let stderr = "";
+      let outputBytes = 0;
+      let exceededLimit = false;
+      let timedOut = false;
+      let settled = false;
+      let killEscalationTimer: NodeJS.Timeout | null = null;
+
+      const timer = setTimeout(() => {
+        timedOut = true;
+        forceKill("SIGTERM");
+      }, timeoutMs);
+
+      function forceKill(signal: "SIGTERM" | "SIGKILL"): void {
+        child.kill(signal);
+        if (signal === "SIGTERM" && killEscalationTimer === null) {
+          killEscalationTimer = setTimeout(() => {
+            if (!settled) {
+              child.kill("SIGKILL");
+            }
+          }, SIGKILL_GRACE_MS);
+        }
+      }
+
+      function appendStreamDiagnostics(base: string): string {
+        if (streamErrors.length === 0) {
+          return base;
+        }
+        return `${base} [stream errors: ${streamErrors.join("; ")}]`;
+      }
+
+      function settle(payload: {
+        cause: "ok" | "exit" | "spawn-error" | "size-limit" | "timeout";
+        exitCode: number | null;
+        message?: string;
+      }): void {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(timer);
+        if (killEscalationTimer !== null) {
+          clearTimeout(killEscalationTimer);
+        }
+        // 把 decoder 内部 pending 字节冲洗出来
+        stdout += stdoutDecoder.end();
+        stderr += stderrDecoder.end();
+        if (payload.cause === "ok" && streamErrors.length === 0) {
+          resolve(stdout);
+          return;
+        }
+        const reasonPrefix = (() => {
+          if (payload.cause === "ok") {
+            return "git 成功退出但 stream 有 error";
+          }
+          if (payload.cause === "spawn-error") {
+            return "git 无法启动";
+          }
+          if (payload.cause === "size-limit") {
+            return `git 输出超过字节上限(${maxOutputBytes} bytes)`;
+          }
+          if (payload.cause === "timeout") {
+            return `git 执行超过 ${timeoutMs}ms 超时`;
+          }
+          return `git 退出码 ${payload.exitCode}`;
+        })();
+        const baseMessage =
+          payload.message != null && payload.message.length > 0
+            ? `${reasonPrefix}: ${payload.message}`
+            : reasonPrefix;
+        reject(
+          new GitExecError({
+            args,
+            cwd: options.cwd,
+            exitCode: payload.exitCode,
+            message: appendStreamDiagnostics(baseMessage),
+            stderr,
+            stdout,
+          })
+        );
+      }
+
+      function trackChunkBytes(chunk: Buffer): boolean {
+        if (exceededLimit) {
+          return false;
+        }
+        outputBytes += chunk.length;
+        if (outputBytes > maxOutputBytes) {
+          exceededLimit = true;
+          forceKill("SIGTERM");
+          return false;
+        }
+        return true;
+      }
+
+      // stream "error" 累加到诊断字段(典型:EPIPE)。settle 时合并进 GitExecError.message
+      child.stdout.on("error", (err: Error) => {
+        streamErrors.push(`stdout: ${err.message}`);
+      });
+      child.stderr.on("error", (err: Error) => {
+        streamErrors.push(`stderr: ${err.message}`);
+      });
+
+      child.stdout.on("data", (chunk: Buffer) => {
+        if (!trackChunkBytes(chunk)) {
+          return;
+        }
+        stdout += stdoutDecoder.write(chunk);
+      });
+
+      child.stderr.on("data", (chunk: Buffer) => {
+        if (!trackChunkBytes(chunk)) {
+          return;
+        }
+        stderr += stderrDecoder.write(chunk);
+      });
+
+      child.on("error", (err) => {
+        settle({ cause: "spawn-error", exitCode: null, message: err.message });
+      });
+
+      child.on("close", (code) => {
+        if (exceededLimit) {
+          settle({ cause: "size-limit", exitCode: code });
+          return;
+        }
+        if (timedOut) {
+          settle({ cause: "timeout", exitCode: code });
+          return;
+        }
+        if (code === 0) {
+          settle({ cause: "ok", exitCode: 0 });
+          return;
+        }
+        settle({ cause: "exit", exitCode: code, message: stderr.trim() });
+      });
+    });
+  };
+}
+
+/** 生产默认实现。下游 import 这个即可,行为与之前 export function execGit 等价。 */
+export const execGit = createExecGit();

--- a/src/main/services/git-parsers.ts
+++ b/src/main/services/git-parsers.ts
@@ -1,0 +1,326 @@
+/**
+ * git CLI 输出的纯函数解析器。集中在此让 git-service.ts 仅聚焦于 service 编排。
+ * 所有解析器都接受字符串、不发副作用、不依赖任何运行时状态;便于单测喂 fixture。
+ */
+import type {
+  GitBranchInfo,
+  GitBranchRef,
+  GitCommit,
+  GitDiffFilePatch,
+  GitDiffHunk,
+  GitDiffPatch,
+  GitDiffStat,
+  GitFileStatus,
+  GitStatus,
+} from "../../shared/contracts/git.ts";
+
+const BRANCH_AB_RE = /^\+(\d+) -(\d+)$/;
+const DIFF_HEADER_RE = /^diff --git a\/(.+) b\/(.+)$/;
+const HUNK_HEADER_RE = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/;
+
+function applyBranchHeader(branch: GitBranchInfo, header: string): void {
+  if (header.startsWith("branch.head ")) {
+    const name = header.slice("branch.head ".length);
+    branch.branch = name === "(detached)" ? null : name;
+    return;
+  }
+  if (header.startsWith("branch.upstream ")) {
+    branch.upstream = header.slice("branch.upstream ".length);
+    return;
+  }
+  if (header.startsWith("branch.ab ")) {
+    const match = BRANCH_AB_RE.exec(header.slice("branch.ab ".length));
+    if (match) {
+      branch.ahead = Number(match[1]);
+      branch.behind = Number(match[2]);
+    }
+  }
+}
+
+/** ordinary 条目：`1 <XY> <sub> <mH> <mI> <mW> <hH> <hI> <path>` */
+function parseOrdinaryEntry(record: string): GitFileStatus {
+  return {
+    index: record.charAt(2),
+    origPath: null,
+    path: record.split(" ").slice(8).join(" "),
+    worktree: record.charAt(3),
+  };
+}
+
+/** rename/copy 条目：`2 <XY> ... <Xscore> <path>`，紧跟一条 origPath 记录 */
+function parseRenamedEntry(record: string, origPath: string): GitFileStatus {
+  return {
+    index: record.charAt(2),
+    origPath,
+    path: record.split(" ").slice(9).join(" "),
+    worktree: record.charAt(3),
+  };
+}
+
+/** unmerged 条目：`u <XY> <sub> <m1> <m2> <m3> <mW> <h1> <h2> <h3> <path>` */
+function parseUnmergedEntry(record: string): GitFileStatus {
+  return {
+    index: record.charAt(2),
+    origPath: null,
+    path: record.split(" ").slice(10).join(" "),
+    worktree: record.charAt(3),
+  };
+}
+
+/**
+ * 解析 `git status --porcelain=v2 --branch -z` 的输出。
+ * 记录以 NUL 分隔；"# " 开头是分支 header,"1"/"2"/"u"/"?" 开头是文件条目。
+ * rename("2")额外占用紧跟的 origPath 记录。
+ */
+export function parseGitStatus(output: string): GitStatus {
+  const branch: GitBranchInfo = {
+    ahead: 0,
+    behind: 0,
+    branch: null,
+    upstream: null,
+  };
+  const files: GitFileStatus[] = [];
+  const records = output.split("\0");
+
+  let index = 0;
+  while (index < records.length) {
+    const record = records[index] ?? "";
+    if (record.length === 0) {
+      index += 1;
+      continue;
+    }
+    const tag = record.charAt(0);
+    if (tag === "#") {
+      applyBranchHeader(branch, record.slice(2));
+    } else if (tag === "1") {
+      files.push(parseOrdinaryEntry(record));
+    } else if (tag === "2") {
+      files.push(parseRenamedEntry(record, records[index + 1] ?? ""));
+      index += 1;
+    } else if (tag === "u") {
+      files.push(parseUnmergedEntry(record));
+    } else if (tag === "?") {
+      files.push({
+        index: "?",
+        origPath: null,
+        path: record.slice(2),
+        worktree: "?",
+      });
+    }
+    index += 1;
+  }
+
+  return { branch, files };
+}
+
+/**
+ * 解析 `git log --format=%H%x1f%an%x1f%aI%x1f%s%x1e` 的输出。
+ * 字段用 US(\x1f) 分隔、记录用 RS(\x1e) 分隔,避免与路径/message 内容歧义。
+ */
+export function parseGitLog(output: string): GitCommit[] {
+  const commits: GitCommit[] = [];
+  for (const record of output.split("\x1e")) {
+    const trimmed = record.trim();
+    if (trimmed.length === 0) {
+      continue;
+    }
+    const fields = trimmed.split("\x1f");
+    commits.push({
+      author: fields[1] ?? "",
+      date: fields[2] ?? "",
+      hash: fields[0] ?? "",
+      message: fields[3] ?? "",
+    });
+  }
+  return commits;
+}
+
+/**
+ * 解析 `git diff --numstat -z --no-renames` 的输出。
+ * 每条 `adds\tdels\tpath`(NUL 分隔);binary 文件 adds/dels 为 "-"。
+ * path 可能含 tab,故只切前两个 tab,剩余整段作 path。
+ */
+export function parseGitNumstat(output: string): GitDiffStat[] {
+  const stats: GitDiffStat[] = [];
+  for (const record of output.split("\0")) {
+    if (record.length === 0) {
+      continue;
+    }
+    const firstTab = record.indexOf("\t");
+    const secondTab = firstTab === -1 ? -1 : record.indexOf("\t", firstTab + 1);
+    if (firstTab === -1 || secondTab === -1) {
+      continue;
+    }
+    const addsRaw = record.slice(0, firstTab);
+    const delsRaw = record.slice(firstTab + 1, secondTab);
+    const binary = addsRaw === "-" || delsRaw === "-";
+    stats.push({
+      binary,
+      deletions: binary ? 0 : Number(delsRaw),
+      insertions: binary ? 0 : Number(addsRaw),
+      path: record.slice(secondTab + 1),
+    });
+  }
+  return stats;
+}
+
+function startNewFile(line: string): GitDiffFilePatch | null {
+  if (!line.startsWith("diff --git ")) {
+    return null;
+  }
+  const match = DIFF_HEADER_RE.exec(line);
+  return {
+    binary: false,
+    hunks: [],
+    oldPath: null,
+    path: match?.[2] ?? "",
+  };
+}
+
+/** 处理 binary / rename / --- / +++ 等文件元信息行;命中返回 true。 */
+function applyFileMetadata(current: GitDiffFilePatch, line: string): boolean {
+  if (line.startsWith("Binary files ")) {
+    current.binary = true;
+    return true;
+  }
+  if (line.startsWith("rename from ")) {
+    current.oldPath = line.slice("rename from ".length);
+    return true;
+  }
+  if (line.startsWith("rename to ")) {
+    current.path = line.slice("rename to ".length);
+    return true;
+  }
+  if (line.startsWith("--- ")) {
+    const p = line.slice(4);
+    if (p !== "/dev/null" && p.startsWith("a/")) {
+      const oldName = p.slice(2);
+      if (oldName !== current.path) {
+        current.oldPath = oldName;
+      }
+    }
+    return true;
+  }
+  if (line.startsWith("+++ ")) {
+    const p = line.slice(4);
+    if (p !== "/dev/null" && p.startsWith("b/")) {
+      current.path = p.slice(2);
+    }
+    return true;
+  }
+  return false;
+}
+
+function startNewHunk(line: string): GitDiffHunk | null {
+  const match = HUNK_HEADER_RE.exec(line);
+  if (!match) {
+    return null;
+  }
+  return {
+    lines: [],
+    newLines: Number(match[4] ?? "1"),
+    newStart: Number(match[3]),
+    oldLines: Number(match[2] ?? "1"),
+    oldStart: Number(match[1]),
+  };
+}
+
+function appendHunkLine(hunk: GitDiffHunk, line: string): void {
+  const tag = line.charAt(0);
+  if (tag === "+") {
+    hunk.lines.push({ kind: "add", text: line.slice(1) });
+  } else if (tag === "-") {
+    hunk.lines.push({ kind: "del", text: line.slice(1) });
+  } else if (tag === " ") {
+    hunk.lines.push({ kind: "context", text: line.slice(1) });
+  }
+}
+
+/**
+ * 解析 git 原生 unified diff 文本为结构化 patch(files + hunks + lines)。
+ * 让 diff 渲染插件不必各自实现解析器;只输出数据,不渲染。
+ * 不支持的形式(合并冲突 --combined / --cc)会被静默忽略。
+ */
+export function parseUnifiedDiff(text: string): GitDiffPatch {
+  const files: GitDiffFilePatch[] = [];
+  let current: GitDiffFilePatch | null = null;
+  let hunk: GitDiffHunk | null = null;
+
+  function flushHunk(): void {
+    if (hunk && current) {
+      current.hunks.push(hunk);
+      hunk = null;
+    }
+  }
+  function flushFile(): void {
+    flushHunk();
+    if (current) {
+      files.push(current);
+      current = null;
+    }
+  }
+
+  for (const line of text.split("\n")) {
+    const newFile = startNewFile(line);
+    if (newFile) {
+      flushFile();
+      current = newFile;
+      continue;
+    }
+    if (!current) {
+      continue;
+    }
+    if (applyFileMetadata(current, line)) {
+      continue;
+    }
+    const newHunk = startNewHunk(line);
+    if (newHunk) {
+      flushHunk();
+      hunk = newHunk;
+      continue;
+    }
+    if (hunk) {
+      appendHunkLine(hunk, line);
+    }
+  }
+  flushFile();
+  return { files };
+}
+
+/**
+ * 解析 `git for-each-ref --format=%(refname)%00%(upstream:short)%00%(objectname)%00%(HEAD)` 输出。
+ * refname 完整路径(refs/heads/x 或 refs/remotes/origin/x);HEAD 字段 "*" 表示当前分支。
+ * 记录用换行分隔;字段用 NUL 分隔,避免 upstream 名含特殊字符。
+ */
+export function parseGitBranchRefs(output: string): GitBranchRef[] {
+  const refs: GitBranchRef[] = [];
+  for (const line of output.split("\n")) {
+    if (line.length === 0) {
+      continue;
+    }
+    const fields = line.split("\0");
+    const refname = fields[0] ?? "";
+    const upstream = fields[1] ?? "";
+    const oid = fields[2] ?? "";
+    const headMark = fields[3] ?? "";
+    let kind: "local" | "remote";
+    let name: string;
+    if (refname.startsWith("refs/heads/")) {
+      kind = "local";
+      name = refname.slice("refs/heads/".length);
+    } else if (refname.startsWith("refs/remotes/")) {
+      kind = "remote";
+      name = refname.slice("refs/remotes/".length);
+    } else {
+      continue;
+    }
+    refs.push({
+      isCurrent: headMark === "*",
+      kind,
+      lastCommit: oid,
+      name,
+      upstream: upstream.length > 0 ? upstream : null,
+    });
+  }
+  return refs;
+}

--- a/src/main/services/git-service.ts
+++ b/src/main/services/git-service.ts
@@ -1,0 +1,379 @@
+import type { z } from "zod";
+import type {
+  GitBranchRef,
+  GitCommit,
+  GitDiffPatch,
+  GitDiffSummary,
+  GitRepoInfo,
+  GitStatus,
+  getFileContentOptionsSchema,
+  gitCommitOptionsSchema,
+  gitCreateBranchOptionsSchema,
+  gitDeleteBranchOptionsSchema,
+  gitDiffOptionsSchema,
+  gitLogOptionsSchema,
+  gitPathsSchema,
+  listBranchesOptionsSchema,
+} from "../../shared/contracts/git.ts";
+import { execGit } from "./git-exec.ts";
+import {
+  parseGitBranchRefs,
+  parseGitLog,
+  parseGitNumstat,
+  parseGitStatus,
+  parseUnifiedDiff,
+} from "./git-parsers.ts";
+
+const GIT_LOG_FORMAT = "%H%x1f%an%x1f%aI%x1f%s%x1e";
+const ORIGIN_HEAD_RE = /^refs\/remotes\/origin\/(.+)$/;
+
+/** 从 contracts schema 派生的 IPC 兼容 option 类型,避免 exactOptionalPropertyTypes 冲突。 */
+export type GitDiffOptions = z.infer<typeof gitDiffOptionsSchema>;
+export type GitLogOptions = z.infer<typeof gitLogOptionsSchema>;
+export type ListBranchesOptions = z.infer<typeof listBranchesOptionsSchema>;
+export type GetFileContentOptions = z.infer<typeof getFileContentOptionsSchema>;
+export type GitPathsRequest = z.infer<typeof gitPathsSchema>;
+export type GitCommitOptions = z.infer<typeof gitCommitOptionsSchema>;
+export type GitCreateBranchOptions = z.infer<
+  typeof gitCreateBranchOptionsSchema
+>;
+export type GitDeleteBranchOptions = z.infer<
+  typeof gitDeleteBranchOptionsSchema
+>;
+
+/** 写操作统一 60s 超时(避免大仓库继承 git-exec 默认 10s 失败)。 */
+const WRITE_TIMEOUT_MS = 60_000;
+
+/**
+ * branch name 不允许以 "-" 开头,否则 git 会把它当 flag(`git branch --help` 等)。
+ * spawn argv 模式虽不构成 shell 注入,但语义会被破坏:任何拿到 git:write 的插件
+ * 传 `name: "--force"` 都会触发非预期分支。
+ */
+function assertSafeBranchName(name: string): void {
+  if (name.startsWith("-")) {
+    throw new Error(
+      `branch name must not start with "-" (would be interpreted as git flag): ${name}`
+    );
+  }
+}
+
+export interface GitService {
+  checkoutBranch(cwd: string, name: string): Promise<void>;
+  commit(cwd: string, options: GitCommitOptions): Promise<void>;
+  createBranch(cwd: string, options: GitCreateBranchOptions): Promise<void>;
+  deleteBranch(cwd: string, options: GitDeleteBranchOptions): Promise<void>;
+  discardChanges(cwd: string, request: GitPathsRequest): Promise<void>;
+  // —— 读 ——
+  getCommit(cwd: string, oid: string): Promise<GitCommit>;
+  getCommitPatch(cwd: string, oid: string): Promise<GitDiffPatch>;
+  getDiffPatch(cwd: string, options?: GitDiffOptions): Promise<GitDiffPatch>;
+  getDiffSummary(
+    cwd: string,
+    options?: GitDiffOptions
+  ): Promise<GitDiffSummary>;
+  getDiffText(cwd: string, options?: GitDiffOptions): Promise<string>;
+  getFileContent(cwd: string, options: GetFileContentOptions): Promise<string>;
+  getLog(cwd: string, options?: GitLogOptions): Promise<GitCommit[]>;
+  getRepoInfo(cwd: string): Promise<GitRepoInfo>;
+  getStatus(cwd: string): Promise<GitStatus>;
+  isWorkingTreeClean(cwd: string): Promise<boolean>;
+  listBranches(
+    cwd: string,
+    options: ListBranchesOptions
+  ): Promise<GitBranchRef[]>;
+  listTags(cwd: string): Promise<string[]>;
+  resolveRef(cwd: string, ref: string): Promise<string>;
+  // —— 写(需 git:write capability) ——
+  stage(cwd: string, request: GitPathsRequest): Promise<void>;
+  unstage(cwd: string, request: GitPathsRequest): Promise<void>;
+  validateBranchName(cwd: string, name: string): Promise<boolean>;
+}
+
+export interface CreateGitServiceOptions {
+  execGit?: (
+    args: readonly string[],
+    cwd: string,
+    options?: { timeoutMs?: number }
+  ) => Promise<string>;
+}
+
+function diffRangeArgs(options: GitDiffOptions): string[] {
+  const args: string[] = [];
+  if (options.staged) {
+    args.push("--cached");
+  }
+  if (options.from && options.to) {
+    args.push(`${options.from}..${options.to}`);
+  } else if (options.from) {
+    args.push(options.from);
+  }
+  if (options.paths && options.paths.length > 0) {
+    args.push("--", ...options.paths);
+  }
+  return args;
+}
+
+function logArgs(options: GitLogOptions): string[] {
+  const maxCount = options.maxCount ?? 50;
+  const args: string[] = [
+    "log",
+    `--format=${GIT_LOG_FORMAT}`,
+    `--max-count=${maxCount}`,
+  ];
+  if (options.author) {
+    args.push(`--author=${options.author}`);
+  }
+  if (options.grep) {
+    args.push(`--grep=${options.grep}`);
+  }
+  if (options.since) {
+    args.push(`--since=${options.since}`);
+  }
+  if (options.until) {
+    args.push(`--until=${options.until}`);
+  }
+  if (options.path) {
+    args.push("--", options.path);
+  }
+  return args;
+}
+
+function defaultExecGit(
+  args: readonly string[],
+  cwd: string,
+  options?: { timeoutMs?: number }
+): Promise<string> {
+  return execGit(args, { cwd, ...options });
+}
+
+async function readHeadOid(
+  cwd: string,
+  exec: (args: readonly string[], cwd: string) => Promise<string>
+): Promise<string | null> {
+  try {
+    return (await exec(["rev-parse", "--verify", "HEAD"], cwd)).trim();
+  } catch {
+    return null;
+  }
+}
+
+async function readDefaultBranch(
+  cwd: string,
+  exec: (args: readonly string[], cwd: string) => Promise<string>
+): Promise<string | null> {
+  try {
+    const out = (
+      await exec(["symbolic-ref", "refs/remotes/origin/HEAD"], cwd)
+    ).trim();
+    return ORIGIN_HEAD_RE.exec(out)?.[1] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 核心 git 读服务(main 进程)。默认 spawn 原生 git(execGit 可注入便于测试)。
+ * 只读:不含任何写操作(stage/commit 等留待后续按 git:write capability 扩展)。
+ */
+export function createGitService({
+  execGit = defaultExecGit,
+}: CreateGitServiceOptions = {}): GitService {
+  return {
+    getCommit: async (cwd, oid) => {
+      const output = await execGit(
+        ["log", "-1", `--format=${GIT_LOG_FORMAT}`, oid],
+        cwd
+      );
+      const head = parseGitLog(output)[0];
+      if (head === undefined) {
+        throw new Error(`commit not found: ${oid}`);
+      }
+      return head;
+    },
+    getCommitPatch: async (cwd, oid) => {
+      const text = await execGit(
+        ["show", "--format=", "--no-color", "--no-ext-diff", oid],
+        cwd
+      );
+      return parseUnifiedDiff(text);
+    },
+    getDiffSummary: async (cwd, options = {}) => {
+      const output = await execGit(
+        ["diff", "--numstat", "-z", "--no-renames", ...diffRangeArgs(options)],
+        cwd
+      );
+      const files = parseGitNumstat(output);
+      return {
+        changed: files.length,
+        deletions: files.reduce((sum, file) => sum + file.deletions, 0),
+        files,
+        insertions: files.reduce((sum, file) => sum + file.insertions, 0),
+      };
+    },
+    getDiffPatch: async (cwd, options = {}) => {
+      const text = await execGit(
+        ["diff", "--no-color", "--no-ext-diff", ...diffRangeArgs(options)],
+        cwd
+      );
+      return parseUnifiedDiff(text);
+    },
+    getDiffText: (cwd, options = {}) =>
+      execGit(
+        ["diff", "--no-color", "--no-ext-diff", ...diffRangeArgs(options)],
+        cwd
+      ),
+    getFileContent: (cwd, options) =>
+      execGit(["show", `${options.ref ?? "HEAD"}:${options.path}`], cwd),
+    getLog: async (cwd, options = {}) => {
+      const output = await execGit(logArgs(options), cwd);
+      return parseGitLog(output);
+    },
+    getRepoInfo: async (cwd) => {
+      // --path-format=absolute 让 --git-common-dir 也返回绝对路径
+      // (默认它返回相对路径 ".git",会让 isWorktree 在普通仓库假阳性为 true)
+      const pathOutput = await execGit(
+        [
+          "rev-parse",
+          "--path-format=absolute",
+          "--show-toplevel",
+          "--absolute-git-dir",
+          "--git-common-dir",
+        ],
+        cwd
+      );
+      const lines = pathOutput
+        .split("\n")
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0);
+      const gitRoot = lines[0] ?? "";
+      const gitDir = lines[1] ?? "";
+      const gitCommonDir = lines[2] ?? "";
+      const bareOutput = (
+        await execGit(["rev-parse", "--is-bare-repository"], cwd)
+      ).trim();
+      const [headOid, defaultBranch] = await Promise.all([
+        readHeadOid(cwd, execGit),
+        readDefaultBranch(cwd, execGit),
+      ]);
+      return {
+        defaultBranch,
+        gitCommonDir,
+        gitRoot,
+        headOid,
+        isBare: bareOutput === "true",
+        isWorktree: gitDir !== gitCommonDir,
+      };
+    },
+    getStatus: async (cwd) => {
+      const output = await execGit(
+        ["status", "--porcelain=v2", "--branch", "-z"],
+        cwd
+      );
+      return parseGitStatus(output);
+    },
+    isWorkingTreeClean: async (cwd) => {
+      const output = await execGit(
+        ["status", "--porcelain=v2", "--branch", "-z"],
+        cwd
+      );
+      return parseGitStatus(output).files.length === 0;
+    },
+    listBranches: async (cwd, options) => {
+      const refs = ["refs/heads", "refs/remotes"].filter((ref) => {
+        if (options.kind === "local") {
+          return ref === "refs/heads";
+        }
+        if (options.kind === "remote") {
+          return ref === "refs/remotes";
+        }
+        return true;
+      });
+      const output = await execGit(
+        [
+          "for-each-ref",
+          "--format=%(refname)%00%(upstream:short)%00%(objectname)%00%(HEAD)",
+          ...refs,
+        ],
+        cwd
+      );
+      return parseGitBranchRefs(output);
+    },
+    listTags: async (cwd) => {
+      const output = await execGit(
+        ["for-each-ref", "--format=%(refname:short)", "refs/tags"],
+        cwd
+      );
+      return output
+        .split("\n")
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0);
+    },
+    resolveRef: async (cwd, ref) => {
+      const output = await execGit(["rev-parse", "--verify", ref], cwd);
+      return output.trim();
+    },
+    validateBranchName: async (cwd, name) => {
+      try {
+        await execGit(["check-ref-format", "--branch", name], cwd);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    // —— 写操作:全部传 timeoutMs 60s ——
+    stage: async (cwd, request) => {
+      if (request.paths.length === 0) {
+        throw new Error("stage requires at least one path");
+      }
+      await execGit(["add", "--", ...request.paths], cwd, {
+        timeoutMs: WRITE_TIMEOUT_MS,
+      });
+    },
+    unstage: async (cwd, request) => {
+      if (request.paths.length === 0) {
+        throw new Error("unstage requires at least one path");
+      }
+      await execGit(["restore", "--staged", "--", ...request.paths], cwd, {
+        timeoutMs: WRITE_TIMEOUT_MS,
+      });
+    },
+    discardChanges: async (cwd, request) => {
+      if (request.paths.length === 0) {
+        throw new Error("discardChanges requires at least one path");
+      }
+      await execGit(["restore", "--", ...request.paths], cwd, {
+        timeoutMs: WRITE_TIMEOUT_MS,
+      });
+    },
+    commit: async (cwd, options) => {
+      const args = ["commit", "-m", options.message];
+      if (options.signoff) {
+        args.push("--signoff");
+      }
+      if (options.allowEmpty) {
+        args.push("--allow-empty");
+      }
+      await execGit(args, cwd, { timeoutMs: WRITE_TIMEOUT_MS });
+    },
+    createBranch: async (cwd, options) => {
+      assertSafeBranchName(options.name);
+      const args = ["branch", options.name];
+      if (options.startPoint) {
+        args.push(options.startPoint);
+      }
+      await execGit(args, cwd, { timeoutMs: WRITE_TIMEOUT_MS });
+    },
+    deleteBranch: async (cwd, options) => {
+      assertSafeBranchName(options.name);
+      await execGit(
+        ["branch", options.force ? "-D" : "-d", options.name],
+        cwd,
+        { timeoutMs: WRITE_TIMEOUT_MS }
+      );
+    },
+    checkoutBranch: async (cwd, name) => {
+      assertSafeBranchName(name);
+      await execGit(["switch", name], cwd, { timeoutMs: WRITE_TIMEOUT_MS });
+    },
+  };
+}

--- a/src/main/services/git-watch-service.ts
+++ b/src/main/services/git-watch-service.ts
@@ -1,0 +1,237 @@
+import { createHash } from "node:crypto";
+import { type FSWatcher, watch as fsWatchNative } from "node:fs";
+import type {
+  GitChangeEvent,
+  GitChangeKind,
+} from "../../shared/contracts/git.ts";
+import { execGit } from "./git-exec.ts";
+
+const DEFAULT_DEBOUNCE_MS = 400;
+const DEFAULT_POLL_MS = 30_000;
+
+export type FsWatchFn = (
+  path: string,
+  options?: { recursive?: boolean }
+) => FSWatcher;
+
+export interface CreateGitWatchServiceOptions {
+  /** sha256(HEAD oid + symbolic-ref HEAD)。注入便于测试。 */
+  computeHeadSignature?: (gitRoot: string) => Promise<string>;
+  /** sha256(git status --porcelain=v2 -z)。注入便于测试。 */
+  computeWorktreeSignature?: (gitRoot: string) => Promise<string>;
+  debounceMs?: number;
+  /** fs.watch 替身。默认尝试 recursive,失败 fallback 到 .git 目录。 */
+  fsWatch?: FsWatchFn;
+  pollMs?: number;
+}
+
+export interface GitWatchService {
+  /** 主动关闭所有 watcher 和 poll timer。 */
+  dispose(): Promise<void>;
+  /**
+   * 订阅 gitRoot 的 git 变化。返回 unsubscribe 函数。
+   * 同一 gitRoot 多个 listener 共用一个底层 fs watcher(引用计数)。
+   * 最后一个 listener 退订时,watcher 自动关闭。
+   */
+  watch(gitRoot: string, listener: (event: GitChangeEvent) => void): () => void;
+}
+
+interface WatchEntry {
+  /**
+   * baseline(initial refresh force=true)是否已完成。
+   * 完成前所有 fs event 与 poll 都被忽略,避免 worktreeSig/headSig 仍为 ""
+   * 与新签名比较时误报 changeKind="both"。
+   */
+  baselineReady: boolean;
+  debounceTimer: NodeJS.Timeout | null;
+  headSig: string;
+  listeners: Set<(event: GitChangeEvent) => void>;
+  pollTimer: NodeJS.Timeout;
+  watcher: FSWatcher;
+  worktreeSig: string;
+}
+
+async function defaultWorktreeSignature(gitRoot: string): Promise<string> {
+  try {
+    const output = await execGit(["status", "--porcelain=v2", "-z"], {
+      cwd: gitRoot,
+    });
+    return createHash("sha256").update(output).digest("hex");
+  } catch {
+    return "";
+  }
+}
+
+async function defaultHeadSignature(gitRoot: string): Promise<string> {
+  let head = "";
+  let ref = "";
+  try {
+    head = await execGit(["rev-parse", "HEAD"], { cwd: gitRoot });
+  } catch {
+    // 空仓库无 HEAD
+  }
+  try {
+    ref = await execGit(["symbolic-ref", "-q", "HEAD"], { cwd: gitRoot });
+  } catch {
+    // detached HEAD
+  }
+  return createHash("sha256").update(`${head}\n${ref}`).digest("hex");
+}
+
+function defaultFsWatch(path: string): FSWatcher {
+  try {
+    return fsWatchNative(path, { recursive: true });
+  } catch {
+    // Linux 不支持 recursive 时,降级只 watch .git(HEAD/index 变更仍能捕获)
+    return fsWatchNative(`${path}/.git`);
+  }
+}
+
+function deriveChangeKind(
+  worktreeChanged: boolean,
+  headChanged: boolean
+): GitChangeKind | null {
+  if (worktreeChanged && headChanged) {
+    return "both";
+  }
+  if (worktreeChanged) {
+    return "worktree";
+  }
+  if (headChanged) {
+    return "head";
+  }
+  return null;
+}
+
+/**
+ * git 变更监听服务。
+ * 设计:
+ * - fs.watch 触发 → 400ms debounce → 重算签名 → 比对 → 通知 listeners
+ * - 30s 兜底轮询防止 watcher 漏事件
+ * - 引用计数:多个 listener 共用同一 fs watcher
+ * - 签名(porcelain v2 status + HEAD ref)hash 化避免大输出常驻内存
+ */
+export function createGitWatchService({
+  computeWorktreeSignature = defaultWorktreeSignature,
+  computeHeadSignature = defaultHeadSignature,
+  fsWatch = defaultFsWatch,
+  debounceMs = DEFAULT_DEBOUNCE_MS,
+  pollMs = DEFAULT_POLL_MS,
+}: CreateGitWatchServiceOptions = {}): GitWatchService {
+  const entries = new Map<string, WatchEntry>();
+
+  async function refresh(gitRoot: string, force: boolean): Promise<void> {
+    const entry = entries.get(gitRoot);
+    if (!entry) {
+      return;
+    }
+    const [nextWorktree, nextHead] = await Promise.all([
+      computeWorktreeSignature(gitRoot),
+      computeHeadSignature(gitRoot),
+    ]);
+    const worktreeChanged = nextWorktree !== entry.worktreeSig;
+    const headChanged = nextHead !== entry.headSig;
+    entry.worktreeSig = nextWorktree;
+    entry.headSig = nextHead;
+    if (force) {
+      return;
+    }
+    const changeKind = deriveChangeKind(worktreeChanged, headChanged);
+    if (!changeKind) {
+      return;
+    }
+    for (const listener of entry.listeners) {
+      listener({ changeKind, gitRoot });
+    }
+  }
+
+  function scheduleRefresh(gitRoot: string): void {
+    const entry = entries.get(gitRoot);
+    if (!entry?.baselineReady) {
+      // baseline 未完成,fs event 静默丢弃(避免与初始 "" 签名误比较)
+      return;
+    }
+    if (entry.debounceTimer !== null) {
+      clearTimeout(entry.debounceTimer);
+    }
+    entry.debounceTimer = setTimeout(() => {
+      const target = entries.get(gitRoot);
+      if (target) {
+        target.debounceTimer = null;
+      }
+      refresh(gitRoot, false).catch(() => {
+        // 单次失败由下一次 fs 事件或轮询兜底
+      });
+    }, debounceMs);
+  }
+
+  function disposeEntry(entry: WatchEntry): void {
+    if (entry.debounceTimer !== null) {
+      clearTimeout(entry.debounceTimer);
+    }
+    clearInterval(entry.pollTimer);
+    entry.watcher.close();
+  }
+
+  function watch(
+    gitRoot: string,
+    listener: (event: GitChangeEvent) => void
+  ): () => void {
+    let entry = entries.get(gitRoot);
+    if (!entry) {
+      const watcher = fsWatch(gitRoot, { recursive: true });
+      watcher.on("error", () => {
+        // 兜底:watcher 内部错误(EBADF/EPERM 等)由轮询补救
+      });
+      const pollTimer = setInterval(() => {
+        const target = entries.get(gitRoot);
+        if (!target?.baselineReady) {
+          return;
+        }
+        refresh(gitRoot, false).catch(() => undefined);
+      }, pollMs);
+      entry = {
+        baselineReady: false,
+        debounceTimer: null,
+        headSig: "",
+        listeners: new Set(),
+        pollTimer,
+        watcher,
+        worktreeSig: "",
+      };
+      entries.set(gitRoot, entry);
+      watcher.on("change", () => scheduleRefresh(gitRoot));
+      // 初始签名采集:完成后才标 baselineReady,避免与初始 "" 签名比较误报
+      refresh(gitRoot, true)
+        .catch(() => undefined)
+        .finally(() => {
+          const target = entries.get(gitRoot);
+          if (target) {
+            target.baselineReady = true;
+          }
+        });
+    }
+    entry.listeners.add(listener);
+    return () => {
+      const target = entries.get(gitRoot);
+      if (!target) {
+        return;
+      }
+      target.listeners.delete(listener);
+      if (target.listeners.size === 0) {
+        disposeEntry(target);
+        entries.delete(gitRoot);
+      }
+    };
+  }
+
+  function dispose(): Promise<void> {
+    for (const entry of entries.values()) {
+      disposeEntry(entry);
+    }
+    entries.clear();
+    return Promise.resolve();
+  }
+
+  return { dispose, watch };
+}

--- a/src/main/services/panel-context-resolver.ts
+++ b/src/main/services/panel-context-resolver.ts
@@ -1,15 +1,12 @@
-import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
 import type { Stats } from "node:fs";
 import { realpath as fsRealpath, stat as fsStat } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
-import { promisify } from "node:util";
 import type {
   PanelContext,
   PanelContextSource,
 } from "@shared/contracts/panel.ts";
-
-const execFileAsync = promisify(execFile);
+import { execGit } from "./git-exec.ts";
 
 export interface ResolvePanelContextOptions {
   execGit?: (
@@ -22,12 +19,8 @@ export interface ResolvePanelContextOptions {
   stat?: (path: string) => Promise<Stats>;
 }
 
-async function defaultExecGit(
-  args: readonly string[],
-  cwd: string
-): Promise<string> {
-  const { stdout } = await execFileAsync("git", [...args], { cwd });
-  return stdout;
+function defaultExecGit(args: readonly string[], cwd: string): Promise<string> {
+  return execGit(args, { cwd });
 }
 
 function outputText(output: string | { stdout: string }): string {

--- a/src/main/services/worktree-service.ts
+++ b/src/main/services/worktree-service.ts
@@ -1,7 +1,5 @@
-import { execFile } from "node:child_process";
 import { mkdir as fsMkdir, realpath as fsRealpath } from "node:fs/promises";
 import { isAbsolute, join, relative, resolve } from "node:path";
-import { promisify } from "node:util";
 import type {
   WorktreeCheckRequest,
   WorktreeCheckResult,
@@ -14,8 +12,8 @@ import type {
   WorktreeRemoveRequest,
   WorktreeRemoveResult,
 } from "@shared/contracts/worktree.ts";
+import { execGit } from "./git-exec.ts";
 
-const execFileAsync = promisify(execFile);
 const SAFE_WORKTREE_NAME_PATTERN = /^[A-Za-z0-9._-]+$/;
 
 export interface WorktreeService {
@@ -26,7 +24,11 @@ export interface WorktreeService {
 }
 
 export interface CreateWorktreeServiceOptions {
-  execGit?: (args: readonly string[], cwd: string) => Promise<string>;
+  execGit?: (
+    args: readonly string[],
+    cwd: string,
+    options?: { timeoutMs?: number }
+  ) => Promise<string>;
   mkdir?: (path: string) => Promise<void>;
   realpath?: (path: string) => Promise<string>;
 }
@@ -41,12 +43,12 @@ export class WorktreeServiceError extends Error {
   }
 }
 
-async function defaultExecGit(
+function defaultExecGit(
   args: readonly string[],
-  cwd: string
+  cwd: string,
+  options?: { timeoutMs?: number }
 ): Promise<string> {
-  const { stdout } = await execFileAsync("git", [...args], { cwd });
-  return stdout;
+  return execGit(args, { cwd, ...options });
 }
 
 async function safeRealpath(
@@ -265,7 +267,11 @@ export function createWorktreeService({
         ["worktree", "list", "--porcelain", "-z"],
         realCurrentPath
       );
-    } catch {
+    } catch (err) {
+      console.warn(
+        "[worktree-service] worktree list failed:",
+        err instanceof Error ? err.message : err
+      );
       return {
         path: resolvedPath,
         reason: "git_unavailable",
@@ -322,7 +328,8 @@ export function createWorktreeService({
         targetPath,
         ...(request.base ? [request.base] : []),
       ],
-      before.mainPath
+      before.mainPath,
+      { timeoutMs: 60_000 }
     );
 
     const after = await list({ path: targetPath });
@@ -385,7 +392,9 @@ export function createWorktreeService({
     }
 
     try {
-      await execGit(["worktree", "remove", target.path], before.mainPath);
+      await execGit(["worktree", "remove", target.path], before.mainPath, {
+        timeoutMs: 60_000,
+      });
     } catch (err) {
       serviceError(
         "git_unavailable",

--- a/src/plugins/api/renderer.ts
+++ b/src/plugins/api/renderer.ts
@@ -1,3 +1,8 @@
+import type {
+  GitChangeEvent,
+  GitRepoInfo,
+  GitStatus,
+} from "@shared/contracts/git.ts";
 import type { PanelContext } from "@shared/contracts/panel.ts";
 import type {
   WorktreeCheckRequest,
@@ -100,6 +105,18 @@ export interface RendererPluginContext {
   };
   commandPalette: {
     openQuickPick(quickPick: RendererPluginQuickPick): void;
+  };
+  /**
+   * Git 主体能力(对应 main 进程 GitService;插件按 manifest 声明的 capability 调用)。
+   * 只暴露插件常用的 3 个方法,其他按需扩展。
+   */
+  git: {
+    getStatus(cwd: string): Promise<GitStatus>;
+    getRepoInfo(cwd: string): Promise<GitRepoInfo>;
+    watch(
+      gitRoot: string,
+      listener: (event: GitChangeEvent) => void
+    ): () => void;
   };
   i18n: {
     commandDescription(commandId: string): string | undefined;

--- a/src/plugins/builtin/worktree/renderer/worktree-status-item.tsx
+++ b/src/plugins/builtin/worktree/renderer/worktree-status-item.tsx
@@ -2,7 +2,9 @@ import type {
   RendererPluginContext,
   RendererTerminalStatusItemContext,
 } from "@plugins/api/renderer.ts";
+import type { GitStatus } from "@shared/contracts/git.ts";
 import { GitBranch } from "lucide-react";
+import { useEffect, useState } from "react";
 import { openWorktreeListQuickPick } from "./worktree-list-action.ts";
 
 const PATH_SEPARATOR_RE = /[\\/]/;
@@ -28,7 +30,7 @@ function shortHead(head: string | undefined): string | undefined {
   return head ? head.slice(0, 7) : undefined;
 }
 
-function statusLabel(
+function baseLabel(
   pluginContext: RendererPluginContext,
   panelContext: RendererTerminalStatusItemContext["context"],
   worktreeName: string
@@ -45,6 +47,74 @@ function statusLabel(
   return worktreeName;
 }
 
+/**
+ * 实时 git status 钩子。订阅主体 git.watch 广播,初值用 git.getStatus 拉一次。
+ * 调用 unsubscribe 自动在 cleanup 阶段取消订阅(防止 webContents 内 listener 累积)。
+ */
+function useGitStatus(
+  pluginContext: RendererPluginContext,
+  gitRoot: string | undefined
+): GitStatus | null {
+  const [status, setStatus] = useState<GitStatus | null>(null);
+
+  useEffect(() => {
+    if (!gitRoot) {
+      setStatus(null);
+      return;
+    }
+    let cancelled = false;
+    pluginContext.git
+      .getStatus(gitRoot)
+      .then((next) => {
+        if (!cancelled) {
+          setStatus(next);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setStatus(null);
+        }
+      });
+    const unsubscribe = pluginContext.git.watch(gitRoot, () => {
+      pluginContext.git
+        .getStatus(gitRoot)
+        .then((next) => {
+          if (!cancelled) {
+            setStatus(next);
+          }
+        })
+        .catch(() => undefined);
+    });
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
+  }, [pluginContext, gitRoot]);
+
+  return status;
+}
+
+function formatAheadBehind(status: GitStatus | null): string {
+  if (!status) {
+    return "";
+  }
+  const parts: string[] = [];
+  if (status.branch.ahead > 0) {
+    parts.push(`↑${status.branch.ahead}`);
+  }
+  if (status.branch.behind > 0) {
+    parts.push(`↓${status.branch.behind}`);
+  }
+  return parts.length > 0 ? ` ${parts.join("")}` : "";
+}
+
+function formatChanges(status: GitStatus | null): string {
+  if (!status || status.files.length === 0) {
+    return "";
+  }
+  return ` ·${status.files.length}`;
+}
+
 function WorktreeStatusItem({
   context,
   cwd,
@@ -53,6 +123,7 @@ function WorktreeStatusItem({
   pluginContext: RendererPluginContext;
 }) {
   const worktreePath = context?.worktreeRoot ?? context?.gitRoot;
+  const status = useGitStatus(pluginContext, context?.gitRoot);
   if (!worktreePath) {
     return null;
   }
@@ -60,7 +131,7 @@ function WorktreeStatusItem({
   if (!worktreeName) {
     return null;
   }
-  const label = statusLabel(pluginContext, context, worktreeName);
+  const label = `${baseLabel(pluginContext, context, worktreeName)}${formatAheadBehind(status)}${formatChanges(status)}`;
   const title = [worktreeName, context?.branch, worktreePath, cwd]
     .filter(Boolean)
     .join(" · ");

--- a/src/preload/git-api.ts
+++ b/src/preload/git-api.ts
@@ -1,0 +1,227 @@
+import type {
+  PierCommand,
+  PierCommandErrorCode,
+  PierCommandResult,
+} from "@shared/contracts/commands.ts";
+import type {
+  GitBranchRef,
+  GitChangeEvent,
+  GitCommit,
+  GitDiffPatch,
+  GitDiffSummary,
+  GitRepoInfo,
+  GitStatus,
+} from "@shared/contracts/git.ts";
+import { PIER, PIER_BROADCAST } from "@shared/ipc-channels.ts";
+import { ipcRenderer } from "electron";
+
+/** diff 范围/路径选项(IPC 层用值类型;详细 zod 在 contracts/git.ts) */
+export interface GitDiffOptionsValue {
+  from?: string;
+  paths?: string[];
+  staged?: boolean;
+  to?: string;
+}
+
+export interface GitLogOptionsValue {
+  author?: string;
+  grep?: string;
+  maxCount?: number;
+  path?: string;
+  since?: string;
+  until?: string;
+}
+
+export interface GitFileContentOptionsValue {
+  path: string;
+  ref?: string;
+}
+
+export interface GitListBranchesOptionsValue {
+  kind: "all" | "local" | "remote";
+}
+
+export interface GitCommitOptionsValue {
+  allowEmpty?: boolean;
+  message: string;
+  signoff?: boolean;
+}
+
+export interface GitCreateBranchOptionsValue {
+  name: string;
+  startPoint?: string;
+}
+
+export interface GitDeleteBranchOptionsValue {
+  force?: boolean;
+  name: string;
+}
+
+export interface PierGitAPI {
+  checkoutBranch: (cwd: string, name: string) => Promise<boolean>;
+  commit: (cwd: string, options: GitCommitOptionsValue) => Promise<boolean>;
+  createBranch: (
+    cwd: string,
+    options: GitCreateBranchOptionsValue
+  ) => Promise<boolean>;
+  deleteBranch: (
+    cwd: string,
+    options: GitDeleteBranchOptionsValue
+  ) => Promise<boolean>;
+  discardChanges: (cwd: string, paths: string[]) => Promise<boolean>;
+  // 读(git:read)
+  getCommit: (cwd: string, oid: string) => Promise<GitCommit>;
+  getCommitPatch: (cwd: string, oid: string) => Promise<GitDiffPatch>;
+  getDiffPatch: (
+    cwd: string,
+    options?: GitDiffOptionsValue
+  ) => Promise<GitDiffPatch>;
+  getDiffSummary: (
+    cwd: string,
+    options?: GitDiffOptionsValue
+  ) => Promise<GitDiffSummary>;
+  getDiffText: (cwd: string, options?: GitDiffOptionsValue) => Promise<string>;
+  getFileContent: (
+    cwd: string,
+    options: GitFileContentOptionsValue
+  ) => Promise<string>;
+  getLog: (cwd: string, options?: GitLogOptionsValue) => Promise<GitCommit[]>;
+  getRepoInfo: (cwd: string) => Promise<GitRepoInfo>;
+  getStatus: (cwd: string) => Promise<GitStatus>;
+  isWorkingTreeClean: (cwd: string) => Promise<boolean>;
+  listBranches: (
+    cwd: string,
+    options: GitListBranchesOptionsValue
+  ) => Promise<GitBranchRef[]>;
+  listTags: (cwd: string) => Promise<string[]>;
+  resolveRef: (cwd: string, ref: string) => Promise<string>;
+  // 写(git:write;默认 desktop-renderer 已给,与 worktree:write 同等待遇;二次确认由插件 UI 负责)
+  stage: (cwd: string, paths: string[]) => Promise<boolean>;
+  unstage: (cwd: string, paths: string[]) => Promise<boolean>;
+  validateBranchName: (cwd: string, name: string) => Promise<boolean>;
+  /** 订阅 gitRoot 的 git 变化。返回 unsubscribe。多次 watch 同一 gitRoot 各自独立。 */
+  watch: (
+    gitRoot: string,
+    listener: (event: GitChangeEvent) => void
+  ) => () => void;
+}
+
+async function invokePierCommand<T>(command: PierCommand): Promise<T> {
+  const result = (await ipcRenderer.invoke(
+    PIER.COMMAND_EXECUTE,
+    command
+  )) as PierCommandResult;
+  if (result.ok) {
+    return result.data as T;
+  }
+  const error = new Error(result.error.message) as Error & {
+    code?: PierCommandErrorCode;
+  };
+  error.code = result.error.code;
+  throw error;
+}
+
+export const gitApi: PierGitAPI = {
+  getStatus: (cwd) =>
+    invokePierCommand<GitStatus>({ cwd, type: "git.getStatus" }),
+  getRepoInfo: (cwd) =>
+    invokePierCommand<GitRepoInfo>({ cwd, type: "git.getRepoInfo" }),
+  isWorkingTreeClean: (cwd) =>
+    invokePierCommand<boolean>({ cwd, type: "git.isWorkingTreeClean" }),
+  getDiffText: (cwd, options) =>
+    invokePierCommand<string>({
+      cwd,
+      ...(options !== undefined && { options }),
+      type: "git.getDiffText",
+    }),
+  getDiffSummary: (cwd, options) =>
+    invokePierCommand<GitDiffSummary>({
+      cwd,
+      ...(options !== undefined && { options }),
+      type: "git.getDiffSummary",
+    }),
+  getDiffPatch: (cwd, options) =>
+    invokePierCommand<GitDiffPatch>({
+      cwd,
+      ...(options !== undefined && { options }),
+      type: "git.getDiffPatch",
+    }),
+  getLog: (cwd, options) =>
+    invokePierCommand<GitCommit[]>({
+      cwd,
+      ...(options !== undefined && { options }),
+      type: "git.getLog",
+    }),
+  getCommit: (cwd, oid) =>
+    invokePierCommand<GitCommit>({ cwd, oid, type: "git.getCommit" }),
+  getCommitPatch: (cwd, oid) =>
+    invokePierCommand<GitDiffPatch>({
+      cwd,
+      oid,
+      type: "git.getCommitPatch",
+    }),
+  getFileContent: (cwd, options) =>
+    invokePierCommand<string>({
+      cwd,
+      options,
+      type: "git.getFileContent",
+    }),
+  listBranches: (cwd, options) =>
+    invokePierCommand<GitBranchRef[]>({
+      cwd,
+      options,
+      type: "git.listBranches",
+    }),
+  listTags: (cwd) => invokePierCommand<string[]>({ cwd, type: "git.listTags" }),
+  resolveRef: (cwd, ref) =>
+    invokePierCommand<string>({ cwd, ref, type: "git.resolveRef" }),
+  validateBranchName: (cwd, name) =>
+    invokePierCommand<boolean>({ cwd, name, type: "git.validateBranchName" }),
+  stage: (cwd, paths) =>
+    invokePierCommand<boolean>({ cwd, paths, type: "git.stage" }),
+  unstage: (cwd, paths) =>
+    invokePierCommand<boolean>({ cwd, paths, type: "git.unstage" }),
+  discardChanges: (cwd, paths) =>
+    invokePierCommand<boolean>({ cwd, paths, type: "git.discardChanges" }),
+  commit: (cwd, options) =>
+    invokePierCommand<boolean>({
+      ...(options.allowEmpty !== undefined && {
+        allowEmpty: options.allowEmpty,
+      }),
+      cwd,
+      message: options.message,
+      ...(options.signoff !== undefined && { signoff: options.signoff }),
+      type: "git.commit",
+    }),
+  createBranch: (cwd, options) =>
+    invokePierCommand<boolean>({
+      cwd,
+      name: options.name,
+      ...(options.startPoint !== undefined && {
+        startPoint: options.startPoint,
+      }),
+      type: "git.createBranch",
+    }),
+  deleteBranch: (cwd, options) =>
+    invokePierCommand<boolean>({
+      cwd,
+      ...(options.force !== undefined && { force: options.force }),
+      name: options.name,
+      type: "git.deleteBranch",
+    }),
+  checkoutBranch: (cwd, name) =>
+    invokePierCommand<boolean>({ cwd, name, type: "git.checkoutBranch" }),
+  watch: (gitRoot, listener) => {
+    const filtered = (_event: unknown, payload: GitChangeEvent): void => {
+      if (payload.gitRoot === gitRoot) {
+        listener(payload);
+      }
+    };
+    ipcRenderer.on(PIER_BROADCAST.GIT_CHANGED, filtered);
+    ipcRenderer.invoke(PIER.GIT_WATCH_START, gitRoot).catch(() => undefined);
+    return () => {
+      ipcRenderer.off(PIER_BROADCAST.GIT_CHANGED, filtered);
+      ipcRenderer.invoke(PIER.GIT_WATCH_STOP, gitRoot).catch(() => undefined);
+    };
+  },
+};

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -45,6 +45,7 @@ import type {
 } from "@shared/contracts/worktree.ts";
 import { PIER, PIER_BROADCAST } from "@shared/ipc-channels.ts";
 import { contextBridge, ipcRenderer } from "electron";
+import { gitApi } from "./git-api.ts";
 
 export interface WindowInfo {
   focused: boolean;
@@ -108,6 +109,8 @@ export interface PierWorktreesAPI {
   open: (request: WorktreeOpenRequest) => Promise<unknown>;
 }
 
+export type { PierGitAPI } from "./git-api.ts";
+
 /**
  * Keyboard chord forward: swift NSEvent monitor 捕获 Cmd+key → main IPC →
  * 这里 dispatch 到 renderer 侧的 listener (shell-keybindings).
@@ -156,6 +159,7 @@ export interface PierWindowAPI {
   createWindow: () => Promise<WindowCreateResult>;
   focusWindow: (windowId: string) => Promise<void>;
   getWindowContext: () => Promise<WindowContext>;
+  git: import("./git-api.ts").PierGitAPI;
   keybinding: PierKeybindingAPI;
   listWindows: () => Promise<WindowInfo[]>;
   menu: PierMenuAPI;
@@ -355,6 +359,8 @@ const worktreesApi: PierWorktreesAPI = {
     }),
 };
 
+// gitApi 实现在独立文件 ./git-api.ts(避免 preload/index.ts 超 500 行硬上限)。
+
 const menuApi: PierMenuAPI = {
   popup: (template, options) =>
     ipcRenderer.invoke("pier:menu:popup", template, options),
@@ -412,6 +418,7 @@ const api: PierWindowAPI = {
   theme: themeApi,
   workspace: workspaceApi,
   worktrees: worktreesApi,
+  git: gitApi,
 };
 
 contextBridge.exposeInMainWorld("pier", api);

--- a/src/renderer/lib/plugins/host-context.ts
+++ b/src/renderer/lib/plugins/host-context.ts
@@ -214,5 +214,10 @@ export function createRendererPluginContext(
       list: (request) => window.pier.worktrees.list(request),
       open: (request) => window.pier.worktrees.open(request),
     },
+    git: {
+      getStatus: (cwd) => window.pier.git.getStatus(cwd),
+      getRepoInfo: (cwd) => window.pier.git.getRepoInfo(cwd),
+      watch: (gitRoot, listener) => window.pier.git.watch(gitRoot, listener),
+    },
   };
 }

--- a/src/shared/contracts/commands.ts
+++ b/src/shared/contracts/commands.ts
@@ -1,4 +1,14 @@
 import { z } from "zod";
+import {
+  getFileContentOptionsSchema,
+  gitCommitOptionsSchema,
+  gitCreateBranchOptionsSchema,
+  gitDeleteBranchOptionsSchema,
+  gitDiffOptionsSchema,
+  gitLogOptionsSchema,
+  gitPathsSchema,
+  listBranchesOptionsSchema,
+} from "./git.ts";
 import { pluginInspectRequestSchema } from "./plugin.ts";
 import { projectPreferencesSchema } from "./preferences.ts";
 import {
@@ -146,6 +156,94 @@ export const pierCommandSchema = z.discriminatedUnion("type", [
   pluginInspectRequestSchema.extend({
     type: z.literal("plugin.disable"),
   }),
+  // Git 只读底座命令（renderer/插件经 IPC 调用 main 的 GitService）
+  z.object({ type: z.literal("git.getStatus"), cwd: z.string().min(1) }),
+  z.object({ type: z.literal("git.getRepoInfo"), cwd: z.string().min(1) }),
+  z.object({
+    type: z.literal("git.isWorkingTreeClean"),
+    cwd: z.string().min(1),
+  }),
+  z.object({
+    cwd: z.string().min(1),
+    options: gitDiffOptionsSchema.optional(),
+    type: z.literal("git.getDiffText"),
+  }),
+  z.object({
+    cwd: z.string().min(1),
+    options: gitDiffOptionsSchema.optional(),
+    type: z.literal("git.getDiffSummary"),
+  }),
+  z.object({
+    cwd: z.string().min(1),
+    options: gitDiffOptionsSchema.optional(),
+    type: z.literal("git.getDiffPatch"),
+  }),
+  z.object({
+    cwd: z.string().min(1),
+    options: gitLogOptionsSchema.optional(),
+    type: z.literal("git.getLog"),
+  }),
+  z.object({
+    cwd: z.string().min(1),
+    oid: z.string().min(1),
+    type: z.literal("git.getCommit"),
+  }),
+  z.object({
+    cwd: z.string().min(1),
+    oid: z.string().min(1),
+    type: z.literal("git.getCommitPatch"),
+  }),
+  z.object({
+    cwd: z.string().min(1),
+    options: getFileContentOptionsSchema,
+    type: z.literal("git.getFileContent"),
+  }),
+  z.object({
+    cwd: z.string().min(1),
+    options: listBranchesOptionsSchema,
+    type: z.literal("git.listBranches"),
+  }),
+  z.object({ type: z.literal("git.listTags"), cwd: z.string().min(1) }),
+  z.object({
+    cwd: z.string().min(1),
+    ref: z.string().min(1),
+    type: z.literal("git.resolveRef"),
+  }),
+  z.object({
+    cwd: z.string().min(1),
+    name: z.string().min(1),
+    type: z.literal("git.validateBranchName"),
+  }),
+  // Git 写命令(需 git:write capability)
+  gitPathsSchema.extend({
+    cwd: z.string().min(1),
+    type: z.literal("git.stage"),
+  }),
+  gitPathsSchema.extend({
+    cwd: z.string().min(1),
+    type: z.literal("git.unstage"),
+  }),
+  gitPathsSchema.extend({
+    cwd: z.string().min(1),
+    type: z.literal("git.discardChanges"),
+  }),
+  gitCommitOptionsSchema.extend({
+    cwd: z.string().min(1),
+    type: z.literal("git.commit"),
+  }),
+  gitCreateBranchOptionsSchema.extend({
+    cwd: z.string().min(1),
+    type: z.literal("git.createBranch"),
+  }),
+  gitDeleteBranchOptionsSchema.extend({
+    cwd: z.string().min(1),
+    type: z.literal("git.deleteBranch"),
+  }),
+  z.object({
+    cwd: z.string().min(1),
+    name: z.string().min(1),
+    type: z.literal("git.checkoutBranch"),
+  }),
 ]);
 
 export type PierCommand = z.infer<typeof pierCommandSchema>;
@@ -172,6 +270,11 @@ export type PierCommandErrorCode =
   | "platform_unavailable"
   | "unsupported"
   | "internal_error"
+  /**
+   * git CLI 退出非 0 时的统一错误码;message 含 git 返回的 stderr 摘要,
+   * 插件可据此分类("already exists"、"not fully merged"、"dirty worktree" 等)。
+   */
+  | "git_error"
   | WorktreeOperationErrorReason;
 
 export type PierCommandResult =

--- a/src/shared/contracts/git.ts
+++ b/src/shared/contracts/git.ts
@@ -1,0 +1,166 @@
+import { z } from "zod";
+
+/**
+ * 单个变更文件的状态。
+ * index/worktree 为 git porcelain 的 XY 状态码（如 "M"、"A"、"?"、"."）。
+ * origPath 仅在重命名/复制时存在（指向旧路径）。
+ */
+export const gitFileStatusSchema = z.object({
+  index: z.string(),
+  origPath: z.string().nullable(),
+  path: z.string(),
+  worktree: z.string(),
+});
+export type GitFileStatus = z.infer<typeof gitFileStatusSchema>;
+
+/** 当前分支与上游的领先/落后信息。detached HEAD 时 branch 为 null。 */
+export const gitBranchInfoSchema = z.object({
+  ahead: z.number(),
+  behind: z.number(),
+  branch: z.string().nullable(),
+  upstream: z.string().nullable(),
+});
+export type GitBranchInfo = z.infer<typeof gitBranchInfoSchema>;
+
+/** 工作区整体状态：分支信息 + 变更文件列表。 */
+export const gitStatusSchema = z.object({
+  branch: gitBranchInfoSchema,
+  files: z.array(gitFileStatusSchema),
+});
+export type GitStatus = z.infer<typeof gitStatusSchema>;
+
+/** 单文件的增删统计。binary 文件 insertions/deletions 记为 0。 */
+export const gitDiffStatSchema = z.object({
+  binary: z.boolean(),
+  deletions: z.number(),
+  insertions: z.number(),
+  path: z.string(),
+});
+export type GitDiffStat = z.infer<typeof gitDiffStatSchema>;
+
+/** 一组变更的增删汇总。 */
+export const gitDiffSummarySchema = z.object({
+  changed: z.number(),
+  deletions: z.number(),
+  files: z.array(gitDiffStatSchema),
+  insertions: z.number(),
+});
+export type GitDiffSummary = z.infer<typeof gitDiffSummarySchema>;
+
+/** 一条提交记录（精简字段）。 */
+export const gitCommitSchema = z.object({
+  author: z.string(),
+  date: z.string(),
+  hash: z.string(),
+  message: z.string(),
+});
+export type GitCommit = z.infer<typeof gitCommitSchema>;
+
+/** 仓库元信息。空仓库 headOid 为 null；origin/HEAD 缺失时 defaultBranch 为 null。 */
+export const gitRepoInfoSchema = z.object({
+  defaultBranch: z.string().nullable(),
+  gitCommonDir: z.string(),
+  gitRoot: z.string(),
+  headOid: z.string().nullable(),
+  isBare: z.boolean(),
+  isWorktree: z.boolean(),
+});
+export type GitRepoInfo = z.infer<typeof gitRepoInfoSchema>;
+
+/** 单个分支引用。kind 区分 local/remote。 */
+export const gitBranchRefSchema = z.object({
+  isCurrent: z.boolean(),
+  kind: z.enum(["local", "remote"]),
+  lastCommit: z.string(),
+  name: z.string(),
+  upstream: z.string().nullable(),
+});
+export type GitBranchRef = z.infer<typeof gitBranchRefSchema>;
+
+/** unified diff 中单行：context/add/del 三种 kind 之一。 */
+export const gitDiffLineSchema = z.object({
+  kind: z.enum(["context", "add", "del"]),
+  text: z.string(),
+});
+export type GitDiffLine = z.infer<typeof gitDiffLineSchema>;
+
+/** 一个 hunk：@@ -oldStart,oldLines +newStart,newLines @@ 起头，跟若干 lines。 */
+export const gitDiffHunkSchema = z.object({
+  lines: z.array(gitDiffLineSchema),
+  newLines: z.number(),
+  newStart: z.number(),
+  oldLines: z.number(),
+  oldStart: z.number(),
+});
+export type GitDiffHunk = z.infer<typeof gitDiffHunkSchema>;
+
+/** 单文件 patch。binary 文件无 hunks。 */
+export const gitDiffFilePatchSchema = z.object({
+  binary: z.boolean(),
+  hunks: z.array(gitDiffHunkSchema),
+  oldPath: z.string().nullable(),
+  path: z.string(),
+});
+export type GitDiffFilePatch = z.infer<typeof gitDiffFilePatchSchema>;
+
+/** 完整 patch：多文件 file patches 的集合。 */
+export const gitDiffPatchSchema = z.object({
+  files: z.array(gitDiffFilePatchSchema),
+});
+export type GitDiffPatch = z.infer<typeof gitDiffPatchSchema>;
+
+/** diff 选项的 IPC schema（main 收到 renderer 命令时校验）。 */
+export const gitDiffOptionsSchema = z.object({
+  from: z.string().optional(),
+  paths: z.array(z.string()).optional(),
+  staged: z.boolean().optional(),
+  to: z.string().optional(),
+});
+
+export const gitLogOptionsSchema = z.object({
+  author: z.string().optional(),
+  grep: z.string().optional(),
+  maxCount: z.number().int().positive().optional(),
+  path: z.string().optional(),
+  since: z.string().optional(),
+  until: z.string().optional(),
+});
+
+export const listBranchesOptionsSchema = z.object({
+  kind: z.enum(["all", "local", "remote"]),
+});
+
+export const getFileContentOptionsSchema = z.object({
+  path: z.string(),
+  ref: z.string().optional(),
+});
+
+/** paths 必须非空数组,避免 `git add` / `git restore` 无意中作用于所有文件。 */
+export const gitPathsSchema = z.object({
+  paths: z.array(z.string().min(1)).min(1),
+});
+
+export const gitCommitOptionsSchema = z.object({
+  allowEmpty: z.boolean().optional(),
+  message: z.string().min(1),
+  signoff: z.boolean().optional(),
+});
+
+export const gitCreateBranchOptionsSchema = z.object({
+  name: z.string().min(1),
+  startPoint: z.string().min(1).optional(),
+});
+
+export const gitDeleteBranchOptionsSchema = z.object({
+  force: z.boolean().optional(),
+  name: z.string().min(1),
+});
+
+/** 变更监听广播事件。changeKind 区分工作区/HEAD/二者同时变化。 */
+export const gitChangeKindSchema = z.enum(["worktree", "head", "both"]);
+export const gitChangeEventSchema = z.object({
+  changeKind: gitChangeKindSchema,
+  gitRoot: z.string(),
+});
+export type GitChangeKind = z.infer<typeof gitChangeKindSchema>;
+export type GitChangeEvent = z.infer<typeof gitChangeEventSchema>;

--- a/src/shared/contracts/permissions.ts
+++ b/src/shared/contracts/permissions.ts
@@ -30,6 +30,7 @@ export const pierCapabilitySchema = z.enum([
   "command:register",
   "panel:register",
   "git:read",
+  "git:write",
   "file:read",
   "transcript:read",
   "profile:read",
@@ -75,6 +76,9 @@ export const DEFAULT_CAPABILITIES_BY_CLIENT_KIND: Record<
     "terminal:control",
     "plugin:read",
     "plugin:write",
+    // 与 worktree:write 同等待遇:主体提供能力,二次确认由插件 UI 负责
+    "git:read",
+    "git:write",
   ],
   "cli-local": [
     "app:read",
@@ -90,6 +94,7 @@ export const DEFAULT_CAPABILITIES_BY_CLIENT_KIND: Record<
     "terminal:read",
     "terminal:control",
     "plugin:read",
+    "git:read",
   ],
   "mcp-local": [
     "app:read",
@@ -102,6 +107,7 @@ export const DEFAULT_CAPABILITIES_BY_CLIENT_KIND: Record<
     "panel:control",
     "terminal:read",
     "terminal:control",
+    "git:read",
   ],
   "mobile-paired": [
     "app:read",

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -6,6 +6,9 @@
 export const PIER = {
   // command router facade
   COMMAND_EXECUTE: "pier://command:execute",
+  // git watch (订阅/退订;事件本身经 PIER_BROADCAST.GIT_CHANGED 广播)
+  GIT_WATCH_START: "pier://git:watch-start",
+  GIT_WATCH_STOP: "pier://git:watch-stop",
   // window
   WINDOW_CLOSE_CURRENT: "pier://window:close-current",
   WINDOW_CLOSE: "pier://window:close",
@@ -32,6 +35,8 @@ export const PIER_BROADCAST = {
   WINDOW_LAYOUT_PULSE: "pier:window:layout-pulse",
   // macOS 原生全屏进出 (main → renderer, payload { isFullscreen }).
   WINDOW_FULLSCREEN_CHANGED: "pier://window:fullscreen-changed",
+  // git 变更广播 (main → renderer, payload GitChangeEvent).
+  GIT_CHANGED: "pier://git:changed",
 } as const;
 
 export type PierCommand = (typeof PIER)[keyof typeof PIER];

--- a/tests/integration/git-ipc-e2e.test.ts
+++ b/tests/integration/git-ipc-e2e.test.ts
@@ -1,0 +1,206 @@
+/**
+ * IPC 链路端到端集成测试:验证 renderer → command-router → GitService 真链路
+ * (覆盖 git-service-e2e 直接调 service 漏掉的两层:
+ *  1) RENDERER_FACADE_COMMAND_TYPES 白名单接入
+ *  2) authorizeCommand 对 git:read/git:write capability 的守门)
+ *
+ * 直接构造 PierCoreServices + createCommandRouter,跳过 ipcMain 但走全部 router 逻辑。
+ */
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createClientRegistry } from "@main/app-core/client-registry.ts";
+import {
+  createCommandRouter,
+  type PierCoreServices,
+} from "@main/app-core/command-router.ts";
+import { execGit } from "@main/services/git-exec.ts";
+import { createGitService } from "@main/services/git-service.ts";
+import { createGitWatchService } from "@main/services/git-watch-service.ts";
+import { createWorktreeService } from "@main/services/worktree-service.ts";
+import type { PierCommand } from "@shared/contracts/commands.ts";
+import {
+  DEFAULT_CAPABILITIES_BY_CLIENT_KIND,
+  type PierCapability,
+  type PierClientKind,
+} from "@shared/contracts/permissions.ts";
+import { afterEach, describe, expect, it } from "vitest";
+
+const NOTHING_TO_COMMIT_RE = /clean|nothing/;
+const SAFE_BRANCH_NAME_RE = /must not start with/;
+
+const tempDirs: string[] = [];
+
+async function makeRepo(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "pier-git-ipc-"));
+  tempDirs.push(dir);
+  await execGit(["init", "-b", "main"], { cwd: dir });
+  await execGit(["config", "user.email", "t@p.local"], { cwd: dir });
+  await execGit(["config", "user.name", "t"], { cwd: dir });
+  await execGit(["config", "commit.gpgsign", "false"], { cwd: dir });
+  await writeFile(join(dir, "a.txt"), "x\n");
+  await execGit(["add", "a.txt"], { cwd: dir });
+  await execGit(["commit", "-m", "init"], { cwd: dir, timeoutMs: 30_000 });
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0).map((d) => rm(d, { force: true, recursive: true }))
+  );
+});
+
+function makeServices(): PierCoreServices {
+  // 只填 router 调 git 命令时实际会用到的 services;其他用 throw 占位避免误用
+  const trap = new Proxy(
+    {},
+    { get: () => () => Promise.reject(new Error("not stubbed")) }
+  );
+  return {
+    commandPaletteMru: trap as never,
+    git: createGitService(),
+    gitWatch: createGitWatchService(),
+    panelContexts: trap as never,
+    plugins: trap as never,
+    preferences: trap as never,
+    processEnvironment: trap as never,
+    rendererCommand: trap as never,
+    tasks: trap as never,
+    terminalLaunches: trap as never,
+    terminalProfiles: trap as never,
+    window: trap as never,
+    workspace: trap as never,
+    worktrees: createWorktreeService(),
+  };
+}
+
+function clientOf(kind: PierClientKind, extra: PierCapability[] = []) {
+  const now = Date.now();
+  return {
+    capabilities: [...DEFAULT_CAPABILITIES_BY_CLIENT_KIND[kind], ...extra],
+    createdAt: now,
+    id: `${kind}-1`,
+    kind,
+    lastSeenAt: now,
+  };
+}
+
+function envelope(clientId: string, command: PierCommand) {
+  return {
+    clientId,
+    command,
+    protocolVersion: 1 as const,
+    requestId: "req-1",
+  };
+}
+
+describe("git IPC 端到端(命令路由 + capability 守门)", () => {
+  it("desktop-renderer 默认拥有 git:read,能调 git.getStatus 拿到真 repo 状态", async () => {
+    const repo = await makeRepo();
+    const clients = createClientRegistry();
+    clients.register(clientOf("desktop-renderer"));
+    const router = createCommandRouter({ clients, services: makeServices() });
+
+    const result = await router.execute(
+      envelope("desktop-renderer-1", {
+        cwd: repo,
+        type: "git.getStatus",
+      })
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const status = result.data as { branch: { branch: string | null } };
+      expect(status.branch.branch).toBe("main");
+    }
+  });
+
+  it("desktop-renderer 默认拥有 git:write,能调 git.stage + git.commit", async () => {
+    const repo = await makeRepo();
+    await writeFile(join(repo, "b.txt"), "y\n");
+    const clients = createClientRegistry();
+    clients.register(clientOf("desktop-renderer"));
+    const router = createCommandRouter({ clients, services: makeServices() });
+
+    const stageResult = await router.execute(
+      envelope("desktop-renderer-1", {
+        cwd: repo,
+        paths: ["b.txt"],
+        type: "git.stage",
+      })
+    );
+    const commitResult = await router.execute(
+      envelope("desktop-renderer-1", {
+        cwd: repo,
+        message: "feat: b",
+        type: "git.commit",
+      })
+    );
+
+    expect(stageResult.ok).toBe(true);
+    expect(commitResult.ok).toBe(true);
+  });
+
+  it("mcp-local 只有 git:read,git.commit 被 permission_denied 拦截", async () => {
+    const repo = await makeRepo();
+    const clients = createClientRegistry();
+    clients.register(clientOf("mcp-local"));
+    const router = createCommandRouter({ clients, services: makeServices() });
+
+    const result = await router.execute(
+      envelope("mcp-local-1", {
+        cwd: repo,
+        message: "x",
+        type: "git.commit",
+      })
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("permission_denied");
+    }
+  });
+
+  it("git CLI 失败(空仓库无变更 commit)经 GitExecError → git_error 错误码 + stderr 透传", async () => {
+    const repo = await makeRepo();
+    const clients = createClientRegistry();
+    clients.register(clientOf("desktop-renderer"));
+    const router = createCommandRouter({ clients, services: makeServices() });
+
+    const result = await router.execute(
+      envelope("desktop-renderer-1", {
+        cwd: repo,
+        message: "empty",
+        type: "git.commit",
+      })
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("git_error");
+      // stderr 摘要应被拼到 message(git 会输出 "nothing to commit" 或 "working tree clean")
+      expect(result.error.message.toLowerCase()).toMatch(NOTHING_TO_COMMIT_RE);
+    }
+  });
+
+  it("分支名以 - 开头被 service 层拒绝(防当 git flag)", async () => {
+    const repo = await makeRepo();
+    const clients = createClientRegistry();
+    clients.register(clientOf("desktop-renderer"));
+    const router = createCommandRouter({ clients, services: makeServices() });
+
+    const result = await router.execute(
+      envelope("desktop-renderer-1", {
+        cwd: repo,
+        name: "--evil",
+        type: "git.createBranch",
+      })
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("internal_error");
+      expect(result.error.message).toMatch(SAFE_BRANCH_NAME_RE);
+    }
+  });
+});

--- a/tests/integration/git-service-e2e.test.ts
+++ b/tests/integration/git-service-e2e.test.ts
@@ -1,0 +1,217 @@
+/**
+ * 端到端集成测试:在真临时 git 仓库里跑 createGitService() 和
+ * createGitWatchService() 的默认配置(真 spawn / 真 fs.watch),
+ * 验证「单元测试只测 args 拼接」之外的运行时行为。
+ *
+ * 单测的盲区(被这层覆盖):
+ * - 写操作的 git CLI flag 拼对了但语义错(`-d`/`-D`/`--cached` 等)
+ * - 解析器对真实 git 输出格式的兼容(版本差异/平台差异)
+ * - watch 真 fs event → debounce → listener 的端到端链路
+ */
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execGit } from "@main/services/git-exec.ts";
+import { createGitService } from "@main/services/git-service.ts";
+import { createGitWatchService } from "@main/services/git-watch-service.ts";
+import { afterEach, describe, expect, it } from "vitest";
+
+const OID_RE = /^[0-9a-f]{40}$/;
+
+const tempDirs: string[] = [];
+
+async function makeRepo(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "pier-git-e2e-"));
+  tempDirs.push(dir);
+  await execGit(["init", "-b", "main"], { cwd: dir });
+  await execGit(["config", "user.email", "test@pier.local"], { cwd: dir });
+  await execGit(["config", "user.name", "Pier Test"], { cwd: dir });
+  await execGit(["config", "commit.gpgsign", "false"], { cwd: dir });
+  await writeFile(join(dir, "base.txt"), "hello\nworld\n");
+  await execGit(["add", "base.txt"], { cwd: dir });
+  await execGit(["commit", "-m", "initial"], { cwd: dir, timeoutMs: 30_000 });
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0).map((dir) => rm(dir, { force: true, recursive: true }))
+  );
+});
+
+describe("GitService 端到端(真临时仓库)", () => {
+  it("getRepoInfo 反映真 HEAD/gitRoot/isWorktree", async () => {
+    const repo = await makeRepo();
+    const git = createGitService();
+
+    const info = await git.getRepoInfo(repo);
+
+    expect(info.headOid).toMatch(OID_RE);
+    expect(info.isBare).toBe(false);
+    expect(info.isWorktree).toBe(false);
+    expect(info.gitRoot).toContain(tempDirs.at(-1) ?? "");
+  });
+
+  it("getStatus 经历 modify→stage→unstage→discard 各阶段反映正确", async () => {
+    const repo = await makeRepo();
+    const git = createGitService();
+
+    expect(await git.isWorkingTreeClean(repo)).toBe(true);
+
+    // modify
+    await writeFile(join(repo, "base.txt"), "modified content\n");
+    const afterModify = await git.getStatus(repo);
+    expect(afterModify.files.some((f) => f.path === "base.txt")).toBe(true);
+    expect(afterModify.files[0]?.worktree).toBe("M");
+
+    // stage
+    await git.stage(repo, { paths: ["base.txt"] });
+    const afterStage = await git.getStatus(repo);
+    expect(afterStage.files[0]?.index).toBe("M");
+
+    // unstage
+    await git.unstage(repo, { paths: ["base.txt"] });
+    const afterUnstage = await git.getStatus(repo);
+    expect(afterUnstage.files[0]?.worktree).toBe("M");
+    expect(afterUnstage.files[0]?.index).toBe(".");
+
+    // discard
+    await git.discardChanges(repo, { paths: ["base.txt"] });
+    expect(await git.isWorkingTreeClean(repo)).toBe(true);
+  });
+
+  it("stage + commit 真的产生新 commit,getLog 看见", async () => {
+    const repo = await makeRepo();
+    const git = createGitService();
+
+    await writeFile(join(repo, "feature.txt"), "new file\n");
+    await git.stage(repo, { paths: ["feature.txt"] });
+    await git.commit(repo, { message: "feat: add feature.txt" });
+
+    const log = await git.getLog(repo, { maxCount: 5 });
+    expect(log[0]?.message).toBe("feat: add feature.txt");
+    expect(log[0]?.author).toBe("Pier Test");
+    expect(log).toHaveLength(2);
+  });
+
+  it("getDiffSummary 反映真实增删行数;getDiffPatch 解析真实 hunk", async () => {
+    const repo = await makeRepo();
+    const git = createGitService();
+    await writeFile(join(repo, "base.txt"), "hello\nworld\nadded\n");
+
+    const summary = await git.getDiffSummary(repo);
+    expect(summary.insertions).toBe(1);
+    expect(summary.deletions).toBe(0);
+    expect(summary.files[0]?.path).toBe("base.txt");
+
+    const patch = await git.getDiffPatch(repo);
+    expect(patch.files[0]?.path).toBe("base.txt");
+    expect(patch.files[0]?.hunks.length).toBeGreaterThan(0);
+    const addLines = patch.files[0]?.hunks[0]?.lines.filter(
+      (l) => l.kind === "add"
+    );
+    expect(addLines?.[0]?.text).toBe("added");
+  });
+
+  it("createBranch + listBranches + checkoutBranch + deleteBranch 全流程", async () => {
+    const repo = await makeRepo();
+    const git = createGitService();
+
+    await git.createBranch(repo, { name: "feature/x" });
+    const branchesAfterCreate = await git.listBranches(repo, { kind: "local" });
+    expect(branchesAfterCreate.map((b) => b.name).sort()).toEqual([
+      "feature/x",
+      "main",
+    ]);
+
+    await git.checkoutBranch(repo, "feature/x");
+    const onFeature = await git.listBranches(repo, { kind: "local" });
+    expect(onFeature.find((b) => b.name === "feature/x")?.isCurrent).toBe(true);
+
+    await git.checkoutBranch(repo, "main");
+    await git.deleteBranch(repo, { name: "feature/x" });
+    const branchesAfterDelete = await git.listBranches(repo, { kind: "local" });
+    expect(branchesAfterDelete.map((b) => b.name)).toEqual(["main"]);
+  });
+
+  it("validateBranchName 对合法/非法名返回正确布尔值", async () => {
+    const repo = await makeRepo();
+    const git = createGitService();
+
+    expect(await git.validateBranchName(repo, "feature/x")).toBe(true);
+    expect(await git.validateBranchName(repo, "..bad")).toBe(false);
+  });
+
+  it("resolveRef 对 HEAD 解析为 40 位 oid", async () => {
+    const repo = await makeRepo();
+    const git = createGitService();
+
+    const oid = await git.resolveRef(repo, "HEAD");
+    expect(oid).toMatch(OID_RE);
+  });
+
+  it("getFileContent 在 HEAD: 路径拿到提交时的内容", async () => {
+    const repo = await makeRepo();
+    const git = createGitService();
+    // 把工作区文件改了,但 HEAD: 应仍是原始内容
+    await writeFile(join(repo, "base.txt"), "WORKTREE CHANGED\n");
+
+    const content = await git.getFileContent(repo, {
+      path: "base.txt",
+      ref: "HEAD",
+    });
+    expect(content).toBe("hello\nworld\n");
+  });
+
+  it("getCommit + getCommitPatch 对真 oid 返回提交详情和 patch", async () => {
+    const repo = await makeRepo();
+    const git = createGitService();
+    const headOid = await git.resolveRef(repo, "HEAD");
+
+    const commit = await git.getCommit(repo, headOid);
+    expect(commit.hash).toBe(headOid);
+    expect(commit.message).toBe("initial");
+
+    const patch = await git.getCommitPatch(repo, headOid);
+    expect(patch.files[0]?.path).toBe("base.txt");
+  });
+
+  it("listTags 在 git tag 后看到该 tag", async () => {
+    const repo = await makeRepo();
+    const git = createGitService();
+    await execGit(["tag", "v0.1.0"], { cwd: repo });
+
+    const tags = await git.listTags(repo);
+    expect(tags).toContain("v0.1.0");
+  });
+});
+
+describe("GitWatchService 端到端(真 fs.watch)", () => {
+  it("修改工作区文件,debounce 后真触发 listener", async () => {
+    const repo = await makeRepo();
+    const watchService = createGitWatchService({
+      debounceMs: 50,
+      pollMs: 60_000, // 拉长兜底,避免干扰本测试
+    });
+    const events: Array<{ changeKind: string; gitRoot: string }> = [];
+
+    try {
+      watchService.watch(repo, (event) => events.push(event));
+
+      // 等基线签名采集完成(初始 force=true 不触发 listener)
+      await new Promise((resolveFn) => setTimeout(resolveFn, 100));
+
+      // 真改文件触发 fs.watch
+      await writeFile(join(repo, "base.txt"), "watcher should see this\n");
+
+      // 等 fs event + debounce + 重算签名
+      await new Promise((resolveFn) => setTimeout(resolveFn, 500));
+
+      expect(events.length).toBeGreaterThanOrEqual(1);
+      expect(events[0]?.gitRoot).toBe(repo);
+      expect(events[0]?.changeKind).toBe("worktree");
+    } finally {
+      await watchService.dispose();
+    }
+  });
+});

--- a/tests/unit/app-core/command-router.test.ts
+++ b/tests/unit/app-core/command-router.test.ts
@@ -1,6 +1,8 @@
 import { createClientRegistry } from "@main/app-core/client-registry.ts";
 import type { PierCoreServices } from "@main/app-core/command-router.ts";
 import { createCommandRouter } from "@main/app-core/command-router.ts";
+import { createGitService } from "@main/services/git-service.ts";
+import { createGitWatchService } from "@main/services/git-watch-service.ts";
 import { PluginServiceError } from "@main/services/plugin-service.ts";
 import type {
   ProcessEnvironmentResolveRequest,
@@ -317,6 +319,8 @@ function services(
         worktrees: [],
       }),
     },
+    git: createGitService(),
+    gitWatch: createGitWatchService(),
   };
 }
 

--- a/tests/unit/app-core/local-control.test.ts
+++ b/tests/unit/app-core/local-control.test.ts
@@ -13,6 +13,8 @@ import {
   createCommandRouter,
   type PierCoreServices,
 } from "@main/app-core/command-router.ts";
+import { createGitService } from "@main/services/git-service.ts";
+import { createGitWatchService } from "@main/services/git-watch-service.ts";
 import { createTaskService } from "@main/services/tasks/task-service.ts";
 import { createWorktreeService } from "@main/services/worktree-service.ts";
 import {
@@ -207,6 +209,8 @@ function cliClientServices(): PierCoreServices {
       saveLayout: async () => undefined,
     },
     worktrees: createWorktreeService(),
+    git: createGitService(),
+    gitWatch: createGitWatchService(),
   };
 }
 

--- a/tests/unit/main/git-exec.test.ts
+++ b/tests/unit/main/git-exec.test.ts
@@ -1,0 +1,144 @@
+import { EventEmitter } from "node:events";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  createExecGit,
+  execGit,
+  GitExecError,
+} from "@main/services/git-exec.ts";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Minimal ChildProcess 替身:够 git-exec 状态机消费的子集
+ * (stdout/stderr 是 Readable-like EventEmitter,kill 记录信号序列)
+ */
+class FakeStream extends EventEmitter {}
+class FakeChild extends EventEmitter {
+  stdout = new FakeStream();
+  stderr = new FakeStream();
+  killed: string[] = [];
+  kill(signal: NodeJS.Signals = "SIGTERM"): boolean {
+    this.killed.push(signal);
+    return true;
+  }
+}
+
+const GIT_VERSION_RE = /^git version /;
+const NOT_A_GIT_REPO_RE = /not a git repository/i;
+const SIZE_LIMIT_RE = /上限|size/i;
+const EPIPE_STDOUT_RE = /EPIPE from stdout/;
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(prefix: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0).map((dir) => rm(dir, { force: true, recursive: true }))
+  );
+});
+
+describe("execGit", () => {
+  it("成功执行 git --version 返回 stdout", async () => {
+    const dir = await makeTempDir("pier-git-exec-version-");
+
+    const stdout = await execGit(["--version"], { cwd: dir });
+
+    expect(stdout).toMatch(GIT_VERSION_RE);
+  });
+
+  it("在非 git 目录跑 git status 抛 GitExecError 含 stderr 与非零 exitCode", async () => {
+    const dir = await makeTempDir("pier-git-exec-non-repo-");
+
+    const error = await execGit(["status"], { cwd: dir }).catch(
+      (err: unknown) => err
+    );
+
+    expect(error).toBeInstanceOf(GitExecError);
+    if (error instanceof GitExecError) {
+      expect(error.exitCode).not.toBe(0);
+      expect(error.stderr).toMatch(NOT_A_GIT_REPO_RE);
+    }
+  });
+
+  it("cwd 生效：在已 init 的临时仓库里 git rev-parse --is-inside-work-tree 返回 true", async () => {
+    const repo = await makeTempDir("pier-git-exec-repo-");
+    await execGit(["init", "-b", "main"], { cwd: repo });
+
+    const stdout = await execGit(["rev-parse", "--is-inside-work-tree"], {
+      cwd: repo,
+    });
+
+    expect(stdout.trim()).toBe("true");
+  });
+
+  // SIGKILL fallback:SIGTERM 后 SIGKILL_GRACE_MS 未关闭强制升级 SIGKILL
+  it("SIGTERM 后 1.5s 未关闭则升级 SIGKILL", async () => {
+    vi.useFakeTimers();
+    const fakeChild = new FakeChild();
+    const fakeSpawn = (() =>
+      fakeChild) as unknown as typeof import("node:child_process").spawn;
+    const exec = createExecGit({ spawn: fakeSpawn });
+
+    const pending = exec(["status"], {
+      cwd: "/tmp/fake",
+      timeoutMs: 100,
+    }).catch(() => {
+      // 我们只关心 kill 顺序,catch 防 unhandled rejection
+    });
+
+    // 推进到 timeout 触发 SIGTERM
+    await vi.advanceTimersByTimeAsync(100);
+    expect(fakeChild.killed).toEqual(["SIGTERM"]);
+
+    // 再推进 1.5s 触发 SIGKILL fallback
+    await vi.advanceTimersByTimeAsync(1500);
+    expect(fakeChild.killed).toEqual(["SIGTERM", "SIGKILL"]);
+
+    // 让 child 真正 close 以便 promise 收尾
+    fakeChild.emit("close", null);
+    await pending;
+    vi.useRealTimers();
+  });
+
+  // stream error 累加:GitExecError.message 应携带 stream error 诊断信息(不再 noop 吞)
+  it("stdout/stderr 的 error 事件被累加到 GitExecError.message", async () => {
+    const fakeChild = new FakeChild();
+    const fakeSpawn = (() =>
+      fakeChild) as unknown as typeof import("node:child_process").spawn;
+    const exec = createExecGit({ spawn: fakeSpawn });
+
+    const pending = exec(["status"], { cwd: "/tmp/fake" });
+
+    queueMicrotask(() => {
+      fakeChild.stdout.emit("error", new Error("EPIPE from stdout"));
+      fakeChild.emit("close", 1);
+    });
+
+    const error = await pending.catch((err: unknown) => err);
+    expect(error).toBeInstanceOf(GitExecError);
+    if (error instanceof GitExecError) {
+      expect(error.message).toMatch(EPIPE_STDOUT_RE);
+    }
+  });
+
+  // C4 验证：maxOutputBytes 可注入；按字节累加（非 string.length）触发 size-limit
+  it("超过 maxOutputBytes 抛 size-limit GitExecError", async () => {
+    const dir = await makeTempDir("pier-git-exec-size-");
+
+    const error = await execGit(["--version"], {
+      cwd: dir,
+      maxOutputBytes: 1,
+    }).catch((err: unknown) => err);
+
+    expect(error).toBeInstanceOf(GitExecError);
+    if (error instanceof GitExecError) {
+      expect(error.message).toMatch(SIZE_LIMIT_RE);
+    }
+  });
+});

--- a/tests/unit/main/git-service.test.ts
+++ b/tests/unit/main/git-service.test.ts
@@ -1,0 +1,847 @@
+import {
+  parseGitBranchRefs,
+  parseGitLog,
+  parseGitNumstat,
+  parseGitStatus,
+  parseUnifiedDiff,
+} from "@main/services/git-parsers.ts";
+import { createGitService } from "@main/services/git-service.ts";
+import { describe, expect, it } from "vitest";
+
+describe("parseGitStatus", () => {
+  it("解析 branch header 的分支名与 ahead/behind", () => {
+    const output = `${[
+      "# branch.oid abc123",
+      "# branch.head main",
+      "# branch.upstream origin/main",
+      "# branch.ab +2 -1",
+    ].join("\0")}\0`;
+
+    const result = parseGitStatus(output);
+
+    expect(result.branch).toEqual({
+      ahead: 2,
+      behind: 1,
+      branch: "main",
+      upstream: "origin/main",
+    });
+    expect(result.files).toEqual([]);
+  });
+
+  it("无上游分支时 ahead/behind 为 0、upstream 为 null", () => {
+    const output = `${["# branch.head main"].join("\0")}\0`;
+
+    expect(parseGitStatus(output).branch).toEqual({
+      ahead: 0,
+      behind: 0,
+      branch: "main",
+      upstream: null,
+    });
+  });
+
+  it("detached HEAD 时 branch 为 null", () => {
+    const output = "# branch.head (detached)\0";
+
+    expect(parseGitStatus(output).branch.branch).toBeNull();
+  });
+
+  it("解析 ordinary 变更文件的 XY 状态码与路径", () => {
+    const output = `${[
+      "# branch.head main",
+      "1 .M N... 100644 100644 100644 aaa bbb src/foo.ts",
+    ].join("\0")}\0`;
+
+    expect(parseGitStatus(output).files).toEqual([
+      { index: ".", origPath: null, path: "src/foo.ts", worktree: "M" },
+    ]);
+  });
+
+  it("解析 untracked 文件", () => {
+    const output = `${["# branch.head main", "? new file.ts"].join("\0")}\0`;
+
+    expect(parseGitStatus(output).files).toEqual([
+      { index: "?", origPath: null, path: "new file.ts", worktree: "?" },
+    ]);
+  });
+
+  it("解析 renamed 文件(含 origPath)", () => {
+    const output = `${[
+      "# branch.head main",
+      "2 R. N... 100644 100644 100644 aaa bbb R100 newname.ts",
+      "oldname.ts",
+    ].join("\0")}\0`;
+
+    expect(parseGitStatus(output).files).toEqual([
+      { index: "R", origPath: "oldname.ts", path: "newname.ts", worktree: "." },
+    ]);
+  });
+
+  // C1: porcelain v2 "u" unmerged 条目（冲突文件）
+  // 格式: u <XY> <sub> <m1> <m2> <m3> <mW> <h1> <h2> <h3> <path>
+  it("解析 unmerged(冲突)文件", () => {
+    const output = `${[
+      "# branch.head main",
+      "u UU N... 100644 100644 100644 100644 oid1 oid2 oid3 src/conflict.ts",
+    ].join("\0")}\0`;
+
+    expect(parseGitStatus(output).files).toEqual([
+      { index: "U", origPath: null, path: "src/conflict.ts", worktree: "U" },
+    ]);
+  });
+});
+
+describe("parseGitLog", () => {
+  it("解析多条 log 记录的 hash/author/date/message", () => {
+    const output = `${[
+      ["abc123", "Alice", "2026-06-01T10:00:00+08:00", "feat: 初始化"].join(
+        "\x1f"
+      ),
+      ["def456", "Bob", "2026-06-02T11:00:00+08:00", "fix: 修复换行"].join(
+        "\x1f"
+      ),
+    ].join("\x1e")}\x1e`;
+
+    expect(parseGitLog(output)).toEqual([
+      {
+        author: "Alice",
+        date: "2026-06-01T10:00:00+08:00",
+        hash: "abc123",
+        message: "feat: 初始化",
+      },
+      {
+        author: "Bob",
+        date: "2026-06-02T11:00:00+08:00",
+        hash: "def456",
+        message: "fix: 修复换行",
+      },
+    ]);
+  });
+
+  it("空输出返回空数组", () => {
+    expect(parseGitLog("")).toEqual([]);
+  });
+});
+
+describe("parseGitNumstat", () => {
+  it("解析普通文件的增删行数", () => {
+    const output = `${["10\t2\tsrc/foo.ts"].join("\0")}\0`;
+
+    expect(parseGitNumstat(output)).toEqual([
+      { binary: false, deletions: 2, insertions: 10, path: "src/foo.ts" },
+    ]);
+  });
+
+  it("binary 文件 insertions/deletions 记为 0、binary 为 true", () => {
+    const output = "-\t-\timg.png\0";
+
+    expect(parseGitNumstat(output)).toEqual([
+      { binary: true, deletions: 0, insertions: 0, path: "img.png" },
+    ]);
+  });
+
+  // C2: 路径含 tab 时不应被截断（-z 只保 NUL 分隔，不保 path 无 tab）
+  it("路径含 tab 字符不被截断", () => {
+    const output = "10\t2\tpath/with\ttab.ts\0";
+
+    expect(parseGitNumstat(output)).toEqual([
+      {
+        binary: false,
+        deletions: 2,
+        insertions: 10,
+        path: "path/with\ttab.ts",
+      },
+    ]);
+  });
+});
+
+describe("parseUnifiedDiff", () => {
+  it("解析单文件单 hunk 的 add/del/context 行", () => {
+    const text = [
+      "diff --git a/src/a.ts b/src/a.ts",
+      "index abc..def 100644",
+      "--- a/src/a.ts",
+      "+++ b/src/a.ts",
+      "@@ -1,3 +1,4 @@",
+      " line1",
+      "-old line",
+      "+new line",
+      "+another",
+      " line3",
+      "",
+    ].join("\n");
+
+    expect(parseUnifiedDiff(text)).toEqual({
+      files: [
+        {
+          binary: false,
+          hunks: [
+            {
+              lines: [
+                { kind: "context", text: "line1" },
+                { kind: "del", text: "old line" },
+                { kind: "add", text: "new line" },
+                { kind: "add", text: "another" },
+                { kind: "context", text: "line3" },
+              ],
+              newLines: 4,
+              newStart: 1,
+              oldLines: 3,
+              oldStart: 1,
+            },
+          ],
+          oldPath: null,
+          path: "src/a.ts",
+        },
+      ],
+    });
+  });
+
+  it("解析 binary 文件：无 hunks、binary=true", () => {
+    const text = [
+      "diff --git a/img.png b/img.png",
+      "Binary files a/img.png and b/img.png differ",
+      "",
+    ].join("\n");
+
+    expect(parseUnifiedDiff(text).files).toEqual([
+      { binary: true, hunks: [], oldPath: null, path: "img.png" },
+    ]);
+  });
+
+  it("解析 rename：oldPath !== path", () => {
+    const text = [
+      "diff --git a/old.ts b/new.ts",
+      "similarity index 100%",
+      "rename from old.ts",
+      "rename to new.ts",
+      "",
+    ].join("\n");
+
+    const result = parseUnifiedDiff(text).files[0];
+    expect(result?.path).toBe("new.ts");
+    expect(result?.oldPath).toBe("old.ts");
+  });
+});
+
+describe("parseGitBranchRefs", () => {
+  it("解析 for-each-ref --format=%(refname)%00%(upstream:short)%00%(objectname)%00%(HEAD) 输出", () => {
+    const output = `${[
+      ["refs/heads/main", "origin/main", "abc123", "*"].join("\0"),
+      ["refs/heads/feature/a", "", "def456", " "].join("\0"),
+      ["refs/remotes/origin/main", "", "abc123", " "].join("\0"),
+    ].join("\n")}\n`;
+
+    expect(parseGitBranchRefs(output)).toEqual([
+      {
+        isCurrent: true,
+        kind: "local",
+        lastCommit: "abc123",
+        name: "main",
+        upstream: "origin/main",
+      },
+      {
+        isCurrent: false,
+        kind: "local",
+        lastCommit: "def456",
+        name: "feature/a",
+        upstream: null,
+      },
+      {
+        isCurrent: false,
+        kind: "remote",
+        lastCommit: "abc123",
+        name: "origin/main",
+        upstream: null,
+      },
+    ]);
+  });
+});
+
+describe("createGitService", () => {
+  it("getStatus 用 porcelain=v2 --branch -z 并解析结果", async () => {
+    const calls: Array<{ args: readonly string[]; cwd: string }> = [];
+    const service = createGitService({
+      execGit: (args, cwd) => {
+        calls.push({ args, cwd });
+        return Promise.resolve(
+          `${[
+            "# branch.head main",
+            "1 .M N... 100644 100644 100644 a b src/foo.ts",
+          ].join("\0")}\0`
+        );
+      },
+    });
+
+    const status = await service.getStatus("/repo");
+
+    expect(calls).toEqual([
+      { args: ["status", "--porcelain=v2", "--branch", "-z"], cwd: "/repo" },
+    ]);
+    expect(status.branch.branch).toBe("main");
+    expect(status.files).toHaveLength(1);
+  });
+
+  // C3: 默认带 --no-color + --no-ext-diff（防用户配 diff.external 覆盖输出）
+  it("getDiffText 默认带 --no-color --no-ext-diff 并原样返回文本", async () => {
+    const calls: Array<readonly string[]> = [];
+    const service = createGitService({
+      execGit: (args) => {
+        calls.push(args);
+        return Promise.resolve("diff --git a/x b/x\n");
+      },
+    });
+
+    await expect(service.getDiffText("/repo")).resolves.toBe(
+      "diff --git a/x b/x\n"
+    );
+    expect(calls[0]).toEqual(["diff", "--no-color", "--no-ext-diff"]);
+  });
+
+  it("getDiffText 的 staged 选项加 --cached", async () => {
+    const calls: Array<readonly string[]> = [];
+    const service = createGitService({
+      execGit: (args) => {
+        calls.push(args);
+        return Promise.resolve("");
+      },
+    });
+
+    await service.getDiffText("/repo", { staged: true });
+
+    expect(calls[0]).toEqual([
+      "diff",
+      "--no-color",
+      "--no-ext-diff",
+      "--cached",
+    ]);
+  });
+
+  it("getDiffSummary 解析 numstat 并汇总增删", async () => {
+    const service = createGitService({
+      execGit: () =>
+        Promise.resolve(`${["10\t2\ta.ts", "3\t1\tb.ts"].join("\0")}\0`),
+    });
+
+    await expect(service.getDiffSummary("/repo")).resolves.toEqual({
+      changed: 2,
+      deletions: 3,
+      files: [
+        { binary: false, deletions: 2, insertions: 10, path: "a.ts" },
+        { binary: false, deletions: 1, insertions: 3, path: "b.ts" },
+      ],
+      insertions: 13,
+    });
+  });
+
+  // B: getRepoInfo
+  it("getRepoInfo 普通仓库返回 gitRoot/commonDir/headOid + isBare=false isWorktree=false", async () => {
+    const service = createGitService({
+      execGit: (args) => {
+        if (args[0] === "rev-parse" && args.includes("--show-toplevel")) {
+          return Promise.resolve("/repo\n/repo/.git\n/repo/.git\n");
+        }
+        if (args[0] === "rev-parse" && args.includes("--is-bare-repository")) {
+          return Promise.resolve("false\n");
+        }
+        if (args[0] === "rev-parse" && args[1] === "--verify") {
+          return Promise.resolve("abc123\n");
+        }
+        if (args[0] === "symbolic-ref") {
+          return Promise.resolve("refs/remotes/origin/main\n");
+        }
+        return Promise.resolve("");
+      },
+    });
+
+    await expect(service.getRepoInfo("/repo")).resolves.toEqual({
+      defaultBranch: "main",
+      gitCommonDir: "/repo/.git",
+      gitRoot: "/repo",
+      headOid: "abc123",
+      isBare: false,
+      isWorktree: false,
+    });
+  });
+
+  it("getRepoInfo 在 worktree 内:gitDir !== gitCommonDir → isWorktree=true", async () => {
+    const service = createGitService({
+      execGit: (args) => {
+        if (args[0] === "rev-parse" && args.includes("--show-toplevel")) {
+          return Promise.resolve(
+            "/repo/.worktrees/feature\n/repo/.git/worktrees/feature\n/repo/.git\n"
+          );
+        }
+        if (args[0] === "rev-parse" && args.includes("--is-bare-repository")) {
+          return Promise.resolve("false\n");
+        }
+        if (args[0] === "rev-parse" && args[1] === "--verify") {
+          return Promise.resolve("def456\n");
+        }
+        if (args[0] === "symbolic-ref") {
+          return Promise.reject(new Error("no symbolic-ref"));
+        }
+        return Promise.resolve("");
+      },
+    });
+
+    await expect(
+      service.getRepoInfo("/repo/.worktrees/feature")
+    ).resolves.toMatchObject({
+      defaultBranch: null,
+      isWorktree: true,
+    });
+  });
+
+  it("getRepoInfo 空仓库(HEAD 不存在):headOid=null", async () => {
+    const service = createGitService({
+      execGit: (args) => {
+        if (args[0] === "rev-parse" && args.includes("--show-toplevel")) {
+          return Promise.resolve("/repo\n/repo/.git\n/repo/.git\n");
+        }
+        if (args[0] === "rev-parse" && args.includes("--is-bare-repository")) {
+          return Promise.resolve("false\n");
+        }
+        if (args[0] === "rev-parse" && args[1] === "--verify") {
+          return Promise.reject(new Error("HEAD doesn't exist"));
+        }
+        return Promise.resolve("");
+      },
+    });
+
+    const result = await service.getRepoInfo("/repo");
+
+    expect(result.headOid).toBeNull();
+  });
+
+  // B: listBranches
+  it("listBranches kind:local 只列 refs/heads", async () => {
+    const calls: Array<readonly string[]> = [];
+    const service = createGitService({
+      execGit: (args) => {
+        calls.push(args);
+        return Promise.resolve(
+          `${["refs/heads/main", "origin/main", "abc", "*"].join("\0")}\n`
+        );
+      },
+    });
+
+    const branches = await service.listBranches("/repo", { kind: "local" });
+
+    expect(calls[0]).toContain("refs/heads");
+    expect(branches).toEqual([
+      {
+        isCurrent: true,
+        kind: "local",
+        lastCommit: "abc",
+        name: "main",
+        upstream: "origin/main",
+      },
+    ]);
+  });
+
+  it("listBranches kind:all 同时列 refs/heads 与 refs/remotes", async () => {
+    const calls: Array<readonly string[]> = [];
+    const service = createGitService({
+      execGit: (args) => {
+        calls.push(args);
+        return Promise.resolve("");
+      },
+    });
+
+    await service.listBranches("/repo", { kind: "all" });
+
+    expect(calls[0]).toContain("refs/heads");
+    expect(calls[0]).toContain("refs/remotes");
+  });
+
+  // B/C: 三个轻量方法
+  it("resolveRef 用 rev-parse --verify 返回 oid", async () => {
+    const calls: Array<readonly string[]> = [];
+    const service = createGitService({
+      execGit: (args) => {
+        calls.push(args);
+        return Promise.resolve("abc123\n");
+      },
+    });
+
+    await expect(service.resolveRef("/repo", "HEAD")).resolves.toBe("abc123");
+    expect(calls[0]).toEqual(["rev-parse", "--verify", "HEAD"]);
+  });
+
+  it("validateBranchName 合法名返回 true", async () => {
+    const calls: Array<readonly string[]> = [];
+    const service = createGitService({
+      execGit: (args) => {
+        calls.push(args);
+        return Promise.resolve("");
+      },
+    });
+
+    await expect(
+      service.validateBranchName("/repo", "feature/a")
+    ).resolves.toBe(true);
+    expect(calls[0]).toEqual(["check-ref-format", "--branch", "feature/a"]);
+  });
+
+  it("validateBranchName 非法名返回 false(不抛错)", async () => {
+    const service = createGitService({
+      execGit: () => Promise.reject(new Error("invalid branch")),
+    });
+
+    await expect(
+      service.validateBranchName("/repo", "bad branch")
+    ).resolves.toBe(false);
+  });
+
+  it("isWorkingTreeClean 无变更文件返回 true", async () => {
+    const service = createGitService({
+      execGit: () => Promise.resolve("# branch.head main\0"),
+    });
+
+    await expect(service.isWorkingTreeClean("/repo")).resolves.toBe(true);
+  });
+
+  it("isWorkingTreeClean 有变更文件返回 false", async () => {
+    const service = createGitService({
+      execGit: () =>
+        Promise.resolve(
+          `${[
+            "# branch.head main",
+            "1 .M N... 100644 100644 100644 a b src/x.ts",
+          ].join("\0")}\0`
+        ),
+    });
+
+    await expect(service.isWorkingTreeClean("/repo")).resolves.toBe(false);
+  });
+
+  // D/E: getFileContent, getCommit, getCommitPatch
+  it("getFileContent 默认用 HEAD:path", async () => {
+    const calls: Array<readonly string[]> = [];
+    const service = createGitService({
+      execGit: (args) => {
+        calls.push(args);
+        return Promise.resolve("const a = 1;\n");
+      },
+    });
+
+    await expect(
+      service.getFileContent("/repo", { path: "src/a.ts" })
+    ).resolves.toBe("const a = 1;\n");
+    expect(calls[0]).toEqual(["show", "HEAD:src/a.ts"]);
+  });
+
+  it("getFileContent 可指定 ref", async () => {
+    const calls: Array<readonly string[]> = [];
+    const service = createGitService({
+      execGit: (args) => {
+        calls.push(args);
+        return Promise.resolve("");
+      },
+    });
+
+    await service.getFileContent("/repo", { path: "src/a.ts", ref: "abc123" });
+    expect(calls[0]).toEqual(["show", "abc123:src/a.ts"]);
+  });
+
+  it("getCommit 用 git log -1 --format=... 返回单条 GitCommit", async () => {
+    const service = createGitService({
+      execGit: () =>
+        Promise.resolve("abc\x1fAlice\x1f2026-06-01\x1ffeat: x\x1e"),
+    });
+
+    await expect(service.getCommit("/repo", "abc")).resolves.toEqual({
+      author: "Alice",
+      date: "2026-06-01",
+      hash: "abc",
+      message: "feat: x",
+    });
+  });
+
+  it("getCommitPatch 用 git show --format= 并解析为 GitDiffPatch", async () => {
+    const calls: Array<readonly string[]> = [];
+    const service = createGitService({
+      execGit: (args) => {
+        calls.push(args);
+        return Promise.resolve(
+          [
+            "diff --git a/x.ts b/x.ts",
+            "--- a/x.ts",
+            "+++ b/x.ts",
+            "@@ -1,1 +1,1 @@",
+            "-old",
+            "+new",
+            "",
+          ].join("\n")
+        );
+      },
+    });
+
+    const patch = await service.getCommitPatch("/repo", "abc");
+    expect(calls[0]).toContain("show");
+    expect(calls[0]).toContain("--no-ext-diff");
+    expect(patch.files[0]?.path).toBe("x.ts");
+    expect(patch.files[0]?.hunks[0]?.lines).toEqual([
+      { kind: "del", text: "old" },
+      { kind: "add", text: "new" },
+    ]);
+  });
+
+  // E: getLog 扩展过滤(author/grep/since/until/path);依 codex 审查不另起 searchCommits
+  it("getLog 把 author/grep/since/until 转成对应 --flag", async () => {
+    const calls: Array<readonly string[]> = [];
+    const service = createGitService({
+      execGit: (args) => {
+        calls.push(args);
+        return Promise.resolve("");
+      },
+    });
+
+    await service.getLog("/repo", {
+      author: "Alice",
+      grep: "fix",
+      since: "2026-01-01",
+      until: "2026-06-01",
+    });
+
+    const args = calls[0] ?? [];
+    expect(args).toContain("--author=Alice");
+    expect(args).toContain("--grep=fix");
+    expect(args).toContain("--since=2026-01-01");
+    expect(args).toContain("--until=2026-06-01");
+  });
+
+  it("getLog 的 path 选项追加 -- <path>(限定文件)", async () => {
+    const calls: Array<readonly string[]> = [];
+    const service = createGitService({
+      execGit: (args) => {
+        calls.push(args);
+        return Promise.resolve("");
+      },
+    });
+
+    await service.getLog("/repo", { path: "src/a.ts" });
+
+    const args = calls[0] ?? [];
+    const dashDashIndex = args.indexOf("--");
+    expect(dashDashIndex).toBeGreaterThanOrEqual(0);
+    expect(args[dashDashIndex + 1]).toBe("src/a.ts");
+  });
+
+  // Phase 2-A: 暂存与提交(写)
+  it("stage 用 git add -- <paths>", async () => {
+    const calls: Array<readonly string[]> = [];
+    const service = createGitService({
+      execGit: (args) => {
+        calls.push(args);
+        return Promise.resolve("");
+      },
+    });
+
+    await service.stage("/repo", { paths: ["src/a.ts", "src/b.ts"] });
+
+    expect(calls[0]).toEqual(["add", "--", "src/a.ts", "src/b.ts"]);
+  });
+
+  it("stage paths 为空抛错(防误调清空所有)", async () => {
+    const service = createGitService({
+      execGit: () => Promise.resolve(""),
+    });
+    await expect(service.stage("/repo", { paths: [] })).rejects.toThrow();
+  });
+
+  it("unstage 用 git restore --staged -- <paths>", async () => {
+    const calls: Array<readonly string[]> = [];
+    const service = createGitService({
+      execGit: (args) => {
+        calls.push(args);
+        return Promise.resolve("");
+      },
+    });
+
+    await service.unstage("/repo", { paths: ["src/a.ts"] });
+
+    expect(calls[0]).toEqual(["restore", "--staged", "--", "src/a.ts"]);
+  });
+
+  it("discardChanges 用 git restore -- <paths>(不带 --staged)", async () => {
+    const calls: Array<readonly string[]> = [];
+    const service = createGitService({
+      execGit: (args) => {
+        calls.push(args);
+        return Promise.resolve("");
+      },
+    });
+
+    await service.discardChanges("/repo", { paths: ["src/a.ts"] });
+
+    expect(calls[0]).toEqual(["restore", "--", "src/a.ts"]);
+  });
+
+  it("discardChanges paths 为空抛错(危险操作显式)", async () => {
+    const service = createGitService({
+      execGit: () => Promise.resolve(""),
+    });
+    await expect(
+      service.discardChanges("/repo", { paths: [] })
+    ).rejects.toThrow();
+  });
+
+  it("commit 用 git commit -m <message>;signoff/allowEmpty 加对应 flag", async () => {
+    const calls: Array<readonly string[]> = [];
+    const service = createGitService({
+      execGit: (args) => {
+        calls.push(args);
+        return Promise.resolve("[main abc] feat: x\n");
+      },
+    });
+
+    await service.commit("/repo", {
+      allowEmpty: true,
+      message: "feat: x",
+      signoff: true,
+    });
+
+    expect(calls[0]).toContain("commit");
+    expect(calls[0]).toContain("-m");
+    expect(calls[0]).toContain("feat: x");
+    expect(calls[0]).toContain("--signoff");
+    expect(calls[0]).toContain("--allow-empty");
+  });
+
+  it("写操作传 timeoutMs: 60000(避免大仓库回归)", async () => {
+    const seenOptions: Array<{ timeoutMs?: number } | undefined> = [];
+    const service = createGitService({
+      execGit: (_args, _cwd, options) => {
+        seenOptions.push(options);
+        return Promise.resolve("");
+      },
+    });
+
+    await service.stage("/repo", { paths: ["a"] });
+    await service.commit("/repo", { message: "m" });
+
+    expect(seenOptions[0]?.timeoutMs).toBe(60_000);
+    expect(seenOptions[1]?.timeoutMs).toBe(60_000);
+  });
+
+  // Phase 2-B: 分支写操作
+  // A1: branch name 不可以 "-" 开头(否则会被 git 当 flag)
+  it("createBranch 拒绝 name 以 - 开头", async () => {
+    const service = createGitService({
+      execGit: () => Promise.resolve(""),
+    });
+    await expect(
+      service.createBranch("/repo", { name: "--evil" })
+    ).rejects.toThrow();
+  });
+
+  it("deleteBranch 拒绝 name 以 - 开头", async () => {
+    const service = createGitService({
+      execGit: () => Promise.resolve(""),
+    });
+    await expect(
+      service.deleteBranch("/repo", { name: "--force" })
+    ).rejects.toThrow();
+  });
+
+  it("checkoutBranch 拒绝 name 以 - 开头", async () => {
+    const service = createGitService({
+      execGit: () => Promise.resolve(""),
+    });
+    await expect(service.checkoutBranch("/repo", "--help")).rejects.toThrow();
+  });
+
+  it("createBranch 用 git branch <name>(无 startPoint)", async () => {
+    const calls: Array<readonly string[]> = [];
+    const service = createGitService({
+      execGit: (args) => {
+        calls.push(args);
+        return Promise.resolve("");
+      },
+    });
+
+    await service.createBranch("/repo", { name: "feature/a" });
+
+    expect(calls[0]).toEqual(["branch", "feature/a"]);
+  });
+
+  it("createBranch 带 startPoint 时附在末尾", async () => {
+    const calls: Array<readonly string[]> = [];
+    const service = createGitService({
+      execGit: (args) => {
+        calls.push(args);
+        return Promise.resolve("");
+      },
+    });
+
+    await service.createBranch("/repo", {
+      name: "feature/a",
+      startPoint: "origin/main",
+    });
+
+    expect(calls[0]).toEqual(["branch", "feature/a", "origin/main"]);
+  });
+
+  it("deleteBranch 默认 -d;force=true 用 -D", async () => {
+    const calls: Array<readonly string[]> = [];
+    const service = createGitService({
+      execGit: (args) => {
+        calls.push(args);
+        return Promise.resolve("");
+      },
+    });
+
+    await service.deleteBranch("/repo", { name: "old" });
+    await service.deleteBranch("/repo", { force: true, name: "rough" });
+
+    expect(calls[0]).toEqual(["branch", "-d", "old"]);
+    expect(calls[1]).toEqual(["branch", "-D", "rough"]);
+  });
+
+  it("checkoutBranch 用 git switch <name>(更现代,避免意外创建)", async () => {
+    const calls: Array<readonly string[]> = [];
+    const service = createGitService({
+      execGit: (args) => {
+        calls.push(args);
+        return Promise.resolve("");
+      },
+    });
+
+    await service.checkoutBranch("/repo", "main");
+
+    expect(calls[0]).toEqual(["switch", "main"]);
+  });
+
+  it("listTags 返回标签名数组", async () => {
+    const service = createGitService({
+      execGit: () => Promise.resolve("v1.0.0\nv1.0.1\nv2.0.0\n"),
+    });
+
+    await expect(service.listTags("/repo")).resolves.toEqual([
+      "v1.0.0",
+      "v1.0.1",
+      "v2.0.0",
+    ]);
+  });
+
+  it("getLog 带 --max-count 并解析记录", async () => {
+    const calls: Array<readonly string[]> = [];
+    const service = createGitService({
+      execGit: (args) => {
+        calls.push(args);
+        return Promise.resolve(
+          `${["abc\x1fAlice\x1f2026-06-01\x1ffeat"].join("\x1e")}\x1e`
+        );
+      },
+    });
+
+    const log = await service.getLog("/repo", { maxCount: 5 });
+
+    expect(calls[0]?.[0]).toBe("log");
+    expect(calls[0]).toContain("--max-count=5");
+    expect(log).toEqual([
+      { author: "Alice", date: "2026-06-01", hash: "abc", message: "feat" },
+    ]);
+  });
+});

--- a/tests/unit/main/git-watch-service.test.ts
+++ b/tests/unit/main/git-watch-service.test.ts
@@ -1,0 +1,230 @@
+import { EventEmitter } from "node:events";
+import { createGitWatchService } from "@main/services/git-watch-service.ts";
+import type { GitChangeEvent } from "@shared/contracts/git.ts";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/** 假 FSWatcher:支持 emit("change", ...) + close 记录。ref/unref 是 FSWatcher 必有方法占位。 */
+class FakeWatcher extends EventEmitter {
+  closed = false;
+  close(): void {
+    this.closed = true;
+  }
+  ref(): this {
+    return this;
+  }
+  unref(): this {
+    return this;
+  }
+}
+
+interface Recorder {
+  headSig: string;
+  headSigCalls: number;
+  worktreeSig: string;
+  worktreeSigCalls: number;
+}
+
+function makeRecorder(): Recorder {
+  return {
+    headSig: "h0",
+    headSigCalls: 0,
+    worktreeSig: "w0",
+    worktreeSigCalls: 0,
+  };
+}
+
+describe("createGitWatchService", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("文件事件触发 debounce 重算签名;变化时通知 listener", async () => {
+    const fakeWatcher = new FakeWatcher();
+    const rec = makeRecorder();
+    const service = createGitWatchService({
+      computeHeadSignature: () => {
+        rec.headSigCalls += 1;
+        return Promise.resolve(rec.headSig);
+      },
+      computeWorktreeSignature: () => {
+        rec.worktreeSigCalls += 1;
+        return Promise.resolve(rec.worktreeSig);
+      },
+      fsWatch: () => fakeWatcher,
+    });
+    const events: GitChangeEvent[] = [];
+    service.watch("/repo", (e) => events.push(e));
+
+    // 等初始签名采集 promise resolve
+    await vi.runOnlyPendingTimersAsync();
+
+    // worktree 签名变化
+    rec.worktreeSig = "w1";
+    fakeWatcher.emit("change", "modify", "src/a.ts");
+
+    await vi.advanceTimersByTimeAsync(400);
+    expect(events).toEqual([{ changeKind: "worktree", gitRoot: "/repo" }]);
+
+    await service.dispose();
+  });
+
+  it("debounce 期间多次 fs event 合并为一次签名重算", async () => {
+    const fakeWatcher = new FakeWatcher();
+    const rec = makeRecorder();
+    const service = createGitWatchService({
+      computeHeadSignature: () => Promise.resolve(rec.headSig),
+      computeWorktreeSignature: () => {
+        rec.worktreeSigCalls += 1;
+        return Promise.resolve(rec.worktreeSig);
+      },
+      fsWatch: () => fakeWatcher,
+    });
+    service.watch("/repo", () => undefined);
+    await vi.runOnlyPendingTimersAsync();
+    const baselineCalls = rec.worktreeSigCalls;
+
+    fakeWatcher.emit("change");
+    fakeWatcher.emit("change");
+    fakeWatcher.emit("change");
+    await vi.advanceTimersByTimeAsync(400);
+
+    // debounce 应该只触发一次重算
+    expect(rec.worktreeSigCalls - baselineCalls).toBe(1);
+
+    await service.dispose();
+  });
+
+  it("签名未变化时不通知 listener", async () => {
+    const fakeWatcher = new FakeWatcher();
+    const rec = makeRecorder();
+    const service = createGitWatchService({
+      computeHeadSignature: () => Promise.resolve(rec.headSig),
+      computeWorktreeSignature: () => Promise.resolve(rec.worktreeSig),
+      fsWatch: () => fakeWatcher,
+    });
+    const events: GitChangeEvent[] = [];
+    service.watch("/repo", (e) => events.push(e));
+    await vi.runOnlyPendingTimersAsync();
+
+    fakeWatcher.emit("change");
+    await vi.advanceTimersByTimeAsync(400);
+
+    expect(events).toEqual([]);
+    await service.dispose();
+  });
+
+  it("两个 listener 共用同一 fsWatcher(引用计数)", async () => {
+    let watcherCount = 0;
+    const fakeWatcher = new FakeWatcher();
+    const rec = makeRecorder();
+    const service = createGitWatchService({
+      computeHeadSignature: () => Promise.resolve(rec.headSig),
+      computeWorktreeSignature: () => Promise.resolve(rec.worktreeSig),
+      fsWatch: () => {
+        watcherCount += 1;
+        return fakeWatcher;
+      },
+    });
+
+    const unsub1 = service.watch("/repo", () => undefined);
+    const unsub2 = service.watch("/repo", () => undefined);
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(watcherCount).toBe(1);
+    expect(fakeWatcher.closed).toBe(false);
+
+    unsub1();
+    expect(fakeWatcher.closed).toBe(false);
+    unsub2();
+    expect(fakeWatcher.closed).toBe(true);
+
+    await service.dispose();
+  });
+
+  it("30s 兜底轮询:无 fs 事件也会重算签名", async () => {
+    const fakeWatcher = new FakeWatcher();
+    const rec = makeRecorder();
+    const service = createGitWatchService({
+      computeHeadSignature: () => Promise.resolve(rec.headSig),
+      computeWorktreeSignature: () => {
+        rec.worktreeSigCalls += 1;
+        return Promise.resolve(rec.worktreeSig);
+      },
+      fsWatch: () => fakeWatcher,
+    });
+    service.watch("/repo", () => undefined);
+    await vi.runOnlyPendingTimersAsync();
+    const baselineCalls = rec.worktreeSigCalls;
+
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect(rec.worktreeSigCalls).toBeGreaterThan(baselineCalls);
+    await service.dispose();
+  });
+
+  // A3: 初始 baseline 采集未完成时,fs 事件不应触发误报
+  it("baseline 完成前的 fs 事件不会误报 changeKind=both", async () => {
+    const fakeWatcher = new FakeWatcher();
+    let resolveBaseline: () => void = () => undefined;
+    const baselineGate = new Promise<void>((res) => {
+      resolveBaseline = res;
+    });
+    const rec = makeRecorder();
+    const service = createGitWatchService({
+      computeHeadSignature: async () => {
+        // 第一次(baseline)被 gate 阻塞;后续即时返回
+        await baselineGate;
+        return rec.headSig;
+      },
+      computeWorktreeSignature: async () => {
+        await baselineGate;
+        return rec.worktreeSig;
+      },
+      fsWatch: () => fakeWatcher,
+    });
+    const events: GitChangeEvent[] = [];
+    service.watch("/repo", (e) => events.push(e));
+
+    // baseline 未完成时,fs 事件不应导致误报
+    fakeWatcher.emit("change");
+    await vi.advanceTimersByTimeAsync(400);
+    expect(events).toEqual([]);
+
+    // 释放 baseline gate
+    resolveBaseline();
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(events).toEqual([]);
+    await service.dispose();
+  });
+
+  it("HEAD 变化时 changeKind=head;worktree 同时变 changeKind=both", async () => {
+    const fakeWatcher = new FakeWatcher();
+    const rec = makeRecorder();
+    const service = createGitWatchService({
+      computeHeadSignature: () => Promise.resolve(rec.headSig),
+      computeWorktreeSignature: () => Promise.resolve(rec.worktreeSig),
+      fsWatch: () => fakeWatcher,
+    });
+    const events: GitChangeEvent[] = [];
+    service.watch("/repo", (e) => events.push(e));
+    await vi.runOnlyPendingTimersAsync();
+
+    rec.headSig = "h1";
+    fakeWatcher.emit("change");
+    await vi.advanceTimersByTimeAsync(400);
+
+    rec.headSig = "h2";
+    rec.worktreeSig = "w1";
+    fakeWatcher.emit("change");
+    await vi.advanceTimersByTimeAsync(400);
+
+    expect(events[0]?.changeKind).toBe("head");
+    expect(events[1]?.changeKind).toBe("both");
+    await service.dispose();
+  });
+});

--- a/tests/unit/main/worktree-service.test.ts
+++ b/tests/unit/main/worktree-service.test.ts
@@ -7,7 +7,7 @@ import {
   createWorktreeService,
   parseGitWorktreeListPorcelainZ,
 } from "@main/services/worktree-service.ts";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 const execFileAsync = promisify(execFile);
 const tempDirs: string[] = [];
@@ -374,6 +374,74 @@ describe("createWorktreeService", () => {
     ).rejects.toMatchObject({
       reason: "current_worktree",
     });
+  });
+
+  // C5: 写操作（worktree add/remove）应传 60s 超时，避免大仓库继承 git-exec 默认 10s 失败
+  it("create 给 worktree add 传 timeoutMs: 60_000", async () => {
+    const addCallOptions: Array<{ timeoutMs?: number } | undefined> = [];
+    let created = false;
+    const service = createWorktreeService({
+      execGit: (args, cwd, options) => {
+        if (args[0] === "worktree" && args[1] === "add") {
+          addCallOptions.push(options);
+          created = true;
+          return Promise.resolve("");
+        }
+        if (args[0] === "rev-parse" && args.includes("--show-toplevel")) {
+          return Promise.resolve(`${cwd}\n`);
+        }
+        if (args[0] === "worktree" && args[1] === "list") {
+          const output = created
+            ? [
+                "worktree /repo",
+                "HEAD abc123",
+                "branch refs/heads/main",
+                "",
+                "worktree /repo/.worktrees/feature-a",
+                "HEAD def456",
+                "branch refs/heads/feature/a",
+                "",
+              ]
+            : ["worktree /repo", "HEAD abc123", "branch refs/heads/main", ""];
+          return Promise.resolve(output.join("\0"));
+        }
+        return Promise.resolve("");
+      },
+      mkdir: () => Promise.resolve(undefined),
+      realpath: (path) => Promise.resolve(path),
+    });
+
+    await service.create({
+      branch: "feature/a",
+      name: "feature-a",
+      path: "/repo",
+    });
+
+    expect(addCallOptions[0]?.timeoutMs).toBe(60_000);
+  });
+
+  // S1: list 中 worktree list 失败时 console.warn 透传 stderr/exitCode（避免迁移后信息静默丢失）
+  it("list 失败时 console.warn 透传错误信息", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {
+      // suppress
+    });
+    const service = createWorktreeService({
+      execGit: (args) => {
+        if (args[0] === "rev-parse") {
+          return Promise.resolve("/repo\n");
+        }
+        if (args[0] === "worktree" && args[1] === "list") {
+          return Promise.reject(new Error("simulated git stderr"));
+        }
+        return Promise.resolve("");
+      },
+      realpath: (path) => Promise.resolve(path),
+    });
+
+    await service.list({ path: "/repo" });
+
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
   });
 
   it("remove 拒绝移除 main .worktrees 目录外的 linked worktree", async () => {

--- a/tests/unit/renderer/worktree-plugin.test.tsx
+++ b/tests/unit/renderer/worktree-plugin.test.tsx
@@ -245,6 +245,26 @@ describe("worktree builtin plugin", () => {
           })),
           open: vi.fn(async () => ({ context, panelId: "terminal-worktree" })),
         },
+        git: {
+          getStatus: vi.fn(async () => ({
+            branch: {
+              ahead: 0,
+              behind: 0,
+              branch: "main",
+              upstream: null,
+            },
+            files: [],
+          })),
+          getRepoInfo: vi.fn(async () => ({
+            defaultBranch: null,
+            gitCommonDir: "/Users/xyz/ABC/pier/.git",
+            gitRoot: "/Users/xyz/ABC/pier",
+            headOid: "abc123",
+            isBare: false,
+            isWorktree: false,
+          })),
+          watch: vi.fn(() => () => undefined),
+        },
       },
     });
   });


### PR DESCRIPTION
## Summary
- 新增 main 进程 `GitService`(21 方法,读 14 + 写 7)+ `GitWatchService`,经 `git-exec.ts` 统一执行底座(超时/字节上限/`StringDecoder`/`SIGKILL` fallback/stream error 累加)。
- 全链路 IPC:21 个 `git.*` 命令进 `RENDERER_FACADE` 白名单 + `desktop-renderer` 默认含 `git:read`/`git:write`(与 `worktree:write` 同等待遇);`GitExecError` 经 router 转 `git_error` 错误码并透传 stderr/stdout 摘要。
- 安全守门:分支名 `assertSafeBranchName` 防当 git flag;`git-watch` IPC 加 `git:read` capability 校验 + `WeakSet` 守护 `destroyed` listener 每 webContents 只注册一次。
- dogfood:worktree 插件状态栏接 `pluginContext.git.getStatus + watch`,实时显示 `branch ↑n↓n ·m`。

## Test plan
- [x] 单测 81:`git-exec` / `git-service` / `git-watch-service` / `worktree-service`(迁移)/ 5 个 parser fixture
- [x] 集成 e2e 17:`git-service-e2e`(真 git 仓库,11+1)+ `git-ipc-e2e`(命令路由 + capability 守门 + 错误码透传,5)
- [x] `pnpm typecheck` / `pnpm lint` / `pnpm depcruise` / `pnpm check:file-size` 全 0 错
- [ ] 手动验证(Pier 真启动后)`window.pier.git.getStatus(repo)` 在 DevTools console 正常返回 + worktree 插件状态栏实时显示 ahead/behind/changes

## Breaking changes
无。新增能力 + 现有 `worktree-service`/`panel-context-resolver` 内部底座统一迁移(对外行为不变)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)