### PR TITLE
feat(command-palette): unified quick-pick row design + stacking/empty-state fixes

### DIFF
--- a/src/main/services/tasks/composer-source.ts
+++ b/src/main/services/tasks/composer-source.ts
@@ -1,0 +1,56 @@
+import { join } from "node:path";
+import type { TaskCandidate } from "@shared/contracts/tasks.ts";
+import { taskCandidate as candidate } from "./task-candidate.ts";
+import { asRecord, commandWithArgs, readTextIfExists } from "./utils.ts";
+
+export interface ComposerSourceOptions {
+  projectRoot: string;
+}
+
+/**
+ * composer scripts 里的标准事件钩子 (pre-install-cmd / post-update-cmd /
+ * pre-autoload-dump 等) 由 composer 生命周期自动触发, 不是用户主动运行的
+ * 任务, 从列表排除; 自定义脚本名不受影响。
+ */
+const COMPOSER_EVENT_HOOK_RE =
+  /^(?:pre|post)-(?:install|update|status|archive|autoload-dump|root-package-install|create-project-cmd|dependencies-solving)/;
+
+function composerScriptDescription(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (Array.isArray(value) && value.every((item) => typeof item === "string")) {
+    return value.join(" && ");
+  }
+  return;
+}
+
+export async function composerSource({
+  projectRoot,
+}: ComposerSourceOptions): Promise<TaskCandidate[]> {
+  const text = await readTextIfExists(join(projectRoot, "composer.json"));
+  if (!text) {
+    return [];
+  }
+  const scripts = asRecord(asRecord(JSON.parse(text))?.scripts);
+  if (!scripts) {
+    return [];
+  }
+  return Object.entries(scripts)
+    .filter(([name]) => !COMPOSER_EVENT_HOOK_RE.test(name))
+    .map(([name, value]) => {
+      const description = composerScriptDescription(value);
+      return candidate({
+        commandSpec: {
+          command: commandWithArgs("composer", ["run-script", name]),
+          kind: "shell",
+        },
+        cwd: projectRoot,
+        ...(description ? { description } : {}),
+        idParts: ["composer", name],
+        label: name,
+        source: "composer",
+        tags: ["php"],
+      });
+    });
+}

--- a/src/main/services/tasks/deno-source.ts
+++ b/src/main/services/tasks/deno-source.ts
@@ -1,0 +1,63 @@
+import { join } from "node:path";
+import type { TaskCandidate } from "@shared/contracts/tasks.ts";
+import { taskCandidate as candidate } from "./task-candidate.ts";
+import {
+  asRecord,
+  asString,
+  commandWithArgs,
+  parseJsonc,
+  readTextIfExists,
+} from "./utils.ts";
+
+export interface DenoSourceOptions {
+  projectRoot: string;
+}
+
+/** deno task 值: 字符串命令, 或对象形式 { command, description }。 */
+function denoTaskDescription(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    return value;
+  }
+  const record = asRecord(value);
+  return asString(record?.description) ?? asString(record?.command);
+}
+
+function isRunnableDenoTask(value: unknown): boolean {
+  if (typeof value === "string") {
+    return value.trim().length > 0;
+  }
+  // 对象任务可以只有 dependencies 没有 command, 同样可通过 deno task 运行。
+  return asRecord(value) !== null;
+}
+
+export async function denoSource({
+  projectRoot,
+}: DenoSourceOptions): Promise<TaskCandidate[]> {
+  const text =
+    (await readTextIfExists(join(projectRoot, "deno.json"))) ??
+    (await readTextIfExists(join(projectRoot, "deno.jsonc")));
+  if (!text) {
+    return [];
+  }
+  const tasks = asRecord(asRecord(parseJsonc(text))?.tasks);
+  if (!tasks) {
+    return [];
+  }
+  return Object.entries(tasks)
+    .filter(([, value]) => isRunnableDenoTask(value))
+    .map(([name, value]) => {
+      const description = denoTaskDescription(value);
+      return candidate({
+        commandSpec: {
+          command: commandWithArgs("deno", ["task", name]),
+          kind: "shell",
+        },
+        cwd: projectRoot,
+        ...(description ? { description } : {}),
+        idParts: ["deno", name],
+        label: name,
+        source: "deno",
+        tags: ["deno"],
+      });
+    });
+}

--- a/src/main/services/tasks/task-execution-plan.ts
+++ b/src/main/services/tasks/task-execution-plan.ts
@@ -11,6 +11,8 @@ const VARIABLE_RE = /\$\{([^}]+)\}/g;
 
 const TASK_SOURCE_LABELS: Record<TaskSource, string> = {
   cargo: "Cargo",
+  composer: "Composer",
+  deno: "Deno",
   history: "Recently Run",
   just: "Justfile",
   make: "Makefile",

--- a/src/main/services/tasks/task-sources.ts
+++ b/src/main/services/tasks/task-sources.ts
@@ -7,6 +7,8 @@ import type {
   TaskSource,
   TaskSourceError,
 } from "@shared/contracts/tasks.ts";
+import { composerSource } from "./composer-source.ts";
+import { denoSource } from "./deno-source.ts";
 import {
   taskCandidate as candidate,
   optionalEnv,
@@ -41,7 +43,12 @@ const LINE_SPLIT_RE = /\r?\n/;
 const SAFE_TOML_SECTION_RE = /^\[([^\]]+)\]$/;
 const SAFE_TOML_ENTRY_RE = /^([A-Za-z0-9_.-]+)\s*=\s*"([^"]+)"\s*$/;
 const TASKFILE_ROOT_RE = /^tasks:\s*$/;
