### PR TITLE
fix(build): align DMG icon coordinates with default background

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -43,9 +43,9 @@ mac:
 
 dmg:
   contents:
-    - x: 110
-      y: 150
-    - x: 240
-      y: 150
+    - x: 130
+      y: 220
+    - x: 410
+      y: 220
       type: link
       path: /Applications


### PR DESCRIPTION
## Summary
- DMG installer arrow was visually detached from the two icons — it appeared to the right of the Applications folder pointing at empty space instead of between Pier and Applications.
- Root cause: no custom DMG background is configured (`build/background.png` / `background.tif` don't exist), so electron-builder falls back to its built-in 540×380 background. That background's arrow is centered for the default icon layout `(130, 220)` / `(410, 220)`. The old coordinates `(110, 150)` and `(240, 150)` pushed both icons into the upper-left, so the background arrow ended up disconnected from them.
- Fix: adjust `dmg.contents` coordinates in `electron-builder.yml` to `(130, 220)` and `(410, 220)` so the built-in arrow lands between the two icons.

## Test plan
- [x] `pnpm build` to produce a fresh DMG under `dist-builder/`
- [x] Open the resulting `Pier-*.dmg` and confirm Pier / Applications sit horizontally aligned with the built-in arrow pointing from Pier to Applications
- [x] Drag-install still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)