### PR TITLE
[codex] Fix agent settings state

### DIFF
--- a/src/main/services/agents/agent-detection-service.ts
+++ b/src/main/services/agents/agent-detection-service.ts
@@ -57,7 +57,34 @@ export function createAgentDetectionService({
   hydratePath = defaultHydratePath,
   probe = defaultProbe,
 }: CreateAgentDetectionServiceArgs = {}): AgentDetectionService {
+  let pathHydrated = false;
+  let hydrateInFlight: Promise<string[]> | null = null;
+
+  async function hydratePathOnce(): Promise<void> {
+    if (pathHydrated) {
+      return;
+    }
+    if (!hydrateInFlight) {
+      hydrateInFlight = hydratePath()
+        .then((added) => {
+          pathHydrated = true;
+          return added;
+        })
+        .finally(() => {
+          hydrateInFlight = null;
+        });
+    }
+    await hydrateInFlight;
+  }
+
+  async function hydratePathNow(): Promise<string[]> {
+    const added = await hydratePath();
+    pathHydrated = true;
+    return added;
+  }
+
   async function detect(): Promise<DetectAgentsResult> {
+    await hydratePathOnce();
     const checks = await Promise.all(
       AGENT_CATALOG.map(async (entry) => {
         const cmds = [entry.detectCmd, ...(entry.detectCmdAliases ?? [])];
@@ -72,7 +99,7 @@ export function createAgentDetectionService({
   return {
     detect,
     async refresh() {
-      const added = await hydratePath();
+      const added = await hydratePathNow();
       const detectResult = await detect();
       return { ...detectResult, addedPathSegments: added };
     },

--- a/src/renderer/i18n/locales/settings-agents.ts
+++ b/src/renderer/i18n/locales/settings-agents.ts
@@ -10,8 +10,8 @@ export const agentsLocales = {
       blank: "Blank terminal",
     },
     list: {
-      title: "Installed agents",
-      description: "Detected agent CLIs",
+      title: "Agent CLIs",
+      description: "Supported and detected agent CLIs",
       refresh: "Refresh",
     },
     status: {
@@ -25,6 +25,7 @@ export const agentsLocales = {
       setDefault: "Set default",
       isDefault: "Default",
       expand: "Details",
+      website: "Website",
     },
     row: {
       launchCmd: "Launch command",
@@ -38,17 +39,17 @@ export const agentsLocales = {
   },
   zhCN: {
     permissionMode: {
-      yolo: "跳过确认",
-      manual: "逐次确认",
-      mixed: "混合",
+      yolo: "跳过权限确认",
+      manual: "手动确认权限",
+      mixed: "已自定义",
     },
     defaultPick: {
       auto: "自动",
       blank: "空白终端",
     },
     list: {
-      title: "已安装的智能体",
-      description: "检测到的 CLI agent",
+      title: "智能体列表",
+      description: "支持和检测到的 CLI agent",
       refresh: "刷新",
     },
     status: {
@@ -62,6 +63,7 @@ export const agentsLocales = {
       setDefault: "设为默认",
       isDefault: "默认",
       expand: "详情",
+      website: "官网",
     },
     row: {
       launchCmd: "启动命令",

--- a/src/renderer/i18n/locales/settings.ts
+++ b/src/renderer/i18n/locales/settings.ts
@@ -265,8 +265,8 @@ export const settingsLocales = {
       terminalNewCwdPolicyDesc: "控制新建或拆分终端时使用哪个工作目录",
       defaultAgent: "默认智能体",
       defaultAgentDesc: "新建 agent 动作默认启动的 CLI",
-      agentPermissionMode: "权限模式",
-      agentPermissionModeDesc: "批量控制是否跳过 agent 权限确认",
+      agentPermissionMode: "权限确认方式",
+      agentPermissionModeDesc: "新建 agent 时，统一设置是否自动跳过权限确认",
     },
     terminal: {
       cursorStyle: {

--- a/src/renderer/lib/actions/new-agent-action.ts
+++ b/src/renderer/lib/actions/new-agent-action.ts
@@ -8,8 +8,8 @@ import { useWorkspaceStore } from "@/stores/workspace.store.ts";
 import type { ActionContribution } from "./contribution-types.ts";
 
 async function handleNewAgent(): Promise<void> {
-  // Detection only auto-runs when the settings page mounts; ensure it has run
-  // so New Agent works on first invocation without opening agent settings.
+  // Startup kicks this off globally; this remains a cheap safety net for tests,
+  // debug windows, or early invocations that race the initial probe.
   await useAgentDetectStore.getState().ensureDetected();
 
   const { detectedIds } = useAgentDetectStore.getState();

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -16,6 +16,7 @@ import { DEFAULT_KEYMAP } from "./lib/keybindings/defaults.ts";
 import { keybindingRegistry } from "./lib/keybindings/registry.ts";
 import { bootstrapBuiltinPlugins } from "./lib/plugins/bootstrap.ts";
 import { registerTerminalActions } from "./panel-kits/terminal/register-actions.ts";
+import { initAgentDetection } from "./stores/agent-detect.store.ts";
 import { initAgentPreferences } from "./stores/agent-preferences.store.ts";
 import { initCommandPaletteMru } from "./stores/command-palette-mru.store.ts";
 import { initFont } from "./stores/font.store.ts";
@@ -59,6 +60,9 @@ async function bootstrap() {
   }
 
   window.pier?.terminal?.setup?.()?.catch(() => undefined);
+  initAgentDetection().catch((err) => {
+    console.error("[pier] agent detection init failed:", err);
+  });
   installTerminalInputRoutingDragWatcher();
   installCommandPaletteMenuRequest();
   initCommandPaletteMru().catch(() => undefined);

--- a/src/renderer/pages/settings/components/agent-row.tsx
+++ b/src/renderer/pages/settings/components/agent-row.tsx
@@ -8,7 +8,7 @@ import {
 import { Item, ItemActions, ItemContent, ItemTitle } from "@pier/ui/item.tsx";
 import { getAgentCatalogEntry } from "@shared/agent-catalog.ts";
 import type { AgentKind } from "@shared/contracts/agent.ts";
-import { ChevronDown, ChevronRight } from "lucide-react";
+import { ChevronDown, ChevronRight, ExternalLink } from "lucide-react";
 import { useState } from "react";
 import { AgentIcon } from "@/components/agent-icons/index.tsx";
 import { useT } from "@/i18n/use-t.ts";
@@ -126,13 +126,13 @@ function resolveStatusLabel(
   isDetected: boolean,
   t: ReturnType<typeof useT>
 ): string {
+  if (!isDetected) {
+    return t("settings.agents.status.missing");
+  }
   if (isDisabled) {
     return t("settings.agents.status.disabled");
   }
-  if (isDetected) {
-    return t("settings.agents.status.detected");
-  }
-  return t("settings.agents.status.missing");
+  return t("settings.agents.status.detected");
 }
 
 function resolveStatusVariant(
@@ -162,7 +162,9 @@ export function AgentRow({ agentId }: { agentId: AgentKind }) {
   const entry = getAgentCatalogEntry(agentId);
   const isDetected = detectedIds.includes(agentId);
   const isDisabled = disabledAgentIds.includes(agentId);
-  const isDefault = defaultAgentId === agentId;
+  const isAvailable = isDetected && !isDisabled;
+  const isDefault = isAvailable && defaultAgentId === agentId;
+  const canExpand = isDetected;
 
   const statusLabel = resolveStatusLabel(isDisabled, isDetected, t);
   const statusVariant = resolveStatusVariant(isDisabled, isDetected);
@@ -199,18 +201,32 @@ export function AgentRow({ agentId }: { agentId: AgentKind }) {
           </ItemTitle>
         </ItemContent>
         <ItemActions>
-          <CollapsibleTrigger asChild>
-            <Button
-              aria-label={t("settings.agents.action.expand")}
-              size="sm"
-              type="button"
-              variant="ghost"
-            >
-              {open ? <ChevronDown /> : <ChevronRight />}
-              {t("settings.agents.action.expand")}
+          {canExpand ? (
+            <CollapsibleTrigger asChild>
+              <Button
+                aria-label={t("settings.agents.action.expand")}
+                size="sm"
+                type="button"
+                variant="ghost"
+              >
+                {open ? <ChevronDown /> : <ChevronRight />}
+                {t("settings.agents.action.expand")}
+              </Button>
+            </CollapsibleTrigger>
+          ) : null}
+          {!isDetected && entry?.homepageUrl ? (
+            <Button asChild size="icon-sm" variant="outline">
+              <a
+                aria-label={t("settings.agents.action.website")}
+                href={entry.homepageUrl}
+                rel="noreferrer"
+                target="_blank"
+              >
+                <ExternalLink />
+              </a>
             </Button>
-          </CollapsibleTrigger>
-          {isDefault ? null : (
+          ) : null}
+          {isAvailable && !isDefault ? (
             <Button
               onClick={() => setDefaultAgentId(agentId).catch(() => undefined)}
               size="sm"
@@ -219,20 +235,22 @@ export function AgentRow({ agentId }: { agentId: AgentKind }) {
             >
               {t("settings.agents.action.setDefault")}
             </Button>
-          )}
-          <Button
-            onClick={toggleDisabled}
-            size="sm"
-            type="button"
-            variant={isDisabled ? "default" : "outline"}
-          >
-            {isDisabled
-              ? t("settings.agents.action.enable")
-              : t("settings.agents.action.disable")}
-          </Button>
+          ) : null}
+          {isDetected ? (
+            <Button
+              onClick={toggleDisabled}
+              size="sm"
+              type="button"
+              variant={isDisabled ? "default" : "outline"}
+            >
+              {isDisabled
+                ? t("settings.agents.action.enable")
+                : t("settings.agents.action.disable")}
+            </Button>
+          ) : null}
         </ItemActions>
 
-        {open ? (
+        {open && canExpand ? (
           <CollapsibleContent asChild forceMount>
             <AgentExpandedDetails agentId={agentId} />
           </CollapsibleContent>

--- a/src/renderer/pages/settings/components/agents-section.tsx
+++ b/src/renderer/pages/settings/components/agents-section.tsx
@@ -146,8 +146,20 @@ function PermissionModeRow() {
 
 function AgentListCard() {
   const t = useT();
+  const detectedIds = useAgentDetectStore((s) => s.detectedIds);
   const isRefreshing = useAgentDetectStore((s) => s.isRefreshing);
   const refresh = useAgentDetectStore((s) => s.refresh);
+  const detectedIdSet = new Set(detectedIds);
+  const orderedEntries = AGENT_CATALOG.map((entry, index) => ({
+    entry,
+    index,
+  }))
+    .sort((left, right) => {
+      const leftRank = detectedIdSet.has(left.entry.id) ? 0 : 1;
+      const rightRank = detectedIdSet.has(right.entry.id) ? 0 : 1;
+      return leftRank - rightRank || left.index - right.index;
+    })
+    .map(({ entry }) => entry);
 
   return (
     <Card>
@@ -170,7 +182,7 @@ function AgentListCard() {
       </CardHeader>
       <CardContent className="flex flex-col gap-3 px-0">
         <ItemGroup className="gap-0">
-          {AGENT_CATALOG.map((entry, index) => (
+          {orderedEntries.map((entry, index) => (
             <Fragment key={entry.id}>
               {index > 0 ? <ItemSeparator className="my-0" /> : null}
               <AgentRow agentId={entry.id} />
@@ -184,11 +196,11 @@ function AgentListCard() {
 
 export function AgentsSection() {
   const t = useT();
-  const detect = useAgentDetectStore((s) => s.detect);
+  const ensureDetected = useAgentDetectStore((s) => s.ensureDetected);
 
   useEffect(() => {
-    detect().catch(() => undefined);
-  }, [detect]);
+    ensureDetected().catch(() => undefined);
+  }, [ensureDetected]);
 
   return (
     <div className="px-4 pb-4" id="agents">

--- a/src/renderer/stores/agent-detect.store.ts
+++ b/src/renderer/stores/agent-detect.store.ts
@@ -5,59 +5,71 @@ interface AgentDetectState {
   detect: () => Promise<void>;
   detectedIds: AgentKind[];
   /**
-   * Detect once if not yet probed. Safe to call from anywhere (e.g. the New
-   * Agent action) without relying on the settings page having mounted. No-op
-   * when detection already succeeded; coalesces concurrent callers onto a
-   * single in-flight probe so the palette never re-runs `which` per invocation.
+   * Detect once if not yet probed. Safe to call from anywhere without relying
+   * on a specific settings panel lifecycle. No-op when detection already
+   * succeeded, including the valid "no agents installed" empty result.
    */
   ensureDetected: () => Promise<void>;
+  hasDetected: boolean;
+  isDetecting: boolean;
   isRefreshing: boolean;
   refresh: () => Promise<void>;
 }
 
-let ensureDetectedInFlight: Promise<void> | null = null;
+let detectInFlight: Promise<void> | null = null;
 
 export const useAgentDetectStore = create<AgentDetectState>((set, get) => ({
   detectedIds: [],
+  hasDetected: false,
+  isDetecting: false,
   isRefreshing: false,
 
-  async detect() {
-    try {
-      const result = await window.pier?.agents?.detect?.();
-      if (result) {
-        set({ detectedIds: result.detectedIds });
-      }
-    } catch (err) {
-      console.error("[agent-detect.store] detect failed:", err);
+  detect() {
+    if (detectInFlight) {
+      return detectInFlight;
     }
+
+    detectInFlight = (async () => {
+      set({ isDetecting: true });
+      try {
+        const result = await window.pier?.agents?.detect?.();
+        if (result) {
+          set({ detectedIds: result.detectedIds, hasDetected: true });
+        }
+      } catch (err) {
+        console.error("[agent-detect.store] detect failed:", err);
+      } finally {
+        set({ isDetecting: false });
+      }
+    })().finally(() => {
+      detectInFlight = null;
+    });
+
+    return detectInFlight;
   },
 
   ensureDetected() {
-    if (get().detectedIds.length > 0) {
+    if (get().hasDetected || get().detectedIds.length > 0) {
       return Promise.resolve();
     }
-    if (ensureDetectedInFlight) {
-      return ensureDetectedInFlight;
-    }
-    ensureDetectedInFlight = get()
-      .detect()
-      .finally(() => {
-        ensureDetectedInFlight = null;
-      });
-    return ensureDetectedInFlight;
+    return get().detect();
   },
 
   async refresh() {
-    set({ isRefreshing: true });
+    set({ isDetecting: true, isRefreshing: true });
     try {
       const result = await window.pier?.agents?.refresh?.();
       if (result) {
-        set({ detectedIds: result.detectedIds });
+        set({ detectedIds: result.detectedIds, hasDetected: true });
       }
     } catch (err) {
       console.error("[agent-detect.store] refresh failed:", err);
     } finally {
-      set({ isRefreshing: false });
+      set({ isDetecting: false, isRefreshing: false });
     }
   },
 }));
+
+export function initAgentDetection(): Promise<void> {
+  return useAgentDetectStore.getState().ensureDetected();
+}

--- a/src/shared/agent-catalog.ts
+++ b/src/shared/agent-catalog.ts
@@ -300,8 +300,8 @@ export const AGENT_CATALOG: readonly AgentCatalogEntry[] = [
     launchCmd: "openclaude",
     detectCmd: "openclaude",
     expectedProcess: "openclaude",
+    homepageUrl: "https://openclaude.gitlawb.com/",
     // 图标 favicons/openclaude.png 是 orca 资产，手动放入（非脚本下载）。
-    // orca 未记 homepageUrl，故省略。
   },
 ];
 

--- a/tests/e2e/agents-settings.spec.ts
+++ b/tests/e2e/agents-settings.spec.ts
@@ -5,6 +5,7 @@ import {
   type ElectronApplication,
   _electron as electron,
   expect,
+  type Page,
   test,
 } from "@playwright/test";
 
@@ -16,6 +17,8 @@ const OUT_MAIN = join(
   "main",
   "index.js"
 );
+const SETTINGS_ACCELERATOR =
+  process.platform === "darwin" ? "Meta+Comma" : "Control+Comma";
 
 async function launchPierApp(): Promise<{
   app: ElectronApplication;
@@ -39,6 +42,17 @@ async function closePierApp({
   rmSync(userDataDir, { recursive: true, force: true });
 }
 
+async function openAgentsSettings(win: Page): Promise<void> {
+  await win.waitForTimeout(1500);
+  await win.keyboard.press(SETTINGS_ACCELERATOR);
+
+  const dialog = win.locator('[role="dialog"]');
+  await expect(dialog).toBeVisible({ timeout: 5000 });
+
+  await win.locator("button").filter({ hasText: "智能体" }).first().click();
+  await win.waitForTimeout(600);
+}
+
 test.describe("Agents Settings e2e", () => {
   test("智能体设置区域可见并渲染 Auto 选项和 claude agent 行", async () => {
     // Electron 冷启动 + React 挂载需要比默认 30s 更多余量
@@ -48,20 +62,7 @@ test.describe("Agents Settings e2e", () => {
       const win = await appContext.app.firstWindow();
       await win.waitForLoadState("domcontentloaded");
 
-      // 命令面板打开设置（等待 React 完全挂载后再发键）
-      await win.waitForTimeout(1500);
-      await win.keyboard.press("Meta+Shift+KeyP");
-      await win.waitForTimeout(1000);
-      await win.locator("[cmdk-item]").filter({ hasText: "打开设置" }).click();
-      await win.waitForTimeout(600);
-
-      // 设置 dialog 应该出现
-      const dialog = win.locator('[role="dialog"]');
-      await expect(dialog).toBeVisible({ timeout: 5000 });
-
-      // 点击侧边栏 "智能体" nav 项（取第一个以规避严格模式）
-      await win.locator("button").filter({ hasText: "智能体" }).first().click();
-      await win.waitForTimeout(600);
+      await openAgentsSettings(win);
 
       // 断言 1：catalog 中 claude 行始终渲染（不依赖机器是否安装 claude）
       await expect(win.locator('[data-testid="agent-row-claude"]')).toBeVisible(
@@ -96,35 +97,37 @@ test.describe("Agents Settings e2e", () => {
     }
   });
 
-  test("展开 claude agent 行显示启动命令", async () => {
+  test("claude agent 行按安装状态显示详情或官网", async () => {
     test.setTimeout(60_000);
     const appContext = await launchPierApp();
     try {
       const win = await appContext.app.firstWindow();
       await win.waitForLoadState("domcontentloaded");
 
-      // 打开设置，进入智能体区域
-      await win.waitForTimeout(1500);
-      await win.keyboard.press("Meta+Shift+KeyP");
-      await win.waitForTimeout(1000);
-      await win.locator("[cmdk-item]").filter({ hasText: "打开设置" }).click();
-      await win.waitForTimeout(600);
-
-      const dialog = win.locator('[role="dialog"]');
-      await expect(dialog).toBeVisible({ timeout: 5000 });
-
-      await win.locator("button").filter({ hasText: "智能体" }).first().click();
-      await win.waitForTimeout(600);
+      await openAgentsSettings(win);
 
       // claude agent 行始终渲染
       const claudeRow = win.locator('[data-testid="agent-row-claude"]');
       await expect(claudeRow).toBeVisible({ timeout: 8000 });
 
-      // 展开详情
+      const isMissing = await claudeRow
+        .getByText("未安装", { exact: true })
+        .isVisible()
+        .catch(() => false);
+
+      if (isMissing) {
+        await expect(
+          claudeRow.getByRole("button", { name: "详情" })
+        ).toHaveCount(0);
+        await expect(
+          claudeRow.getByRole("link", { name: "官网" })
+        ).toHaveAttribute("href", "https://claude.com/claude-code");
+        return;
+      }
+
       await claudeRow.getByRole("button", { name: "详情" }).click();
       await win.waitForTimeout(400);
 
-      // 展开后可见启动命令 "claude"（固定来自 AGENT_CATALOG，不依赖机器环境）
       await expect(
         claudeRow.locator(".font-mono").filter({ hasText: "claude" }).first()
       ).toBeVisible({ timeout: 3000 });

--- a/tests/unit/main/agent-detection-service.test.ts
+++ b/tests/unit/main/agent-detection-service.test.ts
@@ -5,6 +5,7 @@ describe("agent detection", () => {
   it("只返回 probe 命中的 agent", async () => {
     const installed = new Set(["claude", "cursor-agent"]);
     const service = createAgentDetectionService({
+      hydratePath: () => Promise.resolve([]),
       probe: (cmd) => Promise.resolve(installed.has(cmd)),
     });
     const result = await service.detect();
@@ -15,12 +16,13 @@ describe("agent detection", () => {
 
   it("全部未装时返回空", async () => {
     const service = createAgentDetectionService({
+      hydratePath: () => Promise.resolve([]),
       probe: () => Promise.resolve(false),
     });
     expect((await service.detect()).detectedIds).toEqual([]);
   });
 
-  it("refresh 先水合 PATH 再探测", async () => {
+  it("detect 先水合 PATH 再探测", async () => {
     let hydrated = false;
     const service = createAgentDetectionService({
       probe: (cmd) => Promise.resolve(hydrated && cmd === "claude"),
@@ -29,9 +31,22 @@ describe("agent detection", () => {
         return Promise.resolve(["/new/bin"]);
       },
     });
-    expect((await service.detect()).detectedIds).toEqual([]);
+    const result = await service.detect();
+    expect(result.detectedIds).toContain("claude");
+  });
+
+  it("refresh 强制重新水合 PATH 再探测", async () => {
+    let hydrateCount = 0;
+    const service = createAgentDetectionService({
+      probe: (cmd) => Promise.resolve(hydrateCount >= 2 && cmd === "claude"),
+      hydratePath: () => {
+        hydrateCount += 1;
+        return Promise.resolve([`/new/bin/${hydrateCount}`]);
+      },
+    });
+    expect((await service.detect()).detectedIds).not.toContain("claude");
     const r = await service.refresh();
     expect(r.detectedIds).toContain("claude");
-    expect(r.addedPathSegments).toEqual(["/new/bin"]);
+    expect(r.addedPathSegments).toEqual(["/new/bin/2"]);
   });
 });

--- a/tests/unit/renderer/agents-section.test.tsx
+++ b/tests/unit/renderer/agents-section.test.tsx
@@ -4,6 +4,7 @@ import {
   render,
   screen,
   waitFor,
+  within,
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { initI18n } from "@/i18n/index.ts";
@@ -50,7 +51,12 @@ describe("AgentsSection", () => {
   beforeEach(async () => {
     await initI18n();
 
-    useAgentDetectStore.setState({ detectedIds: [], isRefreshing: false });
+    useAgentDetectStore.setState({
+      detectedIds: [],
+      hasDetected: false,
+      isDetecting: false,
+      isRefreshing: false,
+    });
     useAgentPreferencesStore.setState(DEFAULT_PREFERENCES);
 
     Object.defineProperty(window, "pier", {
@@ -62,7 +68,12 @@ describe("AgentsSection", () => {
   afterEach(() => {
     cleanup();
     vi.restoreAllMocks();
-    useAgentDetectStore.setState({ detectedIds: [], isRefreshing: false });
+    useAgentDetectStore.setState({
+      detectedIds: [],
+      hasDetected: false,
+      isDetecting: false,
+      isRefreshing: false,
+    });
     useAgentPreferencesStore.setState(DEFAULT_PREFERENCES);
   });
 
@@ -126,6 +137,22 @@ describe("AgentsSection", () => {
     });
   });
 
+  it("sorts detected agent rows before missing rows", async () => {
+    Object.defineProperty(window, "pier", {
+      configurable: true,
+      value: makePierMock(["codex"]),
+    });
+
+    render(<AgentsSection />);
+
+    await waitFor(() => {
+      expect(screen.getAllByRole("listitem")[0]).toHaveAttribute(
+        "data-testid",
+        "agent-row-codex"
+      );
+    });
+  });
+
   it("shows detected badge for claude after detect", async () => {
     render(<AgentsSection />);
     await waitFor(() => {
@@ -186,6 +213,43 @@ describe("AgentsSection", () => {
         );
       });
     }
+  });
+
+  it("missing agent rows do not show stale default or enablement actions", async () => {
+    useAgentPreferencesStore.setState({
+      ...DEFAULT_PREFERENCES,
+      defaultAgentId: "codex",
+      disabledAgentIds: ["codex"],
+    });
+
+    render(<AgentsSection />);
+
+    await waitFor(() => {
+      expect(useAgentDetectStore.getState().detectedIds).toEqual(["claude"]);
+    });
+
+    const codexRow = screen.getByTestId("agent-row-codex");
+    const codex = within(codexRow);
+    expect(codex.getByText("Not installed")).toBeInTheDocument();
+    expect(codex.queryByText("Default")).not.toBeInTheDocument();
+    expect(
+      codex.queryByRole("button", { name: "Details" })
+    ).not.toBeInTheDocument();
+    const websiteLink = codex.getByRole("link", { name: "Website" });
+    expect(websiteLink).toHaveAttribute(
+      "href",
+      "https://github.com/openai/codex"
+    );
+    expect(websiteLink).toHaveAttribute("target", "_blank");
+    expect(
+      codex.queryByRole("button", { name: "Set default" })
+    ).not.toBeInTheDocument();
+    expect(
+      codex.queryByRole("button", { name: "Disable" })
+    ).not.toBeInTheDocument();
+    expect(
+      codex.queryByRole("button", { name: "Enable" })
+    ).not.toBeInTheDocument();
   });
 
   it("Refresh button calls refresh() and reflects isRefreshing", async () => {

--- a/tests/unit/renderer/new-agent-action.test.ts
+++ b/tests/unit/renderer/new-agent-action.test.ts
@@ -21,8 +21,14 @@ function seedStores(opts: {
   defaultAgentId: AgentKind | "blank" | null;
   detectedIds: AgentKind[];
   disabledAgentIds: AgentKind[];
+  hasDetected?: boolean;
 }): void {
-  useAgentDetectStore.setState({ detectedIds: opts.detectedIds });
+  useAgentDetectStore.setState({
+    detectedIds: opts.detectedIds,
+    hasDetected: opts.hasDetected ?? opts.detectedIds.length > 0,
+    isDetecting: false,
+    isRefreshing: false,
+  });
   useAgentPreferencesStore.setState({
     defaultAgentId: opts.defaultAgentId,
     disabledAgentIds: opts.disabledAgentIds,
@@ -40,7 +46,12 @@ describe("new agent action", () => {
   });
 
   afterEach(() => {
-    useAgentDetectStore.setState({ detectedIds: [] });
+    useAgentDetectStore.setState({
+      detectedIds: [],
+      hasDetected: false,
+      isDetecting: false,
+      isRefreshing: false,
+    });
     useAgentPreferencesStore.setState({
       defaultAgentId: null,
       disabledAgentIds: [],
@@ -89,6 +100,22 @@ describe("new agent action", () => {
 
     await runNewAgent();
 
+    expect(toastMocks.error).toHaveBeenCalledTimes(1);
+    expect(prepareLaunch).not.toHaveBeenCalled();
+    expect(addTerminal).not.toHaveBeenCalled();
+  });
+
+  it("启动探测已完成但结果为空 → 不重复探测，直接 toast", async () => {
+    seedStores({
+      defaultAgentId: null,
+      detectedIds: [],
+      disabledAgentIds: [],
+      hasDetected: true,
+    });
+
+    await runNewAgent();
+
+    expect(detect).not.toHaveBeenCalled();
     expect(toastMocks.error).toHaveBeenCalledTimes(1);
     expect(prepareLaunch).not.toHaveBeenCalled();
     expect(addTerminal).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary

Fixes the agent settings page so CLI availability is detected at app startup, installed agents sort first, unavailable agents show only a website icon action, and stale default/enablement controls no longer appear for missing CLIs. Also clarifies the Chinese permission-mode copy.

## Root Cause

Agent detection was tied to the settings page lifecycle and used only the detected id list to infer whether probing had already completed. That made missing CLIs and not-yet-probed state indistinguishable, and the row actions rendered from catalog entries instead of actual availability.

## Validation

- pnpm lint
- pnpm typecheck
- pnpm vitest run tests/unit/main/agent-detection-service.test.ts tests/unit/renderer/new-agent-action.test.ts tests/unit/renderer/agents-section.test.tsx tests/unit/shared/agent-catalog.test.ts
- pnpm build
- pnpm test:e2e tests/e2e/agents-settings.spec.ts
