### PR TITLE
[codex] Sort run tasks by recent use

### DIFF
--- a/src/main/services/tasks/task-recent-ranking.ts
+++ b/src/main/services/tasks/task-recent-ranking.ts
@@ -1,0 +1,130 @@
+import { frecency } from "@shared/contracts/command-palette-mru.ts";
+import type {
+  TaskCandidate,
+  TaskRecentEntry,
+} from "@shared/contracts/tasks.ts";
+import { commandWithArgs } from "./utils.ts";
+
+export function recentTaskKey(cwd: string, taskId: string): string {
+  return `${cwd}\0${taskId}`;
+}
+
+export function recentCommandKey(cwd: string, command: string): string {
+  return `${cwd}\0${command}`;
+}
+
+function rawCommandForTask(task: TaskCandidate): string {
+  if (task.commandSpec.kind === "process") {
+    return commandWithArgs(task.commandSpec.command, task.commandSpec.args);
+  }
+  return task.commandSpec.command;
+}
+
+function recentScore(
+  entry: TaskRecentEntry,
+  index: number,
+  total: number,
+  now: number
+): number | null {
+  if (
+    entry.useCount != null &&
+    entry.useCount > 0 &&
+    entry.lastUsedAt != null
+  ) {
+    return frecency(
+      {
+        actionId: entry.taskId ?? recentCommandKey(entry.cwd, entry.command),
+        lastUsedAt: entry.lastUsedAt,
+        useCount: entry.useCount,
+      },
+      now
+    );
+  }
+  if (total <= 0) {
+    return null;
+  }
+  return (total - index) / (total + 1);
+}
+
+function buildRecentScoreMaps(
+  entries: readonly TaskRecentEntry[],
+  now: number
+): {
+  byHistoryCommand: ReadonlyMap<string, number>;
+  byLegacyCommand: ReadonlyMap<string, number>;
+  byTask: ReadonlyMap<string, number>;
+} {
+  const byHistoryCommand = new Map<string, number>();
+  const byLegacyCommand = new Map<string, number>();
+  const byTask = new Map<string, number>();
+  for (let index = 0; index < entries.length; index += 1) {
+    const entry = entries[index];
+    if (!entry) {
+      continue;
+    }
+    const score = recentScore(entry, index, entries.length, now);
+    if (score == null) {
+      continue;
+    }
+    const commandKey = recentCommandKey(entry.cwd, entry.command);
+    byHistoryCommand.set(
+      commandKey,
+      Math.max(byHistoryCommand.get(commandKey) ?? 0, score)
+    );
+    if (entry.taskId) {
+      const taskKey = recentTaskKey(entry.cwd, entry.taskId);
+      byTask.set(taskKey, Math.max(byTask.get(taskKey) ?? 0, score));
+    } else {
+      byLegacyCommand.set(
+        commandKey,
+        Math.max(byLegacyCommand.get(commandKey) ?? 0, score)
+      );
+    }
+  }
+  return { byHistoryCommand, byLegacyCommand, byTask };
+}
+
+function taskRecentScore(
+  task: TaskCandidate,
+  maps: ReturnType<typeof buildRecentScoreMaps>
+): number | null {
+  const byTask = maps.byTask.get(recentTaskKey(task.cwd, task.id));
+  if (byTask != null) {
+    return byTask;
+  }
+  const commandKey = recentCommandKey(task.cwd, rawCommandForTask(task));
+  if (task.source === "history") {
+    return maps.byHistoryCommand.get(commandKey) ?? null;
+  }
+  return maps.byLegacyCommand.get(commandKey) ?? null;
+}
+
+export function sortTasksByRecentUse(
+  tasks: readonly TaskCandidate[],
+  entries: readonly TaskRecentEntry[],
+  now: number
+): TaskCandidate[] {
+  if (entries.length === 0) {
+    return [...tasks];
+  }
+  const maps = buildRecentScoreMaps(entries, now);
+  return tasks
+    .map((task, index) => ({
+      index,
+      score: taskRecentScore(task, maps),
+      task,
+    }))
+    .sort((a, b) => {
+      if (a.score != null && b.score == null) {
+        return -1;
+      }
+      if (a.score == null && b.score != null) {
+        return 1;
+      }
+      if (a.score != null && b.score != null && a.score !== b.score) {
+        return b.score - a.score;
+      }
+      return a.index - b.index;
+    })
+    .map((ranked) => ranked.task);
+}