-const TASKFILE_NAME_RE = /^ {2}([A-Za-z0-9_.-]+):\s*$/;
+// 任务名允许命名空间冒号 (docs:build), 缩进宽度以块内首个任务为准。
+const TASKFILE_NAME_RE =
+  /^(\s+)([A-Za-z0-9_.-]+(?::[A-Za-z0-9_.-]+)*):\s*(?:#.*)?$/;
+const LEADING_WHITESPACE_RE = /^\s/;
+const JUST_PRIVATE_ATTR_RE = /^\[[^\]]*private[^\]]*\]$/;
+const JUST_RECIPE_RE = /^([A-Za-z0-9_.-]+)(?:\s+[^:=]+)?\s*:(?!=)/;
 
 async function packageScriptSource({
   projectRoot,
@@ -158,7 +165,7 @@ async function cargoSource({
   if (!(await pathExists(join(projectRoot, "Cargo.toml")))) {
     return [];
   }
-  return ["build", "test", "check", "run"].map((name) =>
+  const builtin = ["build", "test", "check", "run"].map((name) =>
     candidate({
       commandSpec: { command: `cargo ${name}`, kind: "shell" },
       cwd: projectRoot,
@@ -168,6 +175,23 @@ async function cargoSource({
       tags: ["rust"],
     })
   );
+  // .cargo/config.toml 的 [alias] 自定义子命令 (cargo <alias>)。
+  const config =
+    (await readTextIfExists(join(projectRoot, ".cargo", "config.toml"))) ??
+    (await readTextIfExists(join(projectRoot, ".cargo", "config")));
+  const aliases = config ? tomlSectionEntries(config, "alias") : {};
+  const aliasTasks = Object.entries(aliases).map(([name, expansion]) =>
+    candidate({
+      commandSpec: { command: `cargo ${name}`, kind: "shell" },
+      cwd: projectRoot,
+      description: `cargo ${expansion}`,
+      idParts: ["cargo", "alias", name],
+      label: `cargo ${name}`,
+      source: "cargo",
+      tags: ["rust"],
+    })
+  );
+  return [...builtin, ...aliasTasks];
 }
 
 async function makeSource({
@@ -258,9 +282,11 @@ async function miseSource({
   if (!text) {
     return [];
   }
-  const names = [...text.matchAll(/^\[tasks\.([A-Za-z0-9_.-]+)\]$/gm)].flatMap(
-    (match) => (match[1] ? [match[1]] : [])
-  );
+  // 段名任务两种写法: [tasks.build] 与带引号的 [tasks."docs:build"]。
+  const names = [
+    ...text.matchAll(/^\[tasks\.([A-Za-z0-9_.-]+)\]\s*$/gm),
+    ...text.matchAll(/^\[tasks\."([^"]+)"\]\s*$/gm),
+  ].flatMap((match) => (match[1] ? [match[1]] : []));
   const inlineTasks = Object.keys(tomlSectionEntries(text, "tasks"));
   return [...new Set([...names, ...inlineTasks])]
     .filter((name): name is string => typeof name === "string")
@@ -287,12 +313,29 @@ async function justSource({
   if (!text) {
     return [];
   }
-  const recipes = [...text.matchAll(/^([A-Za-z0-9_.-]+)(?:\s+[^:=]+)?\s*:/gm)]
-    .map((match) => match[1])
-    .filter(
-      (name): name is string =>
-        typeof name === "string" && !name.startsWith("_")
-    );
+  // 逐行扫描而非全文 matchAll: 需要排除赋值行 (alias/set/export 的 `:=`)
+  // 和被 [private] 属性标记的 recipe。
+  const recipes: string[] = [];
+  let privatePending = false;
+  for (const line of text.split(LINE_SPLIT_RE)) {
+    const trimmed = line.trim();
+    if (JUST_PRIVATE_ATTR_RE.test(trimmed)) {
+      privatePending = true;
+      continue;
+    }
+    const match = line.match(JUST_RECIPE_RE);
+    if (!match?.[1] || line.includes(":=")) {
+      if (trimmed.length > 0 && !trimmed.startsWith("#")) {
+        privatePending = false;
+      }
+      continue;
+    }
+    if (privatePending || match[1].startsWith("_")) {
+      privatePending = false;
+      continue;
+    }
+    recipes.push(match[1]);
+  }
   return [...new Set(recipes)]
     .filter((name): name is string => typeof name === "string")
     .map((name) =>
@@ -313,17 +356,33 @@ function taskfileNames(text: string): string[] {
   const lines = text.split(LINE_SPLIT_RE);
   const names: string[] = [];
   let inTasks = false;
+  // 块内首个任务的缩进作为该层级基准 (兼容 2/4 空格或 tab)。
+  let taskIndent: null | string = null;
   for (const line of lines) {
-    if (TASKFILE_ROOT_RE.test(line.trim())) {
+    if (TASKFILE_ROOT_RE.test(line)) {
       inTasks = true;
+      taskIndent = null;
       continue;
     }
     if (!inTasks) {
       continue;
     }
+    // 顶格出现其他 root key (vars:/env:/includes: 等) 即离开 tasks 块,
+    // 否则后续块的二级键会被误当成任务。
+    if (
+      line.length > 0 &&
+      !(LEADING_WHITESPACE_RE.test(line) || line.startsWith("#"))
+    ) {
+      inTasks = false;
+      continue;
+    }
     const match = line.match(TASKFILE_NAME_RE);
-    if (match?.[1]) {
-      names.push(match[1]);
+    if (!(match?.[1] && match[2])) {
+      continue;
+    }
+    taskIndent ??= match[1];
+    if (match[1] === taskIndent) {
+      names.push(match[2]);
     }
   }
   return names;
@@ -370,6 +429,8 @@ function historySource({
 
 export const taskSourceProviders: readonly TaskSourceProvider[] = [
   { id: "package-script", list: packageScriptSource },
+  { id: "deno", list: denoSource },
+  { id: "composer", list: composerSource },
   { id: "vscode", list: vscodeSource },
   { id: "zed", list: zedSource },
   { id: "cargo", list: cargoSource },

--- a/src/plugins/api/renderer.ts
+++ b/src/plugins/api/renderer.ts
@@ -82,9 +82,11 @@ export interface RendererPluginQuickPickItem {
   readonly description?: string;
   readonly detail?: string;
   readonly disabled?: boolean;
+  readonly icon?: LucideIcon;
   readonly id: string;
   readonly label: string;
   readonly searchTerms?: readonly string[];
+  readonly variant?: "default" | "destructive";
 }
 
 export interface RendererPluginQuickPickSection {

--- a/src/plugins/builtin/git/renderer/format-relative-time.ts
+++ b/src/plugins/builtin/git/renderer/format-relative-time.ts
@@ -1,0 +1,51 @@
+/**
+ * quick-pick 行右侧时间列的统一格式: 7 天内相对时间("12分钟前"),
+ * 更早显示短日期(跨年补年份)。解析失败返回 "" 由调用方兜底。
+ */
+
+function getIntlLocale(): string {
+  if (typeof document !== "undefined" && document.documentElement.lang) {
+    return document.documentElement.lang;
+  }
+  if (typeof navigator !== "undefined" && navigator.language) {
+    return navigator.language;
+  }
+  return "en-US";
+}
+
+function parseIsoDate(value: null | string | undefined): Date | null {
+  if (!value) {
+    return null;
+  }
+  const date = new Date(value);
+  return Number.isFinite(date.getTime()) ? date : null;
+}
+
+export function formatRelativeTime(value: null | string | undefined): string {
+  const date = parseIsoDate(value);
+  if (!date) {
+    return "";
+  }
+  const diffMs = date.getTime() - Date.now();
+  const absMs = Math.abs(diffMs);
+  const locale = getIntlLocale();
+  const relative = new Intl.RelativeTimeFormat(locale, { numeric: "auto" });
+  const minute = 60_000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+  if (absMs < hour) {
+    return relative.format(Math.round(diffMs / minute), "minute");
+  }
+  if (absMs < day) {
+    return relative.format(Math.round(diffMs / hour), "hour");
+  }
+  if (absMs < 7 * day) {
+    return relative.format(Math.round(diffMs / day), "day");
+  }
+  const sameYear = date.getFullYear() === new Date().getFullYear();
+  return new Intl.DateTimeFormat(locale, {
+    day: "numeric",
+    month: "short",
+    ...(sameYear ? {} : { year: "numeric" as const }),
+  }).format(date);
+}

--- a/src/plugins/builtin/git/renderer/git-branch-quick-pick-row.tsx
+++ b/src/plugins/builtin/git/renderer/git-branch-quick-pick-row.tsx
@@ -1,6 +1,7 @@
 import { Badge } from "@pier/ui/badge.tsx";
 import type { GitDiffBranchOption } from "@shared/contracts/git.ts";
 import { GitBranch } from "lucide-react";
+import { formatRelativeTime } from "./format-relative-time.ts";
 
 /** Badge 默认尺寸偏大,统一压缩到行内 4px 网格;色彩语义交给 variant。 */
 const ROW_BADGE_CLASS = "h-4 rounded-sm px-1.5 text-[10px]";
@@ -140,51 +141,4 @@ function branchAheadBehind(
     ahead: aheadFromCurrent ?? 0,
     behind: behindFromCurrent ?? 0,
   };
-}
-
-function getIntlLocale(): string {
-  if (typeof document !== "undefined" && document.documentElement.lang) {
-    return document.documentElement.lang;
-  }
-  if (typeof navigator !== "undefined" && navigator.language) {
-    return navigator.language;
-  }
-  return "en-US";
-}
-
-function parseIsoDate(value: null | string | undefined): Date | null {
-  if (!value) {
-    return null;
-  }
-  const date = new Date(value);
-  return Number.isFinite(date.getTime()) ? date : null;
-}
-
-function formatRelativeTime(value: null | string | undefined): string {
-  const date = parseIsoDate(value);
-  if (!date) {
-    return "";
-  }
-  const diffMs = date.getTime() - Date.now();
-  const absMs = Math.abs(diffMs);
-  const locale = getIntlLocale();
-  const relative = new Intl.RelativeTimeFormat(locale, { numeric: "auto" });
-  const minute = 60_000;
-  const hour = 60 * minute;
-  const day = 24 * hour;
-  if (absMs < hour) {
-    return relative.format(Math.round(diffMs / minute), "minute");
-  }
-  if (absMs < day) {
-    return relative.format(Math.round(diffMs / hour), "hour");
-  }
-  if (absMs < 7 * day) {
-    return relative.format(Math.round(diffMs / day), "day");
-  }
-  const sameYear = date.getFullYear() === new Date().getFullYear();
-  return new Intl.DateTimeFormat(locale, {
-    day: "numeric",
-    month: "short",
-    ...(sameYear ? {} : { year: "numeric" as const }),
-  }).format(date);
 }

--- a/src/plugins/builtin/git/renderer/git-stash-actions.ts
+++ b/src/plugins/builtin/git/renderer/git-stash-actions.ts
@@ -8,6 +8,7 @@ import type {
   GitStashResult,
 } from "@shared/contracts/git.ts";
 import { Package } from "lucide-react";
+import { formatRelativeTime } from "./format-relative-time.ts";
 import {
   activeCwdOrMessage,
   commandTitle,
@@ -26,13 +27,15 @@ interface StashItem extends RendererPluginQuickPickItem {
 }
 
 function stashItem(entry: GitStashEntry): StashItem {
+  // message 是主要信息, 放第二行(空间足); 日期作次要信息靠右, 与分支列表的相对时间同位。
   return {
-    detail: entry.date,
+    description: formatRelativeTime(entry.date) || entry.date,
+    icon: Package,
     id: String(entry.index),
     index: entry.index,
     label: `stash@{${entry.index}}`,
     searchTerms: [entry.message, entry.hash],
-    ...(entry.message ? { description: entry.message } : {}),
+    ...(entry.message ? { detail: entry.message } : {}),
   };
 }
 

--- a/src/plugins/builtin/git/renderer/git-status-parts.tsx
+++ b/src/plugins/builtin/git/renderer/git-status-parts.tsx
@@ -14,9 +14,9 @@ import {
   Cherry,
   CloudOff,
   FilePlus,
+  FolderGit2,
   GitBranch,
   GitCompareArrows,
-  GitFork,
   GitMerge,
   GitPullRequestArrow,
   type LucideIcon,
@@ -92,7 +92,7 @@ function Pill({
 export function WorktreeBadge({ name }: { name: string }): React.ReactElement {
   return (
     <span className="inline-flex items-center gap-1">
-      <GitFork aria-hidden="true" className="h-3 w-3" />
+      <FolderGit2 aria-hidden="true" className="h-3 w-3" />
       <span className="max-w-[120px] truncate">{name}</span>
     </span>
   );

--- a/src/plugins/builtin/git/renderer/worktree-list-action.ts
+++ b/src/plugins/builtin/git/renderer/worktree-list-action.ts
@@ -8,7 +8,7 @@ import type {
   WorktreeItem,
   WorktreeListResult,
 } from "@shared/contracts/worktree.ts";
-import { GitFork } from "lucide-react";
+import { FolderGit2 } from "lucide-react";
 import { registerWorktreeOperationActions } from "./worktree-operation-actions.ts";
 
 const PATH_SEPARATOR_RE = /[\\/]/;
@@ -68,13 +68,8 @@ function activeWorktreeTarget(
   return { enabled: true, path };
 }
 
-function itemLabel(
-  context: RendererPluginContext,
-  worktree: WorktreeItem
-): string {
-  if (worktree.isMain) {
-    return pluginText(context, "main", "main");
-  }
+function itemLabel(worktree: WorktreeItem): string {
+  // 标题直接用分支名(和分支列表同语言);"主工作树" 语义交给 badge, 避免重复。
   return worktree.branch ?? basename(worktree.path);
 }
 
@@ -84,9 +79,6 @@ function itemDescription(
 ): string | undefined {
   if (worktree.locked) {
     return worktree.lockedReason ?? pluginText(context, "locked", "Locked");
-  }
-  if (worktree.isMain) {
-    return worktree.branch ?? undefined;
   }
   return;
 }
@@ -134,8 +126,9 @@ function buildWorktreeSections(
         ...(description ? { description } : {}),
         detail: worktree.path,
         disabled: false,
+        icon: FolderGit2,
         id: `worktree:${worktree.path}`,
-        label: itemLabel(context, worktree),
+        label: itemLabel(worktree),
         searchTerms: worktreeSearchTerms(worktree),
       };
     });
@@ -248,7 +241,7 @@ function registerWorktreeListAction(
     metadata: {
       categoryKey: "git",
       group: "1_worktree",
-      iconComponent: GitFork,
+      iconComponent: FolderGit2,
       sortOrder: 1,
     },
     surfaces: ["command-palette"],

--- a/src/plugins/builtin/git/renderer/worktree-operation-actions.ts
+++ b/src/plugins/builtin/git/renderer/worktree-operation-actions.ts
@@ -1,6 +1,6 @@
 import type { RendererPluginContext } from "@plugins/api/renderer.ts";
 import type { WorktreeItem } from "@shared/contracts/worktree.ts";
-import { BrushCleaning, GitBranch, Trash2 } from "lucide-react";
+import { BrushCleaning, FolderGit2, GitBranch, Trash2 } from "lucide-react";
 
 const PATH_SEPARATOR_RE = /[\\/]/;
 
@@ -55,13 +55,7 @@ function activeWorktreeTarget(
   return { enabled: true, path };
 }
 
-function itemLabel(
-  context: RendererPluginContext,
-  worktree: WorktreeItem
-): string {
-  if (worktree.isMain) {
-    return pluginText(context, "main", "main");
-  }
+function itemLabel(worktree: WorktreeItem): string {
   return worktree.branch ?? basename(worktree.path);
 }
 
@@ -128,7 +122,8 @@ async function confirmQuickPick(
     context.commandPalette.openQuickPick({
       items: [
         { id: "cancel", label: pluginText(context, "cancel", "Cancel") },
-        { id: "confirm", label: confirmLabel },
+        // 两个调用方 (删除/清理 worktree) 都是破坏性操作, 确认项统一警示色。
+        { id: "confirm", label: confirmLabel, variant: "destructive" },
       ],
       onAccept: (item) => {
         resolve(item.id === "confirm");
@@ -251,8 +246,9 @@ function registerWorktreeDeleteAction(
       }
       const items = candidates.map((worktree) => ({
         detail: worktree.path,
+        icon: FolderGit2,
         id: `delete:${worktree.path}`,
-        label: itemLabel(context, worktree),
+        label: itemLabel(worktree),
         searchTerms: worktreeSearchTerms(worktree),
       }));
       const worktreesById = new Map(
@@ -305,7 +301,7 @@ async function deleteSelectedWorktree(
     context,
     title,
     pluginText(context, "deleteConfirm", "Delete worktree {{name}}?", {
-      name: itemLabel(context, worktree),
+      name: itemLabel(worktree),
     }),
     pluginText(context, "deleteConfirmButton", "Delete")
   );

--- a/src/renderer/components/common/command-palette-quick-pick-view.tsx
+++ b/src/renderer/components/common/command-palette-quick-pick-view.tsx
@@ -1,0 +1,149 @@
+/**
+ * quick-pick 模式的列表渲染: 分组/扁平两种形态 + 默认行。
+ * 状态与事件路由仍在 command-palette.tsx, 这里是纯展示层。
+ */
+
+import { Badge } from "@pier/ui/badge.tsx";
+import { CommandGroup, CommandItem } from "@pier/ui/command.tsx";
+import type { ReactNode } from "react";
+import { quickPickResults } from "@/lib/command-palette/quick-pick-search.ts";
+import type { QuickPick, QuickPickItem } from "@/lib/command-palette/types.ts";
+
+export function quickPickItems(quickPick: QuickPick): readonly QuickPickItem[] {
+  if (quickPick.sections && quickPick.sections.length > 0) {
+    return quickPick.sections.flatMap((section) => section.items);
+  }
+  return quickPick.items ?? [];
+}
+
+export function isQuickPickItemSelectable(
+  quickPick: QuickPick,
+  item: QuickPickItem
+): boolean {
+  return quickPick.loading !== true && item.disabled !== true;
+}
+
+/**
+ * quick-pick 默认行, 与 GitBranchQuickPickRow 同一套视觉语言:
+ * 可选图标 + 标题行 (label + badges) + 副标题行 (detail) + 右侧次要信息
+ * (description)。整行 items-center, 让 CommandItem 尾部的对勾垂直居中。
+ */
+function QuickPickDefaultRow({ item }: { item: QuickPickItem }): ReactNode {
+  const Icon = item.icon;
+  const destructive = item.variant === "destructive";
+  return (
+    <span className="flex min-w-0 flex-1 items-center gap-2.5 py-0.5">
+      {Icon ? (
+        <Icon
+          aria-hidden="true"
+          className={
+            destructive
+              ? "size-4 shrink-0 text-destructive"
+              : "size-4 shrink-0 text-muted-foreground"
+          }
+        />
+      ) : null}
+      <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <span className="flex min-w-0 items-baseline gap-1.5">
+          <span
+            className={
+              destructive
+                ? "min-w-0 truncate font-medium text-destructive text-sm/tight"
+                : "min-w-0 truncate font-medium text-sm/tight"
+            }
+          >
+            {item.label}
+          </span>
+          {item.badges?.map((badge) => (
+            <Badge
+              className="h-4 shrink-0 rounded-sm px-1.5 text-[10px]"
+              key={`${item.id}:${badge.label}`}
+              variant={badge.variant ?? "secondary"}
+            >
+              {badge.label}
+            </Badge>
+          ))}
+        </span>
+        {item.detail ? (
+          <span className="truncate text-muted-foreground text-xs/tight">
+            {item.detail}
+          </span>
+        ) : null}
+      </span>
+      {item.description ? (
+        <span className="min-w-0 max-w-[45%] shrink truncate text-right text-muted-foreground text-xs/tight">
+          {item.description}
+        </span>
+      ) : null}
+    </span>
+  );
+}
+
+export function QuickPickView({
+  quickPick,
+  onAccept,
+  query,
+}: {
+  quickPick: QuickPick;
+  onAccept: (item: QuickPickItem) => Promise<void>;
+  query: string;
+}): ReactNode {
+  const renderItem = (item: QuickPickItem) => {
+    const disabled = !isQuickPickItemSelectable(quickPick, item);
+    const content = quickPick.renderItem ? (
+      quickPick.renderItem(item)
+    ) : (
+      <QuickPickDefaultRow item={item} />
+    );
+    return (
+      <CommandItem
+        aria-current={item.checked === true ? "true" : undefined}
+        className="items-center gap-2 py-2"
+        data-checked={item.checked === true}
+        data-disabled={disabled}
+        disabled={disabled}
+        key={item.id}
+        onSelect={() => {
+          if (disabled) {
+            return;
+          }
+          onAccept(item).catch((err) => {
+            console.error(
+              `[command-palette] quick-pick onAccept ${item.id} rejected:`,
+              err
+            );
+          });
+        }}
+        value={item.id}
+      >
+        {content}
+      </CommandItem>
+    );
+  };
+
+  return (
+    <div className="mt-2">
+      {quickPick.sections && quickPick.sections.length > 0
+        ? quickPick.sections.map((section) => {
+            const items =
+              quickPick.loading === true
+                ? section.items
+                : quickPickResults(section.items, query, section.heading);
+            // shouldFilter={false} 下 cmdk 不感知手动过滤, 不会自动藏空组,
+            // 过滤后无匹配的分组必须在这里跳过, 否则空态下残留组标题。
+            if (items.length === 0) {
+              return null;
+            }
+            return (
+              <CommandGroup heading={section.heading} key={section.id}>
+                {items.map(renderItem)}
+              </CommandGroup>
+            );
+          })
+        : (quickPick.loading === true
+            ? (quickPick.items ?? [])
+            : quickPickResults(quickPick.items ?? [], query)
+          ).map(renderItem)}
+    </div>
+  );
+}

--- a/src/renderer/components/common/command-palette.tsx
+++ b/src/renderer/components/common/command-palette.tsx
@@ -8,14 +8,11 @@
  *     debounced onChangeSelection (preview 去重)。
  */
 
-import { Badge } from "@pier/ui/badge.tsx";
 import {
   Command,
   CommandDialog,
   CommandEmpty,
-  CommandGroup,
   CommandInput,
-  CommandItem,
   CommandList,
 } from "@pier/ui/command.tsx";
 import {
@@ -30,6 +27,11 @@ import {
   CommandsView,
   SearchResultsView,
 } from "@/components/common/command-palette-action-rows.tsx";
+import {
+  isQuickPickItemSelectable,
+  QuickPickView,
+  quickPickItems,
+} from "@/components/common/command-palette-quick-pick-view.tsx";
 import { useT } from "@/i18n/use-t.ts";
 import { actionRegistry } from "@/lib/actions/registry.ts";
 import type { Action } from "@/lib/actions/types.ts";
@@ -39,8 +41,7 @@ import {
 } from "@/lib/command-palette/action-search.ts";
 import { useCommandPaletteController } from "@/lib/command-palette/controller.ts";
 import { CATEGORY_META } from "@/lib/command-palette/frecency.ts";
-import { quickPickResults } from "@/lib/command-palette/quick-pick-search.ts";
-import type { QuickPick, QuickPickItem } from "@/lib/command-palette/types.ts";
+import type { QuickPickItem } from "@/lib/command-palette/types.ts";
 import { formatChord } from "@/lib/keybindings/formatter.ts";
 import { keybindingRegistry } from "@/lib/keybindings/registry.ts";
 import { useCommandPaletteMru } from "@/stores/command-palette-mru.store.ts";
@@ -59,20 +60,6 @@ function useActions(): readonly Action[] {
     () => 0
   );
   return actionRegistry.list("command-palette");
-}
-
-function quickPickItems(quickPick: QuickPick): readonly QuickPickItem[] {
-  if (quickPick.sections && quickPick.sections.length > 0) {
-    return quickPick.sections.flatMap((section) => section.items);
-  }
-  return quickPick.items ?? [];
-}
-
-function isQuickPickItemSelectable(
-  quickPick: QuickPick,
-  item: QuickPickItem
-): boolean {
-  return quickPick.loading !== true && item.disabled !== true;
 }
 
 /**
@@ -373,100 +360,14 @@ export function CommandPalette() {
           value={query}
         />
         <CommandList className="max-h-[min(60vh,520px)]">
-          <CommandEmpty>{t("commandPalette.empty")}</CommandEmpty>
+          <CommandEmpty>
+            {mode === "quick-pick"
+              ? t("commandPalette.emptyQuickPick")
+              : t("commandPalette.empty")}
+          </CommandEmpty>
           {commandContent ?? actionContent}
         </CommandList>
       </Command>
     </CommandDialog>
-  );
-}
-
-function QuickPickView({
-  quickPick,
-  onAccept,
-  query,
-}: {
-  quickPick: QuickPick;
-  onAccept: (item: QuickPickItem) => Promise<void>;
-  query: string;
-}): ReactNode {
-  const renderItem = (item: QuickPickItem) => {
-    const disabled = !isQuickPickItemSelectable(quickPick, item);
-    const content = quickPick.renderItem ? (
-      quickPick.renderItem(item)
-    ) : (
-      <>
-        <span className="min-w-0 flex-1 self-center">
-          <span className="flex min-w-0 items-center gap-1.5">
-            <span className="truncate">{item.label}</span>
-            {item.badges?.map((badge) => (
-              <Badge
-                className="h-4.5 px-1.5 text-[10px]"
-                key={`${item.id}:${badge.label}`}
-                variant={badge.variant ?? "secondary"}
-              >
-                {badge.label}
-              </Badge>
-            ))}
-          </span>
-          {item.detail ? (
-            <span className="block truncate text-muted-foreground text-xs">
-              {item.detail}
-            </span>
-          ) : null}
-        </span>
-        {item.description ? (
-          <span className="ml-auto min-w-0 max-w-[45%] shrink truncate pt-0.5 text-right text-muted-foreground text-xs">
-            {item.description}
-          </span>
-        ) : null}
-      </>
-    );
-    return (
-      <CommandItem
-        aria-current={item.checked === true ? "true" : undefined}
-        className={
-          quickPick.renderItem
-            ? "items-center gap-2 py-2"
-            : "items-start gap-3 py-2"
-        }
-        data-checked={item.checked === true}
-        data-disabled={disabled}
-        disabled={disabled}
-        key={item.id}
-        onSelect={() => {
-          if (disabled) {
-            return;
-          }
-          onAccept(item).catch((err) => {
-            console.error(
-              `[command-palette] quick-pick onAccept ${item.id} rejected:`,
-              err
-            );
-          });
-        }}
-        value={item.id}
-      >
-        {content}
-      </CommandItem>
-    );
-  };
-
-  return (
-    <div className="mt-2">
-      {quickPick.sections && quickPick.sections.length > 0
-        ? quickPick.sections.map((section) => (
-            <CommandGroup heading={section.heading} key={section.id}>
-              {(quickPick.loading === true
-                ? section.items
-                : quickPickResults(section.items, query, section.heading)
-              ).map(renderItem)}
-            </CommandGroup>
-          ))
-        : (quickPick.loading === true
-            ? (quickPick.items ?? [])
-            : quickPickResults(quickPick.items ?? [], query)
-          ).map(renderItem)}
-    </div>
   );
 }

--- a/src/renderer/components/workspace/panel-tab-header.tsx
+++ b/src/renderer/components/workspace/panel-tab-header.tsx
@@ -68,6 +68,10 @@ function localizedTooltipValue(
   switch (value) {
     case "Cargo":
       return t("commandPalette.run.taskTab.source.cargo");
+    case "Composer":
+      return t("commandPalette.run.taskTab.source.composer");
+    case "Deno":
+      return t("commandPalette.run.taskTab.source.deno");
     case "Recently Run":
       return t("commandPalette.run.taskTab.source.history");
     case "Justfile":

--- a/src/renderer/i18n/locales/en/command-palette.ts
+++ b/src/renderer/i18n/locales/en/command-palette.ts
@@ -145,7 +145,7 @@ export const commandPalette = {
     loadingTasksDetail: "Scanning supported task sources in the active project",
     noTasks: "No runnable tasks found",
     noTasksDetail:
-      "Supported sources include package.json, VS Code, Zed, Cargo, Make, mise, Justfile, Taskfile, and pyproject",
+      "Supported sources include package.json, deno.json, composer.json, VS Code, Zed, Cargo, Make, mise, Justfile, Taskfile, and pyproject",
     section: {
       group: "Group {{group}}",
       taskErrors: "Task Source Errors",
@@ -154,6 +154,8 @@ export const commandPalette = {
       hidden: "Hidden",
       source: {
         cargo: "Cargo",
+        composer: "Composer",
+        deno: "Deno",
         history: "Recently Run",
         just: "Justfile",
         make: "Makefile",

--- a/src/renderer/i18n/locales/en/command-palette.ts
+++ b/src/renderer/i18n/locales/en/command-palette.ts
@@ -1,6 +1,7 @@
 export const commandPalette = {
   title: "Command Palette",
   empty: "No matching command",
+  emptyQuickPick: "No matching items",
   searchResults: "Results",
   agents: {
     noAgentDetected: "No agent CLI detected",

--- a/src/renderer/i18n/locales/zh-CN/command-palette.ts
+++ b/src/renderer/i18n/locales/zh-CN/command-palette.ts
@@ -1,6 +1,7 @@
 export const commandPalette = {
   title: "命令面板",
   empty: "无匹配命令",
+  emptyQuickPick: "无匹配项",
   searchResults: "搜索结果",
   agents: {
     noAgentDetected: "未检测到可用 agent",

--- a/src/renderer/i18n/locales/zh-CN/command-palette.ts
+++ b/src/renderer/i18n/locales/zh-CN/command-palette.ts
@@ -187,7 +187,7 @@ export const commandPalette = {
     loadingTasksDetail: "正在扫描当前项目支持的任务源",
     noTasks: "未发现可运行任务",
     noTasksDetail:
-      "支持 package.json、VS Code、Zed、Cargo、Make、mise、Justfile、Taskfile 和 pyproject",
+      "支持 package.json、deno.json、composer.json、VS Code、Zed、Cargo、Make、mise、Justfile、Taskfile 和 pyproject",
     section: {
       group: "第 {{group}} 组",
       taskErrors: "任务来源错误",
@@ -196,6 +196,8 @@ export const commandPalette = {
       hidden: "隐藏",
       source: {
         cargo: "Cargo",
+        composer: "Composer",
+        deno: "Deno",
         history: "最近运行",
         just: "Justfile",
         make: "Makefile",

--- a/src/renderer/lib/actions/run-actions.ts
+++ b/src/renderer/lib/actions/run-actions.ts
@@ -142,6 +142,10 @@ function taskSourceLabel(source: TaskSource): string {
   switch (source) {
     case "cargo":
       return i18next.t("commandPalette.run.taskTab.source.cargo");
+    case "composer":
+      return i18next.t("commandPalette.run.taskTab.source.composer");
+    case "deno":
+      return i18next.t("commandPalette.run.taskTab.source.deno");
     case "history":
       return i18next.t("commandPalette.run.taskTab.source.history");
     case "just":

--- a/src/renderer/lib/actions/run-actions.ts
+++ b/src/renderer/lib/actions/run-actions.ts
@@ -6,7 +6,7 @@ import type {
   TaskSpawnResult,
 } from "@shared/contracts/tasks.ts";
 import i18next from "i18next";
-import { List, Play } from "lucide-react";
+import { List, Play, SquareTerminal } from "lucide-react";
 import { panelKindOf } from "@/components/workspace/panel-registry.ts";
 import type { WorkspacePanelSnapshot } from "@/components/workspace/workspace-panel-snapshots.ts";
 import { buildWorkspacePanelSnapshots } from "@/components/workspace/workspace-panel-snapshots.ts";
@@ -94,6 +94,7 @@ function buildTerminalPanelSections(openPanels: WorkspacePanelSnapshot[]): {
     const item: QuickPickItem = {
       badges: terminalTabBadge(panel),
       checked: panel.active === true,
+      icon: SquareTerminal,
       id: itemId,
       searchTerms: [
         panel.id,
@@ -173,21 +174,18 @@ function commandDetail(task: TaskCandidate): string {
 
 function taskItem(task: TaskCandidate): QuickPickItem {
   const description = task.description ?? task.group;
+  // 列表已按来源分组, 行内不再重复来源 badge; 只保留「隐藏」这类附加语义。
   return {
-    badges: [
-      {
-        label: taskSourceLabel(task.source),
-        variant: task.unsupportedReason ? "outline" : "secondary",
-      },
-      ...(task.hidden
-        ? [
+    ...(task.hidden
+      ? {
+          badges: [
             {
               label: i18next.t("commandPalette.run.taskTab.hidden"),
               variant: "outline" as const,
             },
-          ]
-        : []),
-    ],
+          ],
+        }
+      : {}),
     detail: task.unsupportedReason ?? commandDetail(task),
     disabled: Boolean(task.unsupportedReason),
     id: task.id,

--- a/src/renderer/lib/command-palette/types.ts
+++ b/src/renderer/lib/command-palette/types.ts
@@ -3,6 +3,7 @@
  * Action / ActionMetadata 在 lib/actions/types.ts 中定义（共享）。
  */
 
+import type { LucideIcon } from "lucide-react";
 import type { ReactNode } from "react";
 
 export type CommandPaletteSurface = "command-palette" | (string & {});
@@ -25,9 +26,12 @@ export interface QuickPickItem {
   readonly description?: string;
   readonly detail?: string;
   readonly disabled?: boolean;
+  readonly icon?: LucideIcon;
   readonly id: string;
   readonly label: string;
   readonly searchTerms?: readonly string[];
+  /** destructive: 危险操作项 (删除/清理确认), 标题与图标用警示色。 */
+  readonly variant?: "default" | "destructive";
 }
 
 export interface QuickPickSection {

--- a/src/renderer/lib/plugins/host-context.ts
+++ b/src/renderer/lib/plugins/host-context.ts
@@ -177,7 +177,9 @@ function adaptQuickPickItem(item: RendererPluginQuickPickItem): QuickPickItem {
     ...(item.description ? { description: item.description } : {}),
     ...(item.detail ? { detail: item.detail } : {}),
     ...(item.disabled == null ? {} : { disabled: item.disabled }),
+    ...(item.icon ? { icon: item.icon } : {}),
     ...(item.searchTerms ? { searchTerms: item.searchTerms } : {}),
+    ...(item.variant ? { variant: item.variant } : {}),
   };
 }
 

--- a/src/renderer/stores/app-dialog.store.ts
+++ b/src/renderer/stores/app-dialog.store.ts
@@ -4,6 +4,7 @@
  * 渲染与 blocking overlay 生命周期由 components/common/app-dialog-host.tsx 承担。
  */
 import { create } from "zustand";
+import { useCommandPaletteController } from "@/lib/command-palette/controller.ts";
 
 export interface AppAlertOptions {
   body?: string;
@@ -36,6 +37,9 @@ function openAppDialog(
   kind: AppDialogRequest["kind"],
   options: AppConfirmOptions
 ): Promise<boolean> {
+  // 模态弹窗与命令面板不叠放: 弹窗出现时先关面板 (close 幂等,
+  // 未 accept 的 quick-pick 由面板 dismiss effect 兜底调 onDismiss)。
+  useCommandPaletteController.getState().close();
   useAppDialogStore.getState().current?.resolve(false);
   return new Promise((resolvePromise) => {
     const request: AppDialogRequest = {

--- a/src/shared/contracts/tasks.ts
+++ b/src/shared/contracts/tasks.ts
@@ -5,6 +5,8 @@ export const TASK_EXIT_TITLE_PREFIX = "pier-task-exit:";
 
 export const taskSourceSchema = z.enum([
   "package-script",
+  "deno",
+  "composer",
   "vscode",
   "zed",
   "cargo",

--- a/tests/component/app-dialog-host.test.tsx
+++ b/tests/component/app-dialog-host.test.tsx
@@ -10,6 +10,7 @@ import i18next from "i18next";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AppDialogHost } from "@/components/common/app-dialog-host.tsx";
 import { initI18n } from "@/i18n/index.ts";
+import { useCommandPaletteController } from "@/lib/command-palette/controller.ts";
 import {
   resetAppDialogForTests,
   showAppAlert,
@@ -138,6 +139,28 @@ describe("AppDialogHost", () => {
     expect(useKeybindingScope.getState().overlayStack).not.toContain(
       "overlay:app-dialog"
     );
+  });
+
+  it("弹窗出现时关闭仍开着的命令面板,不与面板叠放", async () => {
+    render(<AppDialogHost />);
+
+    act(() => {
+      useCommandPaletteController.getState().openPalette();
+    });
+    expect(useCommandPaletteController.getState().open).toBe(true);
+
+    let result: Promise<void> | undefined;
+    act(() => {
+      result = showAppAlert({
+        body: "fatal: no rebase in progress",
+        title: "Git 操作失败",
+      });
+    });
+
+    expect(useCommandPaletteController.getState().open).toBe(false);
+    expect(await screen.findByText("Git 操作失败")).toBeVisible();
+    fireEvent.click(screen.getByRole("button", { name: "OK" }));
+    await expect(result).resolves.toBeUndefined();
   });
 
   it("新弹窗替换旧弹窗,旧的按取消 resolve false", async () => {

--- a/tests/component/command-palette-quick-pick.test.tsx
+++ b/tests/component/command-palette-quick-pick.test.tsx
@@ -291,6 +291,95 @@ describe("CommandPalette quick pick rows", () => {
     expect(screen.queryByText("pier")).not.toBeInTheDocument();
   });
 
+  it("moves highlight and preview to the first visible item when the selected item is filtered out", async () => {
+    const onChangeSelection = vi.fn();
+    render(<CommandPalette />);
+
+    act(() => {
+      useCommandPaletteController.getState().openQuickPick({
+        title: "Probe",
+        placeholder: "Search probe",
+        items: [
+          { checked: true, id: "alpha", label: "alpha" },
+          { id: "bravo", label: "bravo" },
+        ],
+        onAccept: vi.fn(),
+        onChangeSelection,
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("alpha")).toBeVisible();
+    });
+    expect(screen.getByText("alpha").closest("[cmdk-item]")).toHaveAttribute(
+      "aria-selected",
+      "true"
+    );
+
+    // 查询把当前高亮的 checked 项过滤掉: 高亮应转移到第一个可见项并触发 preview。
+    fireEvent.change(screen.getByPlaceholderText("Search probe"), {
+      target: { value: "bravo" },
+    });
+    await waitFor(() => {
+      expect(screen.queryByText("alpha")).not.toBeInTheDocument();
+    });
+    expect(screen.getByText("bravo").closest("[cmdk-item]")).toHaveAttribute(
+      "aria-selected",
+      "true"
+    );
+    await waitFor(() => {
+      expect(onChangeSelection).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "bravo" })
+      );
+    });
+  });
+
+  it("hides section headings whose items are all filtered out", async () => {
+    render(<CommandPalette />);
+
+    act(() => {
+      useCommandPaletteController.getState().openQuickPick({
+        title: "Run Task",
+        placeholder: "Search tasks",
+        sections: [
+          {
+            heading: "package.json",
+            id: "package-script",
+            items: [{ id: "task:dev", label: "dev" }],
+          },
+          {
+            heading: "Makefile",
+            id: "make",
+            items: [{ id: "task:build", label: "build" }],
+          },
+        ],
+        onAccept: vi.fn(),
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("package.json")).toBeVisible();
+    });
+
+    // 只匹配 Makefile 分组: package.json 组标题必须整组消失。
+    fireEvent.change(screen.getByPlaceholderText("Search tasks"), {
+      target: { value: "build" },
+    });
+    await waitFor(() => {
+      expect(screen.queryByText("package.json")).not.toBeInTheDocument();
+    });
+    expect(screen.getByText("Makefile")).toBeVisible();
+
+    // 全部不匹配: 所有组标题消失, 只剩空态文案。
+    fireEvent.change(screen.getByPlaceholderText("Search tasks"), {
+      target: { value: "devss" },
+    });
+    await waitFor(() => {
+      expect(screen.queryByText("Makefile")).not.toBeInTheDocument();
+    });
+    expect(screen.queryByText("package.json")).not.toBeInTheDocument();
+  });
+
   it("filters quick-pick items without reordering matches", async () => {
     render(<CommandPalette />);
 

--- a/tests/unit/main/tasks/task-sources.test.ts
+++ b/tests/unit/main/tasks/task-sources.test.ts
@@ -114,4 +114,158 @@ describe("task sources", () => {
       ])
     );
   });
+
+  it("collects deno.json(c) tasks including object-form tasks", async () => {
+    await writeFile(
+      join(projectRoot, "deno.jsonc"),
+      `{
+        // jsonc comment
+        "tasks": {
+          "dev": "deno run -A --watch main.ts",
+          "check": { "command": "deno lint", "description": "Lint sources" }
+        }
+      }`
+    );
+
+    const result = await collectTaskCandidates({ homeDir, projectRoot });
+
+    expect(result.errors).toEqual([]);
+    expect(
+      result.tasks
+        .filter((task) => task.source === "deno")
+        .map((task) => [task.label, task.commandSpec, task.description])
+    ).toEqual([
+      [
+        "dev",
+        { command: "deno task dev", kind: "shell" },
+        "deno run -A --watch main.ts",
+      ],
+      ["check", { command: "deno task check", kind: "shell" }, "Lint sources"],
+    ]);
+  });
+
+  it("collects composer scripts and skips lifecycle event hooks", async () => {
+    await writeFile(
+      join(projectRoot, "composer.json"),
+      JSON.stringify({
+        scripts: {
+          "post-install-cmd": "php artisan clear",
+          test: ["phpunit", "phpstan analyse"],
+        },
+      })
+    );
+
+    const result = await collectTaskCandidates({ homeDir, projectRoot });
+
+    expect(result.errors).toEqual([]);
+    expect(
+      result.tasks
+        .filter((task) => task.source === "composer")
+        .map((task) => [task.label, task.commandSpec, task.description])
+    ).toEqual([
+      [
+        "test",
+        { command: "composer run-script test", kind: "shell" },
+        "phpunit && phpstan analyse",
+      ],
+    ]);
+  });
+
+  it("collects cargo aliases from .cargo/config.toml", async () => {
+    await writeFile(
+      join(projectRoot, "Cargo.toml"),
+      '[package]\nname = "demo"\n'
+    );
+    await mkdir(join(projectRoot, ".cargo"));
+    await writeFile(
+      join(projectRoot, ".cargo", "config.toml"),
+      '[alias]\nlint = "clippy --all-targets"\n'
+    );
+
+    const result = await collectTaskCandidates({ homeDir, projectRoot });
+
+    expect(
+      result.tasks
+        .filter((task) => task.source === "cargo")
+        .map((task) => task.label)
+    ).toEqual([
+      "cargo build",
+      "cargo test",
+      "cargo check",
+      "cargo run",
+      "cargo lint",
+    ]);
+  });
+
+  it("keeps Taskfile parsing inside the tasks block and supports 4-space indent + namespaced names", async () => {
+    await writeFile(
+      join(projectRoot, "Taskfile.yml"),
+      [
+        "version: '3'",
+        "tasks:",
+        "    build:",
+        "        cmds:",
+        "            - go build",
+        "    docs:publish:",
+        "        cmds:",
+        "            - mkdocs deploy",
+        "vars:",
+        "  GREETING: hello",
+        "",
+      ].join("\n")
+    );
+
+    const result = await collectTaskCandidates({ homeDir, projectRoot });
+
+    expect(
+      result.tasks
+        .filter((task) => task.source === "taskfile")
+        .map((task) => task.label)
+    ).toEqual(["build", "docs:publish"]);
+  });
+
+  it("excludes just assignments and [private] recipes", async () => {
+    await writeFile(
+      join(projectRoot, "Justfile"),
+      [
+        'set shell := ["bash", "-c"]',
+        "alias b := build",
+        "",
+        "build:",
+        "    cargo build",
+        "",
+        "[private]",
+        "hidden-task:",
+        "    echo hidden",
+        "",
+        "_helper:",
+        "    echo helper",
+        "",
+      ].join("\n")
+    );
+
+    const result = await collectTaskCandidates({ homeDir, projectRoot });
+
+    expect(
+      result.tasks
+        .filter((task) => task.source === "just")
+        .map((task) => task.label)
+    ).toEqual(["build"]);
+  });
+
+  it("collects quoted mise task section names", async () => {
+    await writeFile(
+      join(projectRoot, ".mise.toml"),
+      '[tasks."docs:build"]\nrun = "mkdocs build"\n\n[tasks.dev]\nrun = "pnpm dev"\n'
+    );
+
+    const result = await collectTaskCandidates({ homeDir, projectRoot });
+
+    expect(
+      result.tasks
+        .filter((task) => task.source === "mise")
+        .map((task) => task.label)
+        .sort()
+    ).toEqual(["dev", "docs:build"]);
+  });
 });

--- a/tests/unit/renderer/git-plugin.test.tsx
+++ b/tests/unit/renderer/git-plugin.test.tsx
@@ -792,15 +792,16 @@ describe("git builtin plugin", () => {
     const prunable = quickPick?.sections
       ?.flatMap((section) => section.items)
       .find((item) => item.id === "worktree:/Users/xyz/ABC/pier-stale");
+    // 标题直接用分支名, "主工作树" 语义只由 badge 表达, 不再重复放 description。
     expect(main).toMatchObject({
       badges: expect.arrayContaining([
         expect.objectContaining({ label: "main" }),
       ]),
       checked: true,
-      description: "main",
       detail: "/Users/xyz/ABC/pier",
       label: "main",
     });
+    expect(main?.description).toBeUndefined();
     expect(linked).toMatchObject({
       detail: "/Users/xyz/ABC/pier-feature",
       label: "feature/worktree",


### PR DESCRIPTION
## 变更内容

命令面板 quick-pick 全面整改:视觉统一 + 交互 bug 修复 + 任务来源扩展。

### UI 统一(参考分支列表的视觉语言)

- **默认行渲染器重写**(`command-palette-quick-pick-view.tsx`):图标 + 标题/badge 行 + detail 副行 + 右侧次要信息,整行 `items-center` —— 修复对勾不垂直居中;所有未写自定义 `renderItem` 的 quick-pick(工作树、stash、任务、终端、主题等)自动受益
- **`QuickPickItem` 新增 `icon` / `variant: "destructive"` 字段**,贯穿插件 API(`renderer.ts` → `host-context.ts` 适配)
- 工作树/终端/stash 行补图标;主工作树标题改用分支名,去掉与「主工作树」badge 的重复;任务行去掉与分组标题重复的来源 badge;worktree 域图标统一 `GitFork` → `FolderGit2`(含状态栏徽章)
- stash 日期从 git 原始字符串改为相对时间(「12分钟前」),`formatRelativeTime` 从分支行组件抽为共享模块
- 删除/清理 worktree 的确认项使用警示色区分破坏性操作

### Bug 修复

1. **空分组标题残留**:`shouldFilter={false}` 手动过滤下 cmdk 不会自动隐藏空组,查询无匹配时组标题(如「package.json」)残留在空态上方 —— 过滤后为空的分组现在整组跳过
2. **模态弹窗与面板叠放**:命令触发错误弹窗(如「中止变基」→「Git 操作失败」)时面板留在弹窗底下 —— 在 `openAppDialog` 唯一入口处关闭面板,覆盖所有 alert/confirm 调用方
3. **空态文案错位**:quick-pick 里显示「无匹配命令」不准确,新增「无匹配项」文案(中英文)

### 运行任务来源扩展(第二个 commit)

- **新增 Deno 来源**:`deno.json` / `deno.jsonc` 的 `tasks`,支持字符串与对象两种任务形式,运行 `deno task <name>`
- **新增 Composer 来源**:`composer.json` 的 `scripts`,排除 `pre/post-*` 生命周期事件钩子,运行 `composer run-script <name>`
- **解析器加固**:
  - Taskfile:任意缩进、`tasks:` 块边界正确退出(此前 `vars:` 等后续顶层块的子键会被误报成任务)、命名空间任务名(`docs:publish`)
  - Justfile:排除 `:=` 赋值行(此前 `set`/`alias` 被误报成 recipe)、跳过 `[private]` recipe
  - mise:支持带引号的段名 `[tasks."docs:build"]`
  - Cargo:读取 `.cargo/config.toml` 的 `[alias]` 自定义子命令

### 结构调整

- `command-palette.tsx` 触及 500 行硬上限(depcruise 报错),quick-pick 视图层拆分为 `command-palette-quick-pick-view.tsx`(纯展示,与已有 `command-palette-action-rows.tsx` 同一拆分模式)

## 审阅提示

- **`src/shared/contracts/tasks.ts` 有跨进程契约改动**(`taskSourceSchema` 新增 `deno` / `composer`,纯增量)
- 主工作树列表项的契约变化:label 从「主工作树」改为分支名,`description` 不再重复分支名(`git-plugin.test.tsx` 断言已同步更新)
- 探针实测确认:高亮项被查询过滤掉时 cmdk 会自动转移高亮并触发 preview,无需额外处理 —— 已加回归测试锁定该契约
- 已知遗留(本 PR 不处理):`window.prompt` 两处(创建工作树、任务参数输入)需要面板内 InputBox 原语,已另立任务;Gradle/Maven 无静态任务清单,需执行构建工具枚举,建议单独立项

## 验证

- `pnpm check`(typecheck + lint + depcruise + 文件大小)通过
- 单测 1054 个、组件测试 134 个全部通过(新增:任务来源 6 个、空组隐藏、高亮转移、弹窗关面板等 10 个用例)

🤖 Generated with [Claude Code](https://claude.com/claude-code)