### PR TITLE
Add short Unix socket fallback for long user data paths

### DIFF
--- a/bin/pier.mjs
+++ b/bin/pier.mjs
@@ -3,7 +3,7 @@
 import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { createConnection } from "node:net";
-import { homedir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import {
   hasPierCliOption,
@@ -12,6 +12,8 @@ import {
 } from "./pier-cli-parser.js";
 
 const ENV_KEY_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+const SOCKET_FILENAME = "pier-control.sock";
+const UNIX_SOCKET_PATH_MAX_BYTES = 103;
 
 function shortHash(input) {
   return createHash("sha256").update(input).digest("hex").slice(0, 16);
@@ -37,7 +39,11 @@ function socketPathForUserData(userDataDir) {
   if (process.platform === "win32") {
     return `\\\\.\\pipe\\pier-control-${shortHash(userDataDir)}`;
   }
-  return join(userDataDir, "pier-control.sock");
+  const socketPath = join(userDataDir, SOCKET_FILENAME);
+  if (Buffer.byteLength(socketPath) <= UNIX_SOCKET_PATH_MAX_BYTES) {
+    return socketPath;
+  }
+  return join(tmpdir(), `pier-control-${shortHash(userDataDir)}.sock`);
 }
 
 function readJson(file) {

--- a/src/main/adapters/cli/local-control-server.ts
+++ b/src/main/adapters/cli/local-control-server.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, unlinkSync } from "node:fs";
 import { createServer, type Server, type Socket } from "node:net";
+import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import type { PierCommandResult } from "@shared/contracts/commands.ts";
 
@@ -15,9 +16,14 @@ export interface CreatePierLocalControlServerArgs {
 }
 
 const SOCKET_FILENAME = "pier-control.sock";
+const UNIX_SOCKET_PATH_MAX_BYTES = 103;
 
 function stablePipeSuffix(input: string): string {
   return createHash("sha256").update(input).digest("hex").slice(0, 16);
+}
+
+function shortUnixSocketPath(userDataDir: string): string {
+  return join(tmpdir(), `pier-control-${stablePipeSuffix(userDataDir)}.sock`);
 }
 
 export function resolveLocalControlSocketPath(
@@ -27,7 +33,11 @@ export function resolveLocalControlSocketPath(
   if (platform === "win32") {
     return `\\\\.\\pipe\\pier-control-${stablePipeSuffix(userDataDir)}`;
   }
-  return join(userDataDir, SOCKET_FILENAME);
+  const socketPath = join(userDataDir, SOCKET_FILENAME);
+  if (Buffer.byteLength(socketPath) <= UNIX_SOCKET_PATH_MAX_BYTES) {
+    return socketPath;
+  }
+  return shortUnixSocketPath(userDataDir);
 }
 
 function failure(

--- a/tests/unit/app-core/cli-bin.test.ts
+++ b/tests/unit/app-core/cli-bin.test.ts
@@ -1,4 +1,5 @@
 import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
@@ -12,6 +13,14 @@ import { afterEach, describe, expect, it } from "vitest";
 
 const execFileAsync = promisify(execFile);
 const tempDirs: string[] = [];
+
+function fallbackSocketPathForUserData(userDataDir: string): string {
+  const suffix = createHash("sha256")
+    .update(userDataDir)
+    .digest("hex")
+    .slice(0, 16);
+  return join(tmpdir(), `pier-control-${suffix}.sock`);
+}
 
 async function makeTempDir(): Promise<string> {
   const dir = await mkdtemp(join(tmpdir(), "pier-cli-bin-"));
@@ -384,6 +393,41 @@ describe("bin/pier.mjs", () => {
 
     expect(stdout).toBe("");
     await server.close();
+  });
+
+  it("PIER_USER_DATA_DIR 过长时连接到稳定短 socket 路径", async () => {
+    const userDataDir = `/Users/sheep/Library/Application Support/Pier-dev/${"very-long-worktree-name-".repeat(4)}`;
+    const socketPath = fallbackSocketPathForUserData(userDataDir);
+    const server = createPierLocalControlServer({
+      handleRequest: (envelope) => {
+        const parsed = pierCommandEnvelopeSchema.parse(envelope);
+        return Promise.resolve({
+          data: { status: "ok" },
+          ok: true,
+          requestId: parsed.requestId,
+        });
+      },
+      socketPath,
+    });
+    await server.start();
+
+    try {
+      const { stdout } = await execFileAsync(
+        "node",
+        ["bin/pier.mjs", "status", "--json"],
+        {
+          env: { ...process.env, PIER_USER_DATA_DIR: userDataDir },
+        }
+      );
+
+      expect(JSON.parse(stdout)).toMatchObject({
+        data: { status: "ok" },
+        ok: true,
+      });
+    } finally {
+      await server.close();
+      await rm(socketPath, { force: true });
+    }
   });
 
   it("真实 socket 请求携带 CLI 环境但 print-envelope 不输出", async () => {

--- a/tests/unit/app-core/local-control.test.ts
+++ b/tests/unit/app-core/local-control.test.ts
@@ -1,4 +1,5 @@
 import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
 import { mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -29,6 +30,14 @@ import { makeFakePreferences } from "../../setup/preferences-fixture.ts";
 const tempDirs: string[] = [];
 const WINDOWS_NAMED_PIPE_PATTERN = /^\\\\\.\\pipe\\pier-control-[a-f0-9]{16}$/;
 const execFileAsync = promisify(execFile);
+
+function expectedFallbackSocketPath(userDataDir: string): string {
+  const suffix = createHash("sha256")
+    .update(userDataDir)
+    .digest("hex")
+    .slice(0, 16);
+  return join(tmpdir(), `pier-control-${suffix}.sock`);
+}
 
 async function sendRawRequest(
   socketPath: string,
@@ -228,6 +237,14 @@ describe("resolveLocalControlSocketPath", () => {
   it("在 Unix 平台把 socket 放在 userData 下", () => {
     expect(resolveLocalControlSocketPath("/tmp/pier-user-data", "darwin")).toBe(
       "/tmp/pier-user-data/pier-control.sock"
+    );
+  });
+
+  it("在 Unix socket 路径过长时回退到稳定短路径", () => {
+    const userDataDir = `/Users/sheep/Library/Application Support/Pier-dev/${"very-long-worktree-name-".repeat(4)}`;
+
+    expect(resolveLocalControlSocketPath(userDataDir, "darwin")).toBe(
+      expectedFallbackSocketPath(userDataDir)
     );
   });
 


### PR DESCRIPTION
## Summary
- Add a Unix socket path fallback under `tmpdir()` when the default socket path would exceed platform limits.
- Keep the fallback stable by hashing `PIER_USER_DATA_DIR` so the CLI and local control server resolve the same path.
- Cover the new behavior with unit tests for both path resolution and CLI-to-server connectivity.

## Testing
- Added unit tests for long-path fallback resolution.
- Added a CLI integration-style test that verifies status requests succeed through the fallback socket path.
- Existing test coverage for the normal socket path remains in place.