--- a/src/main/services/tasks/task-service.ts
+++ b/src/main/services/tasks/task-service.ts
@@ -18,6 +18,11 @@ import {
   requiredInputsForTask,
 } from "./task-execution-plan.ts";
 import {
+  recentCommandKey,
+  recentTaskKey,
+  sortTasksByRecentUse,
+} from "./task-recent-ranking.ts";
+import {
   createTaskRunCoordinator,
   type TaskRunCoordinatorStartResult,
   type TaskRunTerminalOpenResult,
@@ -168,11 +173,15 @@ export function createTaskService({
 
   const collect = async (projectRoot: string) => {
     await ensureRecentLoaded();
-    return await collectTaskCandidates({
+    const result = await collectTaskCandidates({
       projectRoot,
       recentTasks,
       ...(homeDir ? { homeDir } : {}),
     } satisfies CollectTaskCandidatesOptions);
+    return {
+      ...result,
+      tasks: sortTasksByRecentUse(result.tasks, recentTasks, now()),
+    };
   };
 
   function rememberPanelRun(
@@ -310,17 +319,35 @@ export function createTaskService({
 
   async function recordRecentLaunch(launch: TaskLaunchPlan): Promise<void> {
     await ensureRecentLoaded();
+    const usedAt = now();
+    const existing = recentTasks.find((recent) =>
+      recent.taskId
+        ? recentTaskKey(recent.cwd, recent.taskId) ===
+          recentTaskKey(launch.cwd, launch.taskId)
+        : recentCommandKey(recent.cwd, recent.command) ===
+          recentCommandKey(launch.cwd, launch.rawCommand ?? launch.command)
+    );
     const entry: TaskRecentEntry = {
       command: launch.rawCommand ?? launch.command,
       cwd: launch.cwd,
+      lastUsedAt: usedAt,
       label: launch.label || basename(launch.cwd),
       source: "history",
+      taskId: launch.taskId,
+      useCount: (existing?.useCount ?? 0) + 1,
     };
     recentTasks = [
       entry,
       ...recentTasks.filter(
         (recent) =>
-          !(recent.cwd === entry.cwd && recent.command === entry.command)
+          !(
+            (recent.taskId
+              ? recentTaskKey(recent.cwd, recent.taskId) ===
+                recentTaskKey(entry.cwd, launch.taskId)
+              : false) ||
+            recentCommandKey(recent.cwd, recent.command) ===
+              recentCommandKey(entry.cwd, entry.command)
+          )
       ),
     ].slice(0, recentLimit);
     await writeRecentState({ entries: recentTasks, version: 1 });

--- a/src/shared/contracts/tasks.ts
+++ b/src/shared/contracts/tasks.ts
@@ -207,8 +207,11 @@ export const taskRecentEntrySchema = z
   .object({
     command: z.string().min(1),
     cwd: z.string().min(1),
+    lastUsedAt: z.number().int().optional(),
     label: z.string().min(1),
     source: z.literal("history"),
+    taskId: z.string().min(1).optional(),
+    useCount: z.number().int().nonnegative().optional(),
   })
   .strict();
 export type TaskRecentEntry = z.infer<typeof taskRecentEntrySchema>;

--- a/tests/unit/main/tasks/task-execution-plan.test.ts
+++ b/tests/unit/main/tasks/task-execution-plan.test.ts
@@ -10,6 +10,7 @@ const INPUT_PKG_VAR = `${TASK_VAR_PREFIX}{input:pkg}`;
 const ENV_TARGET_VAR = `${TASK_VAR_PREFIX}{env:PIER_TARGET}`;
 const WORKSPACE_FOLDER_VAR = `${TASK_VAR_PREFIX}{workspaceFolder}`;
 const WORKSPACE_FOLDER_BASENAME_VAR = `${TASK_VAR_PREFIX}{workspaceFolderBasename}`;
+const DAY_MS = 86_400_000;
 
 describe("task execution planning", () => {
   let projectRoot = "";
@@ -583,8 +584,10 @@ describe("task execution planning", () => {
 
   it("persists recent task history through injected storage", async () => {
     const writes: unknown[] = [];
+    const now = 1_772_000_000_000;
     const service = createTaskService({
       homeDir,
+      now: () => now,
       readRecentState: async () => ({ entries: [], version: 1 }),
       writeRecentState: (state) => {
         writes.push(state);
@@ -610,8 +613,11 @@ describe("task execution planning", () => {
           {
             command: "pnpm check",
             cwd: projectRoot,
+            lastUsedAt: now,
             label: "check",
             source: "history",
+            taskId: "package-script:check",
+            useCount: 1,
           },
         ],
         version: 1,
@@ -626,5 +632,56 @@ describe("task execution planning", () => {
         }),
       ]),
     });
+  });
+
+  it("sorts task candidates by recent use weight", async () => {
+    const now = 100 * DAY_MS;
+    await writeFile(
+      join(projectRoot, "package.json"),
+      JSON.stringify({
+        scripts: {
+          alpha: "node alpha.js",
+          beta: "node beta.js",
+          gamma: "node gamma.js",
+        },
+      })
+    );
+    await writeFile(join(projectRoot, "pnpm-lock.yaml"), "lockfileVersion: 9");
+    const service = createTaskService({
+      homeDir,
+      now: () => now,
+      readRecentState: async () => ({
+        entries: [
+          {
+            command: "pnpm run alpha",
+            cwd: projectRoot,
+            label: "alpha",
+            lastUsedAt: now,
+            source: "history",
+            taskId: "package-script:alpha",
+            useCount: 1,
+          },
+          {
+            command: "pnpm run beta",
+            cwd: projectRoot,
+            label: "beta",
+            lastUsedAt: now - 14 * DAY_MS,
+            source: "history",
+            taskId: "package-script:beta",
+            useCount: 4,
+          },
+        ],
+        version: 1,
+      }),
+      writeRecentState: async () => undefined,
+    });
+
+    const listed = await service.list({ projectRoot });
+
+    expect(
+      listed.tasks
+        .filter((task) => task.source === "package-script")
+        .map((task) => task.label)
+    ).toEqual(["beta", "alpha", "gamma"]);
   });
 });


### PR DESCRIPTION
## Summary
- Record task recent usage with task id, count, and last-used timestamp while preserving compatibility with existing history entries.
- Sort run-task candidates by frecency before returning them to the command palette.
- Add coverage for recent persistence and task candidate ordering.

## Root Cause
Run Task quick-pick items were grouped from the raw task list without weighting original task candidates by the existing recent-task state. Recent history entries existed, but package/vscode/make/etc. tasks themselves did not move up after use.

## Validation
- pnpm test:unit -- tests/unit/main/tasks/task-execution-plan.test.ts
- pnpm check