### PR TITLE
fix(terminal): 精简 resize 占位为纯终端背景色

### DIFF
--- a/src/renderer/panel-kits/terminal/terminal-panel.tsx
+++ b/src/renderer/panel-kits/terminal/terminal-panel.tsx
@@ -310,12 +310,7 @@ export function TerminalPanel(props: IDockviewPanelProps) {
             ref={anchorRef}
           />
           {showPlaceholder ? (
-            <TerminalSurfacePlaceholder
-              className={terminalContentClassName}
-              cwd={effectiveCwd}
-              tabTitle={effectiveTab?.title ?? null}
-              title={effectiveTitle}
-            />
+            <TerminalSurfacePlaceholder className={terminalContentClassName} />
           ) : null}
           {error ? (
             <div

--- a/src/renderer/panel-kits/terminal/terminal-surface-placeholder.tsx
+++ b/src/renderer/panel-kits/terminal/terminal-surface-placeholder.tsx
@@ -1,37 +1,19 @@
-import { SquareTerminal } from "lucide-react";
-import { basename } from "./terminal-tab-chrome.ts";
-
 interface TerminalSurfacePlaceholderProps {
   className: string;
-  cwd: string | null;
-  tabTitle: string | null;
-  title: string | null;
 }
 
 /**
- * 终端表面占位：resize 期间（及 native 终端首次就绪前）顶替 native 终端区域。
- * 标识优先取 tab 标题 / 终端标题 / 目录名；颜色跟随当前终端主题。
+ * 终端表面占位：resize 期间及 native 终端首次就绪前，用终端主题背景色顶替 native
+ * 终端区域，避免几何瞬变时看到窗口底色。不带 marker，与真实终端 buffer 底色无缝衔接。
  */
 export function TerminalSurfacePlaceholder({
   className,
-  cwd,
-  tabTitle,
-  title,
 }: TerminalSurfacePlaceholderProps) {
-  const label = tabTitle ?? title ?? (cwd ? basename(cwd) : "Terminal");
   return (
     <div
       aria-hidden="true"
-      className={`pointer-events-none flex items-center justify-center bg-[var(--terminal-background,var(--background))] ${className}`}
+      className={`pointer-events-none bg-[var(--terminal-background,var(--background))] ${className}`}
       data-testid="terminal-placeholder"
-    >
-      <div
-        className="flex min-w-0 max-w-full flex-col items-center gap-2.5 px-6 text-center opacity-40"
-        style={{ color: "var(--terminal-foreground, var(--muted-foreground))" }}
-      >
-        <SquareTerminal aria-hidden="true" className="size-8" />
-        <span className="max-w-full truncate font-medium text-sm">{label}</span>
-      </div>
-    </div>
+    />
   );
 }


### PR DESCRIPTION
## 背景

[terminal-surface-placeholder.tsx](src/renderer/panel-kits/terminal/terminal-surface-placeholder.tsx) 在两个场景顶替 native 终端区域：

1. **resize / maximize 隐身**：`onWindowLayoutPulse('resize','active')` → 全局 `suppressTerminals` = true → native 终端 `visible=false` 隐身，web 占位顶替
2. **native 首次就绪前**：`nativeTerminalReady=false`

原实现在两种场景都居中显示 `SquareTerminal` icon + label（tab title / terminal title / cwd basename），整体 `opacity-40`。resize 期间产生「终端有内容 → 弱化 icon 居中显示 → 内容恢复」的视觉跳变，比"内容停顿不动"更刺眼。

## 业界调研

- **原生终端**（iTerm2 / kitty / Alacritty / Ghostty）：resize 时内容 letterbox 停留，纯 terminal bg 色，无 marker
- **VS Code integrated terminal**（同为 Electron、同类问题：[#230120](https://github.com/microsoft/vscode/issues/230120)、[#172281](https://github.com/microsoft/vscode/issues/172281)）：默认纯色 bg，从没引入 loading UI 遮盖
- **Electron webview 通病**（[#9280](https://github.com/electron/electron/issues/9280)、[#27378](https://github.com/electron/electron/issues/27378)）：解法都是几何同步 + 同色背景，而非 UI 装饰
- **UX 研究**（NN/g、LogRocket）：skeleton/shimmer 只适用于 > 500ms 的加载，resize < 200ms 场景加装饰只会变闪烁

结论：**纯 `var(--terminal-background)` 背景是最佳选择**——与真实 buffer 底色一致，做到"视觉零边界"，也和业界一致。

## 改动

- 移除占位内部的 `SquareTerminal` icon 与 label 中间层
- 只保留 `pointer-events-none` + `bg-[var(--terminal-background,var(--background))]` 的空 div
- 同步清理 `cwd` / `tabTitle` / `title` 三个孤儿 prop 与 `SquareTerminal` / `basename` import
- 简化 [terminal-panel.tsx:312-314](src/renderer/panel-kits/terminal/terminal-panel.tsx#L312) 调用侧

diff 净删 23 行。

## 兼容性

- `testid="terminal-placeholder"` 保留
- className 仍包含 `--terminal-background`
- `basename` 仍为 [terminal-tab-chrome.ts](src/renderer/panel-kits/terminal/terminal-tab-chrome.ts) 的独立 export，别处调用不受影响
- 现有 3 处 lifecycle 测试断言（[tests/component/terminal-panel-lifecycle.test.tsx:727,798,813](tests/component/terminal-panel-lifecycle.test.tsx#L727)）只关心 testid 存在/消失和 className 包含 `--terminal-background`，全部继续通过

## Test plan

- [x] \`pnpm typecheck\`
- [x] \`pnpm test:unit -- terminal-panel-lifecycle\`
- [x] \`pnpm dev\` 后拖窗口边缘 resize，观察终端区域无 icon 闪现，背景色与终端 buffer 底色一致
- [x] 双击 tab title 触发 maximize/unmaximize，观察同样无 icon 闪现
- [x] 新开 terminal panel 首次挂载，占位显示纯 terminal bg 色（不再有 icon + label loading hint）

🤖 Generated with [Claude Code](https://claude.com/claude-code)