### PR TITLE
fix(foreground-activity): 双层活动模型修正 agent 状态谎报与事件丢失

### DIFF
--- a/src/main/services/agents/integrations/cline.ts
+++ b/src/main/services/agents/integrations/cline.ts
@@ -48,6 +48,10 @@ const CLINE_EVENTS: ReadonlyArray<{
   { fileName: "PreToolUse", pierEvent: "ToolStart" },
   { fileName: "PostToolUse", pierEvent: "ToolComplete" },
   { fileName: "TaskCancel", pierEvent: "Stop" },
+  // 正常完成必须有回合边界信号——缺了它状态会卡在 tool/processing 直到
+  // 30min TTL 衰减（loomdesk cline eventStatusMap 同款映射）。
+  { fileName: "TaskComplete", pierEvent: "Stop" },
+  { fileName: "PreCompact", pierEvent: "processing" },
 ];
 
 export function clineHooksDir(): string {

--- a/src/main/services/agents/integrations/gemini.ts
+++ b/src/main/services/agents/integrations/gemini.ts
@@ -10,9 +10,12 @@ import {
 
 /**
  * Gemini CLI hook 事件 → pier 事件名。
- * 依据 Gemini CLI hooks 文档：无权限确认类 hook（PermissionRequest 无
- * 对应原生事件）——Gemini 的授权确认在 hook 体系之外, 因此 pier 的
- * "waiting" 状态经由 hook 路径不可达（同 grok 集成的取舍）。
+ * 依据 google-gemini/gemini-cli packages/core/src/hooks/types.ts：
+ * HookEventName 含 Notification, NotificationType 当前仅 ToolPermission
+ * （工具权限弹窗提示）——observability-only, 不能 grant/block, 但足以
+ * 驱动 pier 的 "waiting" 状态, 映 PermissionRequest。
+ * （此前注释断言"无权限确认类 hook"已过时——上游 docs/hooks/reference.md
+ * §Notification 明确该事件在 Tool Permissions 系统提示时触发。）
  * 工具事件（BeforeTool/AfterTool）matcher 用空字符串 ""（Gemini 官方
  * 事件表约定, 区别于 grok 的 "*"）。
  *
@@ -34,6 +37,7 @@ const GEMINI_SPEC: NestedJsonIntegrationSpec = {
     { nativeEvent: "SessionEnd", pierEvent: "SessionEnd" },
     { nativeEvent: "BeforeAgent", pierEvent: "PromptSubmit" },
     { nativeEvent: "AfterAgent", pierEvent: "Stop" },
+    { nativeEvent: "Notification", pierEvent: "PermissionRequest" },
     { matcher: "", nativeEvent: "BeforeTool", pierEvent: "ToolStart" },
     { matcher: "", nativeEvent: "AfterTool", pierEvent: "ToolComplete" },
   ],

--- a/src/main/services/agents/integrations/mimo-code.ts
+++ b/src/main/services/agents/integrations/mimo-code.ts
@@ -78,6 +78,15 @@ function mapPierEvent(event) {
   if (event.type === "session.created") return "SessionStart";
   if (event.type === "session.idle") return "Stop";
   if (event.type === "session.error") return "error";
+  if (event.type === "session.status") {
+    // 同 opencode（MiMo 是 opencode fork, SDK 事件同源）:
+    // busy/retry 推进心跳, idle 回合结束。
+    const statusType =
+      event.properties && event.properties.status && event.properties.status.type;
+    if (statusType === "busy" || statusType === "retry") return "running";
+    if (statusType === "idle") return "Stop";
+    return null;
+  }
   if (event.type === "tui.command.execute") {
     const command = event.properties && event.properties.command;
     return command === "prompt.submit" ? "PromptSubmit" : null;

--- a/src/main/services/agents/integrations/opencode.ts
+++ b/src/main/services/agents/integrations/opencode.ts
@@ -59,8 +59,9 @@ export function opencodeConfigPath(): string {
  * 类型的 command 联合里没有 "input_submit"），permission.updated→
  * PermissionRequest（SDK 类型只有 EventPermissionUpdated /
  * EventPermissionReplied 两种, 没有 "permission.asked"——旧文档页过时）,
- * permission.replied→processing, tool.execute.before→ToolStart,
- * tool.execute.after→ToolComplete。
+ * permission.replied→processing, session.status(busy/retry)→running、
+ * (idle)→Stop（EventSessionStatus——模型忙碌/重试中的推进心跳）,
+ * tool.execute.before→ToolStart, tool.execute.after→ToolComplete。
  */
 export function buildOpencodePluginSource(
   pluginId: AgentKind = AGENT_ID
@@ -96,6 +97,16 @@ function mapPierEvent(event) {
   if (event.type === "session.created") return "SessionStart";
   if (event.type === "session.idle") return "Stop";
   if (event.type === "session.error") return "error";
+  if (event.type === "session.status") {
+    // SDK EventSessionStatus: properties.status.type = busy/retry/idle
+    // （sst/opencode packages/sdk/js/src/gen/types.gen.ts SessionStatus 联合）。
+    // busy/retry 是模型推进/重试中——缺了它长回合只剩 prompt.submit 一跳。
+    const statusType =
+      event.properties && event.properties.status && event.properties.status.type;
+    if (statusType === "busy" || statusType === "retry") return "running";
+    if (statusType === "idle") return "Stop";
+    return null;
+  }
   if (event.type === "tui.command.execute") {
     const command = event.properties && event.properties.command;
     return command === "prompt.submit" ? "PromptSubmit" : null;

--- a/src/main/services/agents/integrations/qwen-code.ts
+++ b/src/main/services/agents/integrations/qwen-code.ts
@@ -30,8 +30,17 @@ const QWEN_CODE_SPEC: NestedJsonIntegrationSpec = {
     { nativeEvent: "StopFailure", pierEvent: "error" },
     { nativeEvent: "PreToolUse", pierEvent: "ToolStart" },
     { nativeEvent: "PostToolUse", pierEvent: "ToolComplete" },
+    // QwenLM/qwen-code packages/core/src/hooks/types.ts HookEventName
+    // 实锤含以下三个状态相关事件（docs/users/features/hooks.md 同步列出）。
+    { nativeEvent: "PermissionRequest", pierEvent: "PermissionRequest" },
+    { nativeEvent: "SubagentStart", pierEvent: "SubagentStart" },
+    { nativeEvent: "SubagentStop", pierEvent: "SubagentStop" },
     { nativeEvent: "SessionEnd", pierEvent: "SessionEnd" },
   ],
+  // ⚠️ 同 gemini.ts 的单位陷阱：Qwen Code 是 Gemini CLI fork, hook 配置的
+  // `timeout` 字段按【毫秒】解释。不覆盖此值时 shared 工厂默认写 5——
+  // 即 5ms, hook 几乎必超时被杀, 整条状态链路静默失效。此处必须是毫秒值。
+  timeoutSeconds: 10_000,
 };
 
 export const qwenCodeIntegration = createNestedJsonIntegration(QWEN_CODE_SPEC);

--- a/src/main/services/foreground-activity/aggregator.ts
+++ b/src/main/services/foreground-activity/aggregator.ts
@@ -1,28 +1,30 @@
 import type { AgentHookEventPayload } from "@shared/contracts/agent-session.ts";
-import {
-  activityStatusForHookEvent,
-  type ForegroundActivity,
-  type ForegroundActivityBroadcast,
-  type TaskActivity,
+import type {
+  ForegroundActivity,
+  ForegroundActivityBroadcast,
 } from "@shared/contracts/foreground-activity.ts";
+import { activityStatusForHookEvent } from "@shared/contracts/foreground-activity.ts";
 import {
-  type ActivityEntry,
+  type AgentLaunchLayer,
   applyTurnBookkeeping,
   armHookTtlTimer,
   CLOSE_COOLDOWN_MS,
-  clearAllTimers,
-  clearHookTtlTimer,
-  clearVisibilityTimer,
+  clearCommandTimers,
+  clearHookTimers,
+  clearSlotTimers,
   EMIT_DEBOUNCE_MS,
-  newHookAgentEntry,
-  newLaunchAgentEntry,
-  newShellEntry,
-  newTaskEntry,
+  type HookLayer,
+  newAgentLaunchLayer,
+  newHookLayer,
+  newShellLayer,
+  newTaskLayer,
+  type PanelSlot,
+  projectSlot,
   SESSION_CREATING_EVENTS,
   SESSION_END_COOLDOWN_MS,
   SUBAGENT_EVENTS,
   SUSPENDED_JOB_EXIT_CODES,
-  setAgentStatus,
+  setHookStatus,
   TASK_EXIT_LINGER_MS,
   type TimerCtx,
   VISIBILITY_DEBOUNCE_MS,
@@ -33,32 +35,42 @@ import type {
 } from "./types.ts";
 
 /**
- * ForegroundActivityAggregator 实现。API 与文档在 ./types.ts。
+ * ForegroundActivityAggregator 实现。API 与文档在 ./types.ts, 模型与投影在
+ * ./entry.ts。
  *
- * 语义：cooldown 拦迟到 / SessionStart 消抖 250ms / hook TTL 30min 衰减 /
- * subagent 计数 / turn bookkeeping / Ctrl+Z 悬挂例外。逐字迁移自
- * loomdesk 与老 AgentSessionAggregator, 保 tests 回归覆盖。
+ * 双层语义：command 层（OSC/launcher/task）与 hook 层（JSONL 事件）独立
+ * 生灭, 互不覆写；每 panel 投影至多一条 activity。冷却拦迟到 / 新层 250ms
+ * 消抖 / hook TTL 30min 衰减 / subagent 计数 / turn bookkeeping /
+ * Ctrl+Z 悬挂例外——语义细节与 loomdesk ActivityAggregator 对齐。
  */
 export function createForegroundActivityAggregator(
   opts: ForegroundActivityAggregatorOpts = {}
 ): ForegroundActivityAggregator {
   const now = opts.now ?? Date.now;
-  const entries = new Map<string, ActivityEntry>();
-  /** key → 冷却截止时刻。 */
-  const cooldownUntil = new Map<string, number>();
+  const slots = new Map<string, PanelSlot>();
+  /**
+   * panel 死亡冷却（panelClosed/windowClosed/retainPanels）——面板已不在，
+   * 拦一切迟到事件（hook + 命令）。
+   */
+  const panelCooldownUntil = new Map<string, number>();
+  /**
+   * hook 收尾冷却（命令退出/SessionEnd/task linger）——只拦迟到 hook 事件。
+   * 新命令是新鲜 OSC 证据, 永不被此冷却拦截（loomdesk
+   * recentlyEndedSessions 同语义:只 gate agent_hook 条目创建）。
+   */
+  const hookCooldownUntil = new Map<string, number>();
   const listeners = new Set<(b: ForegroundActivityBroadcast) => void>();
-  let emitTimer: ReturnType<typeof setTimeout> | null = null;
+  let emitTimer: NodeJS.Timeout | null = null;
   let disposed = false;
   let broadcastSeq = 0;
 
   function buildBroadcast(): ForegroundActivityBroadcast {
     broadcastSeq += 1;
     const activities: ForegroundActivity[] = [];
-    for (const entry of entries.values()) {
-      if (!entry.hidden) {
-        // 浅拷贝防外部 mutate 污染内部 activity 引用
-        // (IPC serialize 会 structuredClone, 但同进程内 listener 直接消费引用)。
-        activities.push({ ...entry.activity });
+    for (const [panelId, slot] of slots) {
+      const activity = projectSlot(panelId, slot);
+      if (activity) {
+        activities.push(activity);
       }
     }
     return { activities, ts: broadcastSeq };
@@ -77,58 +89,65 @@ export function createForegroundActivityAggregator(
     }, EMIT_DEBOUNCE_MS);
   }
 
-  const timerCtx: TimerCtx = { entries, scheduleEmit, now };
+  const timerCtx: TimerCtx = { now, scheduleEmit, slots };
 
-  function isInCloseCooldown(key: string): boolean {
-    const until = cooldownUntil.get(key);
+  function isInCooldown(map: Map<string, number>, key: string): boolean {
+    const until = map.get(key);
     if (until === undefined) {
       return false;
     }
     if (now() >= until) {
-      cooldownUntil.delete(key);
+      map.delete(key);
       return false;
     }
     return true;
   }
 
-  function deleteEntry(key: string): boolean {
-    const entry = entries.get(key);
-    if (!entry) {
-      return false;
+  function slotFor(key: string): PanelSlot {
+    let slot = slots.get(key);
+    if (!slot) {
+      slot = { command: null, hook: null };
+      slots.set(key, slot);
     }
-    clearAllTimers(entry);
-    entries.delete(key);
-    return true;
+    return slot;
   }
 
-  function closeEntry(key: string, cooldownMs = CLOSE_COOLDOWN_MS): boolean {
-    const removed = deleteEntry(key);
-    cooldownUntil.set(key, now() + cooldownMs);
-    return removed;
+  function dropSlotIfEmpty(key: string): void {
+    const slot = slots.get(key);
+    if (slot && !slot.command && !slot.hook) {
+      slots.delete(key);
+    }
+  }
+
+  /** 整 slot 清除 + 冷却进指定表。返回是否确有移除（决定要不要 emit）。 */
+  function closeSlot(
+    key: string,
+    cooldown: { map: Map<string, number>; ms: number }
+  ): boolean {
+    const slot = slots.get(key);
+    if (slot) {
+      clearSlotTimers(slot);
+      slots.delete(key);
+    }
+    cooldown.map.set(key, now() + cooldown.ms);
+    return slot !== undefined;
   }
 
   function pruneExpiredCooldowns(): void {
-    for (const [id, until] of cooldownUntil) {
-      if (now() >= until) {
-        cooldownUntil.delete(id);
+    for (const map of [panelCooldownUntil, hookCooldownUntil]) {
+      for (const [id, until] of map) {
+        if (now() >= until) {
+          map.delete(id);
+        }
       }
     }
   }
 
-  function revealEntry(entry: ActivityEntry): void {
-    if (entry.hidden) {
-      entry.hidden = false;
-      clearVisibilityTimer(entry);
-    }
-  }
-
-  function armVisibilityTimer(key: string, entry: ActivityEntry): void {
-    if (!entry.hidden) {
-      return;
-    }
-    entry.visibilityTimer = setTimeout(() => {
-      const current = entries.get(key);
-      if (!current) {
+  /** launch 层 250ms 消抖显形（`omp --version` 瞬时命令不闪条）。 */
+  function armLaunchVisibility(key: string, layer: AgentLaunchLayer): void {
+    layer.visibilityTimer = setTimeout(() => {
+      const current = slots.get(key)?.command;
+      if (current?.kind !== "agent-launch" || current !== layer) {
         return;
       }
       current.visibilityTimer = null;
@@ -139,61 +158,77 @@ export function createForegroundActivityAggregator(
     }, VISIBILITY_DEBOUNCE_MS);
   }
 
-  function createHookAgentEntry(
-    key: string,
-    event: AgentHookEventPayload,
-    at: number
-  ): ActivityEntry {
-    const entry = newHookAgentEntry(event, at);
-    entries.set(key, entry);
-    armVisibilityTimer(key, entry);
-    return entry;
-  }
-
-  /** SessionStart 豁免冷却; SessionEnd 移除 + 短冷却拦迟到 hook。已消化返 true。 */
-  function handleLifecycleEvent(key: string, eventName: string): boolean {
-    if (eventName === "SessionStart") {
-      cooldownUntil.delete(key);
-      return false;
-    }
-    if (isInCloseCooldown(key)) {
-      return true;
-    }
-    if (eventName === "SessionEnd") {
-      const removed = deleteEntry(key);
-      cooldownUntil.set(key, now() + SESSION_END_COOLDOWN_MS);
-      if (removed) {
+  /** hook 层 SessionStart 消抖显形（防瞬时闪条）。 */
+  function armHookVisibility(key: string, layer: HookLayer): void {
+    layer.visibilityTimer = setTimeout(() => {
+      const current = slots.get(key)?.hook;
+      if (current !== layer) {
+        return;
+      }
+      current.visibilityTimer = null;
+      if (current.hidden) {
+        current.hidden = false;
         scheduleEmit();
       }
-      return true;
-    }
-    return false;
+    }, VISIBILITY_DEBOUNCE_MS);
   }
 
-  /** 取得/创建 hook agent entry。幽灵门控：终结类迟到事件不得凭空造条目。 */
-  function acquireHookAgentEntry(
+  /** 非 SessionStart 的 hook 事件是真实进展证据——立即显形。 */
+  function revealHook(hook: HookLayer): void {
+    if (hook.hidden) {
+      hook.hidden = false;
+      if (hook.visibilityTimer) {
+        clearTimeout(hook.visibilityTimer);
+        hook.visibilityTimer = null;
+      }
+    }
+  }
+
+  /**
+   * SessionEnd 干净收尾：只清 hook 层（command 层等 OSC D 自己收），
+   * 1.5s 短冷却拦迟到事件。
+   */
+  function endHookSession(key: string): void {
+    const slot = slots.get(key);
+    const hook = slot?.hook ?? null;
+    if (slot && hook) {
+      clearHookTimers(hook);
+      slot.hook = null;
+      dropSlotIfEmpty(key);
+    }
+    hookCooldownUntil.set(key, now() + SESSION_END_COOLDOWN_MS);
+    if (hook) {
+      scheduleEmit();
+    }
+  }
+
+  /**
+   * 取得/新建 hook 层。幽灵门控：终结类迟到事件（Stop/ToolComplete/
+   * SubagentStop/error）不得凭空建会话——返回 null 表示事件应被丢弃。
+   */
+  function acquireHookLayer(
     key: string,
     event: AgentHookEventPayload,
     at: number
-  ): ActivityEntry | null {
-    const existing = entries.get(key);
-    if (existing?.activity.kind === "agent") {
+  ): HookLayer | null {
+    const slot = slotFor(key);
+    const existing = slot.hook;
+    if (existing) {
       if (event.event !== "SessionStart") {
-        revealEntry(existing);
+        revealHook(existing);
       }
       return existing;
     }
-    // existing 是 task/shell/idle — 只有 SESSION_CREATING 事件才允许覆盖为
-    // agent activity。迟到的终结事件 (Stop/ToolComplete/SubagentStop/error)
-    // 不能凭空销毁用户显式建立的 task/shell 活动 (review Commit C P1#1)。
     if (!SESSION_CREATING_EVENTS.has(event.event)) {
+      dropSlotIfEmpty(key);
       return null;
     }
-    if (existing) {
-      clearAllTimers(existing);
-      entries.delete(key);
+    const hook = newHookLayer(event, at);
+    slot.hook = hook;
+    if (hook.hidden) {
+      armHookVisibility(key, hook);
     }
-    return createHookAgentEntry(key, event, at);
+    return hook;
   }
 
   const api: ForegroundActivityAggregator = {
@@ -202,25 +237,29 @@ export function createForegroundActivityAggregator(
         return;
       }
       const key = panelId;
-      cooldownUntil.delete(key);
-      const existing = entries.get(key);
-      if (existing && existing.activity.kind === "agent") {
-        revealEntry(existing);
-        // hook 侧的 TTL timer 无效了（launch 是新生命周期）——清掉
-        // 防止 30min 后回落 ready 的 callback 意外触发。
-        clearHookTtlTimer(existing);
-        existing.activity = {
-          ...existing.activity,
-          agentId,
-        };
+      panelCooldownUntil.delete(key);
+      hookCooldownUntil.delete(key);
+      const slot = slotFor(key);
+      const existing = slot.command;
+      if (existing?.kind === "agent-launch" && existing.agentId === agentId) {
+        // launcher 先验 + OSC 133 C 双击（同 agent）→ 去抖：保层保消抖 timer。
+        existing.updatedAt = now();
+        existing.windowId = windowId;
       } else {
         if (existing) {
-          clearAllTimers(existing);
+          clearCommandTimers(existing);
         }
-        entries.set(
-          key,
-          newLaunchAgentEntry(windowId, panelId, agentId, now())
-        );
+        const layer = newAgentLaunchLayer(windowId, agentId, now());
+        slot.command = layer;
+        armLaunchVisibility(key, layer);
+      }
+      // 异 agent 的 hook 证据在新 agent 命令启动时作废（loomdesk
+      // clearAgentHookActivitiesBySession 同语义）；同 agent 保留——
+      // 覆盖 OSC/hook 到达竞态与相邻重启的证据延续。status 仍唯 hook 可写。
+      const hook = slot.hook;
+      if (hook && hook.agentId !== agentId) {
+        clearHookTimers(hook);
+        slot.hook = null;
       }
       scheduleEmit();
     },
@@ -234,14 +273,17 @@ export function createForegroundActivityAggregator(
         return;
       }
       const key = panelId;
-      if (isInCloseCooldown(key)) {
+      // 只查 panel 死亡冷却：命令收尾的 hook 冷却不拦新命令——
+      // 相邻命令 <5s 也必须正常呈现（loomdesk ingestCommandStart 同语义）。
+      if (isInCooldown(panelCooldownUntil, key)) {
         return;
       }
-      const existing = entries.get(key);
-      if (existing) {
-        clearAllTimers(existing);
+      const slot = slotFor(key);
+      if (slot.command) {
+        clearCommandTimers(slot.command);
       }
-      entries.set(key, newShellEntry(windowId, panelId, commandLine, now()));
+      // 只覆盖 command 层——`fg` 等 shell 命令不摧毁挂起 agent 的 hook 证据。
+      slot.command = newShellLayer(windowId, commandLine, now());
       scheduleEmit();
     },
 
@@ -250,10 +292,12 @@ export function createForegroundActivityAggregator(
         return;
       }
       const key = panelId;
-      if (disposed || !entries.has(key)) {
+      if (disposed || !slots.has(key)) {
         return;
       }
-      if (closeEntry(key)) {
+      // 前台命令退出 = 面板整场结束：双层同清（覆盖崩溃/kill 等无
+      // SessionEnd hook 的路径）+ 5s hook 冷却拦迟到 hook 事件。
+      if (closeSlot(key, { map: hookCooldownUntil, ms: CLOSE_COOLDOWN_MS })) {
         scheduleEmit();
       }
       pruneExpiredCooldowns();
@@ -271,7 +315,19 @@ export function createForegroundActivityAggregator(
         return;
       }
       const key = event.panelId;
-      if (handleLifecycleEvent(key, event.event)) {
+      if (isInCooldown(panelCooldownUntil, key)) {
+        // panel 已死：SessionStart 也不得复活幽灵（loomdesk isKnownSession
+        // 拒掉同类事件的 Pier 替代——panelId 不复用, 复活必为迟到 flush）。
+        return;
+      }
+      if (event.event === "SessionStart") {
+        // 会话开端豁免 hook 收尾冷却（重启即新生命周期）。
+        hookCooldownUntil.delete(key);
+      } else if (isInCooldown(hookCooldownUntil, key)) {
+        return;
+      }
+      if (event.event === "SessionEnd") {
+        endHookSession(key);
         return;
       }
       const status = activityStatusForHookEvent(event.event);
@@ -279,25 +335,20 @@ export function createForegroundActivityAggregator(
         return;
       }
       const at = now();
-      const entry = acquireHookAgentEntry(key, event, at);
-      if (!(entry && applyTurnBookkeeping(entry, event.event))) {
+      const hook = acquireHookLayer(key, event, at);
+      if (!hook) {
         return;
       }
-      if (entry.activity.kind === "agent") {
-        entry.activity = {
-          ...entry.activity,
-          agentId: event.agent,
-          source: "hook",
-        };
+      if (!applyTurnBookkeeping(hook, event.event)) {
+        return;
       }
+      hook.agentId = event.agent;
       if (SUBAGENT_EVENTS.has(event.event)) {
-        if (entry.activity.kind === "agent") {
-          entry.activity = { ...entry.activity, updatedAt: at };
-        }
+        hook.updatedAt = at;
       } else {
-        setAgentStatus(entry, status, at);
+        setHookStatus(hook, status, at);
       }
-      armHookTtlTimer(key, entry, timerCtx);
+      armHookTtlTimer(key, timerCtx);
       scheduleEmit();
     },
 
@@ -306,42 +357,42 @@ export function createForegroundActivityAggregator(
         return;
       }
       const key = panelId;
-      cooldownUntil.delete(key);
-      const existing = entries.get(key);
-      if (existing) {
-        clearAllTimers(existing);
-      }
-      entries.set(
-        key,
-        newTaskEntry(windowId, panelId, task.taskId, task.label, now())
-      );
+      panelCooldownUntil.delete(key);
+      hookCooldownUntil.delete(key);
+      const slot = slotFor(key);
+      // 用户显式操作优先：双层全清（含 hook——task 接管 pty, 旧会话证据作废）。
+      clearSlotTimers(slot);
+      slot.hook = null;
+      slot.command = newTaskLayer(windowId, task.taskId, task.label, now());
       scheduleEmit();
     },
 
     taskFinished(panelId, args) {
-      const key = panelId;
-      const entry = entries.get(key);
-      if (entry?.activity.kind !== "task") {
+      const slot = slots.get(panelId);
+      const command = slot?.command;
+      if (command?.kind !== "task") {
         return;
       }
-      const at = now();
-      const nextActivity: TaskActivity = {
-        ...entry.activity,
-        status: args.status,
-        updatedAt: at,
-        ...(args.exitCode === undefined ? {} : { exitCode: args.exitCode }),
-      };
-      entry.activity = nextActivity;
+      command.status = args.status;
+      command.updatedAt = now();
+      if (args.exitCode !== undefined) {
+        command.exitCode = args.exitCode;
+      }
       // 幂等：linger timer 一旦启动就不重置——防止 native 层多次上报
       // taskExit 导致 linger 无限延长, 用户看不到 activity 消失。
-      if (!entry.taskLingerTimer) {
-        entry.taskLingerTimer = setTimeout(() => {
-          const current = entries.get(key);
-          if (current?.activity.kind !== "task") {
+      if (!command.lingerTimer) {
+        command.lingerTimer = setTimeout(() => {
+          const current = slots.get(panelId)?.command;
+          if (current?.kind !== "task" || current !== command) {
             return;
           }
-          current.taskLingerTimer = null;
-          if (closeEntry(key, TASK_EXIT_LINGER_MS)) {
+          current.lingerTimer = null;
+          if (
+            closeSlot(panelId, {
+              map: hookCooldownUntil,
+              ms: TASK_EXIT_LINGER_MS,
+            })
+          ) {
             scheduleEmit();
           }
         }, TASK_EXIT_LINGER_MS);
@@ -350,8 +401,9 @@ export function createForegroundActivityAggregator(
     },
 
     panelClosed(panelId) {
-      const key = panelId;
-      if (closeEntry(key)) {
+      if (
+        closeSlot(panelId, { map: panelCooldownUntil, ms: CLOSE_COOLDOWN_MS })
+      ) {
         scheduleEmit();
       }
       pruneExpiredCooldowns();
@@ -359,8 +411,12 @@ export function createForegroundActivityAggregator(
 
     windowClosed(windowId) {
       let anyRemoved = false;
-      for (const [key, entry] of [...entries.entries()]) {
-        if (entry.activity.windowId === windowId && closeEntry(key)) {
+      for (const [key, slot] of [...slots.entries()]) {
+        const slotWindowId = slot.command?.windowId ?? slot.hook?.windowId;
+        if (
+          slotWindowId === windowId &&
+          closeSlot(key, { map: panelCooldownUntil, ms: CLOSE_COOLDOWN_MS })
+        ) {
           anyRemoved = true;
         }
       }
@@ -373,14 +429,14 @@ export function createForegroundActivityAggregator(
     retainPanels(windowId, activePanelIds) {
       const active = new Set(activePanelIds);
       let anyRemoved = false;
-      for (const [key, entry] of entries) {
-        if (entry.activity.windowId !== windowId) {
+      for (const [key, slot] of [...slots.entries()]) {
+        const slotWindowId = slot.command?.windowId ?? slot.hook?.windowId;
+        if (slotWindowId !== windowId || active.has(key)) {
           continue;
         }
-        if (active.has(entry.activity.panelId)) {
-          continue;
-        }
-        if (closeEntry(key)) {
+        if (
+          closeSlot(key, { map: panelCooldownUntil, ms: CLOSE_COOLDOWN_MS })
+        ) {
           anyRemoved = true;
         }
       }
@@ -389,6 +445,7 @@ export function createForegroundActivityAggregator(
       }
       pruneExpiredCooldowns();
     },
+
     onChange(cb) {
       listeners.add(cb);
       return () => {
@@ -413,10 +470,10 @@ export function createForegroundActivityAggregator(
         clearTimeout(emitTimer);
         emitTimer = null;
       }
-      for (const entry of entries.values()) {
-        clearAllTimers(entry);
+      for (const slot of slots.values()) {
+        clearSlotTimers(slot);
       }
-      entries.clear();
+      slots.clear();
       listeners.clear();
     },
   };

--- a/src/main/services/foreground-activity/entry.ts
+++ b/src/main/services/foreground-activity/entry.ts
@@ -2,18 +2,24 @@ import type { AgentKind } from "@shared/contracts/agent.ts";
 import type { AgentHookEventPayload } from "@shared/contracts/agent-session.ts";
 import type {
   ActivityStatus,
-  AgentActivity,
   ForegroundActivity,
-  ShellActivity,
-  TaskActivity,
 } from "@shared/contracts/foreground-activity.ts";
 
 /**
- * ForegroundActivity 聚合器的模型层：常量、Entry 结构、newX 工厂、
- * timer 释放、turn 记账、TTL 武装。
+ * ForegroundActivity 聚合器的模型层：常量、双层 slot 结构、层工厂、
+ * timer 帮手、回合记账与投影纯函数。
  *
- * 纯数据/纯函数——聚合逻辑见 aggregator.ts。语义源自 loomdesk / 老
- * AgentSessionAggregator，逐字迁移以保 tests 回归覆盖。
+ * 双层模型（loomdesk pty_command ⊥ agent_hook 分层的 Pier 变体）：
+ * - command 层 — OSC 133 C/D、launcher、task lifecycle 驱动的「前台命令存在」。
+ *   agent-launch 只是先验（二进制在跑），**不携带会话 status**——
+ *   `omp update` 这类非会话子命令因此不会谎报「等待输入」。
+ * - hook 层   — 仅 JSONL hook 事件驱动的「agent 会话证据」，status 唯一来源。
+ *
+ * 两层互不覆写（taskLaunched 清 hook 层是唯一例外——用户显式操作优先）。
+ * OSC 与 hook 的到达顺序竞态因此自然消解（loomdesk 需要
+ * matchingAgentHookDetails 把 hook 明细拷进命令条目，双层下无需）；
+ * `fg` 等 shell 命令也不再摧毁挂起 agent 的会话证据。
+ * 对外仍投影为每 panel 至多一条 ForegroundActivity（renderer 契约不变）。
  */
 
 /** debounce 广播批量（EMIT_DEBOUNCE_MS）。 */
@@ -24,7 +30,11 @@ export const CLOSE_COOLDOWN_MS = 5000;
 export const SESSION_END_COOLDOWN_MS = 1500;
 /** hook 静默 30min → status 回落 ready（活动仍存在, 计数 0）。 */
 export const HOOK_FRESH_TTL_MS = 30 * 60 * 1000;
-/** SessionStart 创建的 agent activity 消抖隐藏时长（防瞬时闪条）。 */
+/**
+ * 新建层的消抖隐藏时长（防瞬时闪条）。hook 层用于 SessionStart；
+ * launch 层一律适用——`omp --version` 这类瞬时命令不闪（loomdesk
+ * starting 相位同款语义）。
+ */
 export const VISIBILITY_DEBOUNCE_MS = 250;
 /** task 结束后的呈现保留时长（用户看到 exit color 一段时间后自然消失）。 */
 export const TASK_EXIT_LINGER_MS = 5000;
@@ -37,7 +47,7 @@ export const TURN_RESET_EVENTS = new Set([
   "processing",
   "running",
 ]);
-/** 会话创建事件——只有正向信号才能建 hook-source 会话（幽灵门控）。 */
+/** 会话创建事件——只有正向信号才能建 hook 层（幽灵门控）。 */
 export const SESSION_CREATING_EVENTS = new Set([
   "SessionStart",
   "PromptSubmit",
@@ -51,180 +61,191 @@ export const SUSPENDED_JOB_EXIT_CODES: ReadonlySet<number> = new Set([
   145, 146, 147, 148,
 ]);
 
-export interface ActivityEntry {
-  activity: ForegroundActivity;
-  /** 消抖隐藏期为 true——不进 broadcast 条目。 */
+/** hook 层——agent 会话证据。字段只由 hook 事件（及 TTL 衰减）改写。 */
+export interface HookLayer {
+  agentId: AgentKind;
+  /** SessionStart 消抖隐藏期为 true——不参与投影。 */
   hidden: boolean;
-  hookTtlTimer: ReturnType<typeof setTimeout> | null;
-  taskLingerTimer: ReturnType<typeof setTimeout> | null;
+  spawnedAt: number;
+  stateStartedAt: number;
+  status: ActivityStatus;
+  subagentCount: number;
+  ttlTimer: NodeJS.Timeout | null;
   turnEnded: boolean;
-  visibilityTimer: ReturnType<typeof setTimeout> | null;
+  updatedAt: number;
+  visibilityTimer: NodeJS.Timeout | null;
+  windowId: string;
+}
+
+/** command 层：agent 先验——只证明二进制在跑, 无会话 status。 */
+export interface AgentLaunchLayer {
+  agentId: AgentKind;
+  /** 消抖隐藏期为 true——不参与投影。 */
+  hidden: boolean;
+  kind: "agent-launch";
+  spawnedAt: number;
+  updatedAt: number;
+  visibilityTimer: NodeJS.Timeout | null;
+  windowId: string;
+}
+
+/** command 层：普通 shell 命令。 */
+export interface ShellLayer {
+  commandLine: string;
+  kind: "shell";
+  spawnedAt: number;
+  updatedAt: number;
+  windowId: string;
+}
+
+/** command 层：pier task（用户显式触发）。 */
+export interface TaskLayer {
+  exitCode?: number;
+  kind: "task";
+  label: string;
+  lingerTimer: NodeJS.Timeout | null;
+  spawnedAt: number;
+  status: "cancelled" | "failure" | "running" | "success";
+  taskId: string;
+  updatedAt: number;
+  windowId: string;
+}
+
+export type CommandLayer = AgentLaunchLayer | ShellLayer | TaskLayer;
+
+/** 每 panel 一个 slot：两层独立生灭, 投影时合成一条 activity。 */
+export interface PanelSlot {
+  command: CommandLayer | null;
+  hook: HookLayer | null;
 }
 
 export interface TimerCtx {
-  entries: Map<string, ActivityEntry>;
   now: () => number;
   scheduleEmit: () => void;
+  slots: Map<string, PanelSlot>;
 }
 
-export function clearHookTtlTimer(entry: ActivityEntry): void {
-  if (entry.hookTtlTimer) {
-    clearTimeout(entry.hookTtlTimer);
-    entry.hookTtlTimer = null;
+export function clearHookTimers(hook: HookLayer): void {
+  if (hook.ttlTimer) {
+    clearTimeout(hook.ttlTimer);
+    hook.ttlTimer = null;
+  }
+  if (hook.visibilityTimer) {
+    clearTimeout(hook.visibilityTimer);
+    hook.visibilityTimer = null;
   }
 }
 
-export function clearVisibilityTimer(entry: ActivityEntry): void {
-  if (entry.visibilityTimer) {
-    clearTimeout(entry.visibilityTimer);
-    entry.visibilityTimer = null;
+export function clearCommandTimers(command: CommandLayer): void {
+  if (command.kind === "agent-launch" && command.visibilityTimer) {
+    clearTimeout(command.visibilityTimer);
+    command.visibilityTimer = null;
+  }
+  if (command.kind === "task" && command.lingerTimer) {
+    clearTimeout(command.lingerTimer);
+    command.lingerTimer = null;
   }
 }
 
-export function clearTaskLingerTimer(entry: ActivityEntry): void {
-  if (entry.taskLingerTimer) {
-    clearTimeout(entry.taskLingerTimer);
-    entry.taskLingerTimer = null;
+export function clearSlotTimers(slot: PanelSlot): void {
+  if (slot.hook) {
+    clearHookTimers(slot.hook);
   }
-}
-
-export function clearAllTimers(entry: ActivityEntry): void {
-  clearHookTtlTimer(entry);
-  clearVisibilityTimer(entry);
-  clearTaskLingerTimer(entry);
+  if (slot.command) {
+    clearCommandTimers(slot.command);
+  }
 }
 
 /** hook 静默 30min 后 processing/tool/waiting/error → ready 衰减。 */
-export function armHookTtlTimer(
-  key: string,
-  entry: ActivityEntry,
-  ctx: TimerCtx
-): void {
-  clearHookTtlTimer(entry);
-  entry.hookTtlTimer = setTimeout(() => {
-    const current = ctx.entries.get(key);
-    if (
-      current?.activity.kind !== "agent" ||
-      current.activity.source !== "hook"
-    ) {
+export function armHookTtlTimer(key: string, ctx: TimerCtx): void {
+  const hook = ctx.slots.get(key)?.hook;
+  if (!hook) {
+    return;
+  }
+  if (hook.ttlTimer) {
+    clearTimeout(hook.ttlTimer);
+    hook.ttlTimer = null;
+  }
+  hook.ttlTimer = setTimeout(() => {
+    const current = ctx.slots.get(key)?.hook;
+    if (!current) {
       return;
     }
-    current.hookTtlTimer = null;
-    if (current.activity.status !== "ready") {
+    current.ttlTimer = null;
+    if (current.status !== "ready") {
       const at = ctx.now();
-      current.activity = {
-        ...current.activity,
-        status: "ready",
-        stateStartedAt: at,
-        updatedAt: at,
-      };
+      current.status = "ready";
+      current.stateStartedAt = at;
+      current.updatedAt = at;
       ctx.scheduleEmit();
     }
   }, HOOK_FRESH_TTL_MS);
 }
 
-export function newHookAgentEntry(
+export function newHookLayer(
   event: AgentHookEventPayload,
   at: number
-): ActivityEntry {
-  const activity: AgentActivity = {
-    kind: "agent",
+): HookLayer {
+  return {
     agentId: event.agent,
-    panelId: event.panelId,
-    windowId: event.windowId,
-    source: "hook",
-    status: "ready",
-    subagentCount: 0,
+    hidden: event.event === "SessionStart",
     spawnedAt: at,
     stateStartedAt: at,
-    updatedAt: at,
-  };
-  return {
-    hidden: event.event === "SessionStart",
-    hookTtlTimer: null,
-    visibilityTimer: null,
-    taskLingerTimer: null,
+    status: "ready",
+    subagentCount: 0,
+    ttlTimer: null,
     turnEnded: false,
-    activity,
+    updatedAt: at,
+    visibilityTimer: null,
+    windowId: event.windowId,
   };
 }
 
-export function newLaunchAgentEntry(
+export function newAgentLaunchLayer(
   windowId: string,
-  panelId: string,
   agentId: AgentKind,
   at: number
-): ActivityEntry {
-  const activity: AgentActivity = {
-    kind: "agent",
-    agentId,
-    panelId,
-    windowId,
-    source: "launch",
-    status: "ready",
-    subagentCount: 0,
-    spawnedAt: at,
-    stateStartedAt: at,
-    updatedAt: at,
-  };
+): AgentLaunchLayer {
   return {
-    hidden: false,
-    hookTtlTimer: null,
+    agentId,
+    hidden: true,
+    kind: "agent-launch",
+    spawnedAt: at,
+    updatedAt: at,
     visibilityTimer: null,
-    taskLingerTimer: null,
-    turnEnded: false,
-    activity,
+    windowId,
   };
 }
 
-export function newTaskEntry(
+export function newShellLayer(
   windowId: string,
-  panelId: string,
+  commandLine: string,
+  at: number
+): ShellLayer {
+  return {
+    commandLine: commandLine.slice(0, 4096),
+    kind: "shell",
+    spawnedAt: at,
+    updatedAt: at,
+    windowId,
+  };
+}
+
+export function newTaskLayer(
+  windowId: string,
   taskId: string,
   label: string,
   at: number
-): ActivityEntry {
-  const activity: TaskActivity = {
+): TaskLayer {
+  return {
     kind: "task",
-    taskId,
     label,
-    panelId,
-    windowId,
+    lingerTimer: null,
+    spawnedAt: at,
     status: "running",
-    spawnedAt: at,
+    taskId,
     updatedAt: at,
-  };
-  return {
-    hidden: false,
-    hookTtlTimer: null,
-    visibilityTimer: null,
-    taskLingerTimer: null,
-    turnEnded: false,
-    activity,
-  };
-}
-
-export function newShellEntry(
-  windowId: string,
-  panelId: string,
-  commandLine: string,
-  at: number
-): ActivityEntry {
-  const activity: ShellActivity = {
-    kind: "shell",
-    panelId,
     windowId,
-    commandLine: commandLine.slice(0, 4096),
-    spawnedAt: at,
-    updatedAt: at,
-  };
-  return {
-    hidden: false,
-    hookTtlTimer: null,
-    visibilityTimer: null,
-    taskLingerTimer: null,
-    turnEnded: false,
-    activity,
   };
 }
 
@@ -233,55 +254,100 @@ export function newShellEntry(
  * PermissionRequest 豁免吸收——权限弹窗是回合复活的证据。
  */
 export function applyTurnBookkeeping(
-  entry: ActivityEntry,
+  hook: HookLayer,
   eventName: string
 ): boolean {
-  if (entry.activity.kind !== "agent") {
-    return true;
-  }
   if (TURN_BOUNDARY_EVENTS.has(eventName)) {
-    entry.turnEnded = true;
-    entry.activity = { ...entry.activity, subagentCount: 0 };
+    hook.turnEnded = true;
+    hook.subagentCount = 0;
   } else if (TURN_RESET_EVENTS.has(eventName)) {
-    entry.turnEnded = false;
-    entry.activity = { ...entry.activity, subagentCount: 0 };
+    hook.turnEnded = false;
+    hook.subagentCount = 0;
   } else if (eventName === "PermissionRequest") {
-    entry.turnEnded = false;
-  } else if (entry.turnEnded) {
+    hook.turnEnded = false;
+  } else if (hook.turnEnded) {
     return false;
   }
   if (eventName === "SubagentStart") {
-    entry.activity = {
-      ...entry.activity,
-      subagentCount: entry.activity.subagentCount + 1,
-    };
+    hook.subagentCount += 1;
   } else if (eventName === "SubagentStop") {
-    entry.activity = {
-      ...entry.activity,
-      subagentCount: Math.max(0, entry.activity.subagentCount - 1),
-    };
+    hook.subagentCount = Math.max(0, hook.subagentCount - 1);
   }
   return true;
 }
 
-/** activity 上设置 agent status（同 status 内保 stateStartedAt 稳定）。 */
-export function setAgentStatus(
-  entry: ActivityEntry,
+/** hook 层设置 status（同 status 内保 stateStartedAt 稳定）。 */
+export function setHookStatus(
+  hook: HookLayer,
   status: ActivityStatus,
   at: number
 ): void {
-  if (entry.activity.kind !== "agent") {
-    return;
+  if (hook.status !== status) {
+    hook.status = status;
+    hook.stateStartedAt = at;
   }
-  const prev = entry.activity;
-  if (prev.status === status) {
-    entry.activity = { ...prev, updatedAt: at };
-  } else {
-    entry.activity = {
-      ...prev,
-      status,
-      stateStartedAt: at,
-      updatedAt: at,
+  hook.updatedAt = at;
+}
+
+/**
+ * slot → 对外 activity 投影（纯函数）。
+ * 优先级：task > hook(可见) > agent-launch(可见) > shell。
+ * hook 证据优先于 launch 先验——`fg` 覆盖 command 层后 agent 会话照常呈现;
+ * launch 先验投影**不带 status**, renderer 只出品牌图标。
+ */
+export function projectSlot(
+  panelId: string,
+  slot: PanelSlot
+): ForegroundActivity | null {
+  const { command, hook } = slot;
+  if (command?.kind === "task") {
+    return {
+      kind: "task",
+      label: command.label,
+      panelId,
+      spawnedAt: command.spawnedAt,
+      status: command.status,
+      taskId: command.taskId,
+      updatedAt: command.updatedAt,
+      windowId: command.windowId,
+      ...(command.exitCode === undefined ? {} : { exitCode: command.exitCode }),
     };
   }
+  if (hook && !hook.hidden) {
+    return {
+      agentId: hook.agentId,
+      kind: "agent",
+      panelId,
+      source: "hook",
+      spawnedAt: hook.spawnedAt,
+      stateStartedAt: hook.stateStartedAt,
+      status: hook.status,
+      subagentCount: hook.subagentCount,
+      updatedAt: hook.updatedAt,
+      windowId: hook.windowId,
+    };
+  }
+  if (command?.kind === "agent-launch" && !command.hidden) {
+    return {
+      agentId: command.agentId,
+      kind: "agent",
+      panelId,
+      source: "launch",
+      spawnedAt: command.spawnedAt,
+      subagentCount: 0,
+      updatedAt: command.updatedAt,
+      windowId: command.windowId,
+    };
+  }
+  if (command?.kind === "shell") {
+    return {
+      commandLine: command.commandLine,
+      kind: "shell",
+      panelId,
+      spawnedAt: command.spawnedAt,
+      updatedAt: command.updatedAt,
+      windowId: command.windowId,
+    };
+  }
+  return null;
 }

--- a/src/main/services/foreground-activity/jsonl-observer.ts
+++ b/src/main/services/foreground-activity/jsonl-observer.ts
@@ -129,12 +129,15 @@ export function createJsonlObserver(opts: JsonlObserverOpts): JsonlObserver {
   async function processChanges(): Promise<void> {
     try {
       const st = await stat(filePath).catch(() => null);
-      if (!st || st.size <= offset) {
-        // 文件缩小（外部截断）——重置 offset
-        if (st && st.size < offset) {
-          offset = st.size;
-          await persistOffset(offsetPath, offset);
-        }
+      if (!st) {
+        return;
+      }
+      if (st.size < offset) {
+        // 文件被外部截断/重建——从头读当前内容（loomdesk watcher 同语义:
+        // 只重置不读会把重建后已写入的合法事件永久跳过）。
+        offset = 0;
+      }
+      if (st.size === offset) {
         return;
       }
       if (st.size > ROTATE_SIZE) {
@@ -143,13 +146,19 @@ export function createJsonlObserver(opts: JsonlObserverOpts): JsonlObserver {
       }
 
       const chunk = await readNewBytes(st.size);
-      offset = st.size;
-      await persistOffset(offsetPath, offset);
-
-      if (!chunk.length) {
+      // 只消费到最后一个完整行边界（字节层面找 0x0A——JSONL 写端不保证
+      // 原子换行边界, 半行必须留在文件里等补齐; 按字节切割也天然规避
+      // UTF-8 多字节字符跨 chunk 被 toString 拆坏的问题）。offset 只推进
+      // 过完整行, 崩溃恢复永不丢已落盘的完整事件。
+      const lastNewline = chunk.lastIndexOf(0x0a);
+      if (lastNewline === -1) {
         return;
       }
-      for (const line of chunk.toString("utf8").split("\n")) {
+      const consumed = chunk.subarray(0, lastNewline + 1);
+      offset += consumed.length;
+      await persistOffset(offsetPath, offset);
+
+      for (const line of consumed.toString("utf8").split("\n")) {
         processLine(line);
       }
     } catch (err) {

--- a/src/main/services/foreground-activity/types.ts
+++ b/src/main/services/foreground-activity/types.ts
@@ -9,26 +9,33 @@ import type { ForegroundActivityBroadcast } from "@shared/contracts/foreground-a
 /**
  * Aggregator 公共 API。native callback、hook observer、task launcher 与 IPC
  * 快照全部经此接口——单入口, 状态归一。
+ *
+ * 内部为双层模型（见 ./entry.ts）：command 层（OSC/launcher/task）与
+ * hook 层（JSONL 事件）独立生灭, 每 panel 投影至多一条 activity。
  */
 export interface ForegroundActivityAggregator {
   /**
-   * launcher 客户端 / native OSC 133 C 命令行匹配的先验点亮：无需 agent
-   * 侧信号即刻建可见 ready 的 agent activity。豁免关闭冷却; 后续 hook
-   * 无缝接管。
+   * launcher 客户端 / native OSC 133 C 命令行匹配的先验点亮：只建
+   * command 层 agent-launch（250ms 消抖后可见, **无 status**——先验只证明
+   * 二进制在跑, 会话状态唯 hook 证据可写）。豁免关闭冷却; hook 层独立
+   * 接管 status。
    */
   agentLaunched(windowId: string, panelId: string, agentId: AgentKind): void;
   dispose(): void;
 
   /** Path B 三 kind: agentEvent（真身，聚合器消费驱动 agent activity）。 */
   ingestAgentEvent(event: AgentHookEventPayload): void;
-  /** 前台命令退出：panel 内活动清理 + 5s 冷却。Ctrl+Z 悬挂（145-148）保留活动。 */
+  /**
+   * 前台命令退出：双层同清 + 5s 冷却（覆盖崩溃/kill 等无 SessionEnd hook
+   * 的路径）。Ctrl+Z 悬挂（145-148）双层保留。
+   */
   ingestCommandFinished(panelId: string, exitCode?: number): void;
   /** Path B 三 kind 占位入口——本 aggregator 不消费, 保 union 完整。 */
   ingestCommandFinishedHook(event: CommandFinishedHookEvent): void;
   /**
    * ghostty shell integration command_started：native 已 embed cmdline，
-   * 我们本地做 matchAgentCommand 词元识别; 非空 agent 走 launch 路径，
-   * null 覆盖为 shell activity。
+   * 我们本地做 matchAgentCommand 词元识别; 非空 agent 走 agentLaunched，
+   * null 只覆盖 command 层为 shell（hook 层不动——`fg` 不摧毁挂起会话）。
    */
   ingestCommandStarted(
     panelId: string,
@@ -56,7 +63,7 @@ export interface ForegroundActivityAggregator {
     }
   ): void;
 
-  /** Task 拉起：用户显式操作优先于 agent, 覆盖 per-panel activity。 */
+  /** Task 拉起：用户显式操作优先, 双层全清后建 task 层。 */
   taskLaunched(
     panelId: string,
     windowId: string,

--- a/src/renderer/panel-kits/terminal/agent-status-item.tsx
+++ b/src/renderer/panel-kits/terminal/agent-status-item.tsx
@@ -36,7 +36,8 @@ function AgentStatusItemView({ panelId }: { panelId: string }) {
   const [nowMs, setNowMs] = useState(() => Date.now());
 
   const agent = isAgentActivity(activity) ? activity : null;
-  const shimmer = agent ? shouldShimmer(agent.status) : false;
+  const status = agent?.status;
+  const shimmer = status !== undefined && shouldShimmer(status);
   useEffect(() => {
     if (!shimmer) {
       return;
@@ -49,25 +50,43 @@ function AgentStatusItemView({ panelId }: { panelId: string }) {
   if (!agent) {
     return null;
   }
-  // ready 也可见（loomdesk："等待输入"）——item 的隐藏只由 agent activity 是否存在决定。
+  const agentLabel =
+    getAgentCatalogEntry(agent.agentId)?.label ?? agent.agentId;
+  // 无 hook 证据（launch 先验, 如 `omp update` 这类非会话子命令）→
+  // icon-only：只出品牌图标, 不谎报状态文案。status 唯 hook 证据可设。
+  if (status === undefined) {
+    return (
+      <span
+        className="inline-flex shrink-0 items-center gap-1"
+        data-agent-status="none"
+        data-testid="agent-status-item"
+      >
+        <span className="inline-flex size-5 shrink-0 items-center justify-center">
+          <AgentIcon agentId={agent.agentId} size={12} />
+        </span>
+        <span className="sr-only">{agentLabel}</span>
+      </span>
+    );
+  }
+  // ready 可见（loomdesk："等待输入"）——hook 证据在场时五态全部出文案。
   const level = shimmer
-    ? longRunLevel(Math.max(0, nowMs - agent.stateStartedAt))
+    ? longRunLevel(
+        Math.max(0, nowMs - (agent.stateStartedAt ?? agent.spawnedAt))
+      )
     : null;
-  const colorVar = statusColorVar(agent.status, level);
-  const label = t(agentStatusTextKey(agent.status));
+  const colorVar = statusColorVar(status, level);
+  const label = t(agentStatusTextKey(status));
   const badge =
     agent.subagentCount > 0
       ? `${label} · ${t("terminal.agentStatus.subagentCount", {
           count: agent.subagentCount,
         })}`
       : label;
-  const agentLabel =
-    getAgentCatalogEntry(agent.agentId)?.label ?? agent.agentId;
 
   return (
     <span
       className="inline-flex shrink-0 items-center gap-1"
-      data-agent-status={agent.status}
+      data-agent-status={status}
       data-testid="agent-status-item"
     >
       <span className="inline-flex size-5 shrink-0 items-center justify-center">

--- a/src/renderer/stores/foreground-activity.store.ts
+++ b/src/renderer/stores/foreground-activity.store.ts
@@ -33,14 +33,6 @@ export const useForegroundActivityStore = create<ForegroundActivityState>(
   })
 );
 
-/** 250ms 之前的 activity 视为可见（spec §4.3 spawnedAt visibility gating）。 */
-export function isVisibleActivity(
-  activity: ForegroundActivity,
-  now: number
-): boolean {
-  return now - activity.spawnedAt >= 250;
-}
-
 export interface ActivityCounts {
   running: number;
   waiting: number;

--- a/src/shared/contracts/foreground-activity.ts
+++ b/src/shared/contracts/foreground-activity.ts
@@ -9,9 +9,8 @@ import type { PanelTabStatus } from "./panel.ts";
  * - `task`   — 面板里跑着 pier task（用户显式触发的 npm/命令）。
  * - `shell`  — 面板里跑着普通 shell 命令（非 agent、非 task）。
  * - `idle`   — 面板存在但无活动（一般不产生 broadcast, 保留 kind 完整）。
- *
- * 优先级（同 panel 出现多种候选时）：agent > task > shell > idle。
- * 例如 agent 会话进行中用户触发 task rerun → task 覆盖 agent。
+ * 优先级（同 panel 出现多种候选时）：task > agent(hook) > agent(launch) > shell。
+ * task 是用户显式操作, 覆盖一切；hook 证据优先于 launch 先验。
  */
 
 export const activityKindSchema = z.enum(["agent", "task", "shell", "idle"]);
@@ -19,11 +18,16 @@ export type ActivityKind = z.infer<typeof activityKindSchema>;
 
 /**
  * Agent 会话运行时状态（loomdesk 五态借鉴）：
- * - `ready`      — 进程存活但无活跃工作
+ * - `ready`      — 进程存活但无活跃工作（回合结束, 等待输入）
  * - `processing` — 主循环推进中
  * - `tool`       — 调用工具
  * - `waiting`    — 等用户输入（PermissionRequest）
  * - `error`      — 最近事件是失败信号
+ *
+ * status 的唯一来源是 hook 证据。launch 先验（OSC 133 / launcher）只能
+ * 证明「面板里有个 agent 二进制在跑」, 不能证明它处于任何会话状态——
+ * 例如 `omp update` 这类非会话子命令。因此 AgentActivity.status 是
+ * optional：缺席 = 无 hook 证据, renderer 只出品牌图标不出状态文案。
  */
 export const activityStatusSchema = z.enum([
   "ready",
@@ -37,7 +41,7 @@ export type ActivityStatus = z.infer<typeof activityStatusSchema>;
 const baseActivityFields = {
   panelId: z.string().min(1),
   windowId: z.string().min(1).max(32),
-  /** activity 首次建立的时刻。renderer 侧 250ms visibility gating 依赖。 */
+  /** activity 首次建立的时刻（250ms 可见性消抖在 main 聚合器内完成）。 */
   spawnedAt: z.number().int().nonnegative(),
   /** 最近一次收到任何信号的时刻。 */
   updatedAt: z.number().int().nonnegative(),
@@ -48,12 +52,15 @@ const agentActivitySchema = z
     kind: z.literal("agent"),
     ...baseActivityFields,
     agentId: agentKindSchema,
-    status: activityStatusSchema,
+    status: activityStatusSchema.optional(),
     /** `hook` = JSONL agentEvent 消息，`launch` = launcher/OSC133 先验点亮。 */
     source: z.enum(["hook", "launch"]),
     subagentCount: z.number().int().nonnegative(),
-    /** 状态最近一次「变化」的时刻（同状态内的心跳事件不重置, 供 UI 计时）。 */
-    stateStartedAt: z.number().int().nonnegative(),
+    /**
+     * 状态最近一次「变化」的时刻（同状态内的心跳事件不重置, 供 UI 计时）。
+     * 与 status 同生同灭：无 hook 证据时缺席。
+     */
+    stateStartedAt: z.number().int().nonnegative().optional(),
   })
   .strict();
 export type AgentActivity = z.infer<typeof agentActivitySchema>;
@@ -135,9 +142,12 @@ export function activityStatusForHookEvent(
   }
 }
 
-/** activity status → tab 指示器状态。ready 映射 idle = tab 无指示器。 */
+/**
+ * activity status → tab 指示器状态。ready 映射 idle = tab 无指示器；
+ * undefined（launch 先验、无 hook 证据）同样无指示器。
+ */
 export function tabStatusForActivityStatus(
-  status: ActivityStatus
+  status: ActivityStatus | undefined
 ): PanelTabStatus {
   switch (status) {
     case "processing":

--- a/tests/unit/agent-command-detection.test.ts
+++ b/tests/unit/agent-command-detection.test.ts
@@ -46,6 +46,9 @@ describe("matchAgentCommand (只匹配可执行体, 不扫参数)", () => {
     ["codex", "codex"],
     ["codex --model gpt-5.5", "codex"],
     ["claude --dangerously-skip-permissions", "claude"],
+    ["claude update", "claude"], // 子命令词不参与身份判定（omp update bug 回归 pin）
+    ["omp update", "omp"],
+    ["omp update --check", "omp"],
     ["OPENAI_API_KEY=x codex", "codex"],
     ["env FOO=bar claude --help", "claude"],
     ["sudo -u me claude", "claude"],
@@ -72,6 +75,8 @@ describe("matchAgentCommand (只匹配可执行体, 不扫参数)", () => {
     "pip install x", // "pi" 词元不得命中 "pip"
     "claudette",
     "my-codex-tool",
+    "compare", // "omp" 词元不得命中子串
+    "romp update", // 词边界：前缀不误伤
     "",
   ])("非 agent 命令 → null: %s", (commandLine) => {
     expect(matchAgentCommand(commandLine)).toBeNull();

--- a/tests/unit/agent-integrations/cline.test.ts
+++ b/tests/unit/agent-integrations/cline.test.ts
@@ -75,7 +75,7 @@ describe("buildClineHookScript", () => {
 });
 
 describe("install/uninstallClineHooks (文件 IO)", () => {
-  it("6 个事件各写一个可执行文件, 文件名精确匹配事件名", async () => {
+  it("8 个事件各写一个可执行文件, 文件名精确匹配事件名", async () => {
     const dir = await mkdtemp(join(tmpdir(), "pier-cline-hooks-"));
     const { installClineHooks, CLINE_EVENT_FILE_NAMES } =
       await loadIntegration();
@@ -87,6 +87,8 @@ describe("install/uninstallClineHooks (文件 IO)", () => {
       "PreToolUse",
       "PostToolUse",
       "TaskCancel",
+      "TaskComplete",
+      "PreCompact",
     ]);
     for (const name of CLINE_EVENT_FILE_NAMES) {
       const path = join(dir, name);
@@ -107,6 +109,8 @@ describe("install/uninstallClineHooks (文件 IO)", () => {
       ["PreToolUse", "ToolStart"],
       ["PostToolUse", "ToolComplete"],
       ["TaskCancel", "Stop"],
+      ["TaskComplete", "Stop"],
+      ["PreCompact", "processing"],
     ];
     for (const [file, pierEvent] of expectations) {
       const content = await readFile(join(dir, file), "utf8");

--- a/tests/unit/agent-integrations/gemini.test.ts
+++ b/tests/unit/agent-integrations/gemini.test.ts
@@ -10,13 +10,13 @@ import {
 } from "../../../src/main/services/agents/integrations/gemini.ts";
 
 const MARK = "PIER_AGENT_HOOKS_DIR";
-const PERMISSION_REQUEST_RE = /PermissionRequest/i;
 
 const GEMINI_EVENTS = [
   "SessionStart",
   "SessionEnd",
   "BeforeAgent",
   "AfterAgent",
+  "Notification",
   "BeforeTool",
   "AfterTool",
 ];
@@ -49,7 +49,7 @@ function allHookEntries(
 }
 
 describe("withPierGeminiHooks", () => {
-  it("为 6 个 Gemini hook 事件各注入一条 pier 命令", () => {
+  it("为 7 个 Gemini hook 事件各注入一条 pier 命令", () => {
     const next = withPierGeminiHooks({});
     const hooks = next.hooks as Record<string, unknown[]>;
     for (const evt of GEMINI_EVENTS) {
@@ -76,15 +76,18 @@ describe("withPierGeminiHooks", () => {
     }
   });
 
-  it("不存在 PermissionRequest 类原生事件键；hooks 下只有 6 个指定事件键", () => {
+  it("Notification 映射 PermissionRequest（ToolPermission 提示）；hooks 键集 = 7 个指定事件全集", () => {
     const next = withPierGeminiHooks({});
-    const hooks = next.hooks as Record<string, unknown[]>;
+    const hooks = hookMatchers(next);
     const keys = Object.keys(hooks);
     expect(keys).toHaveLength(GEMINI_EVENTS.length);
-    for (const key of keys) {
-      expect(key).not.toMatch(PERMISSION_REQUEST_RE);
-    }
     expect(keys.sort()).toEqual([...GEMINI_EVENTS].sort());
+    const notification = hooks.Notification ?? [];
+    expect(notification).toHaveLength(1);
+    expect(notification[0]?.matcher).toBeUndefined();
+    const cmds = notification.flatMap((m) => m.hooks.map((h) => h.command));
+    expect(cmds).toHaveLength(1);
+    expect(cmds[0]).toContain('"PermissionRequest"');
   });
 
   it("幂等：重复安装不产生重复条目", () => {

--- a/tests/unit/main/foreground-activity-aggregator.test.ts
+++ b/tests/unit/main/foreground-activity-aggregator.test.ts
@@ -38,16 +38,48 @@ describe("ForegroundActivityAggregator", () => {
     vi.advanceTimersByTime(ms);
   }
 
-  it("agentLaunched → 建立可见 launch-source agent activity, status ready", () => {
+  it("agentLaunched → 建立 launch-source agent activity, 250ms 消抖后可见且无 status", () => {
     const agg = createForegroundActivityAggregator({ now });
     agg.agentLaunched("1", "p1", "codex");
+    // 消抖期内隐藏（瞬时命令不闪条）
+    expect(agg.snapshot().activities).toHaveLength(0);
+    advance(250);
     const snap = agg.snapshot();
     expect(snap.activities).toHaveLength(1);
     const a = snap.activities[0] as AgentActivity;
     expect(a.kind).toBe("agent");
     expect(a.agentId).toBe("codex");
     expect(a.source).toBe("launch");
-    expect(a.status).toBe("ready");
+    // launch 先验无 hook 证据 → 投影不带 status
+    expect(a.status).toBeUndefined();
+    expect(a.subagentCount).toBe(0);
+    agg.dispose();
+  });
+
+  it("同 agent 双击去抖: launcher + OSC 二次 agentLaunched 不重置消抖 timer", () => {
+    const agg = createForegroundActivityAggregator({ now });
+    agg.agentLaunched("1", "p1", "codex");
+    advance(150);
+    // OSC 133 C 匹配同 agent → 去抖, 不重置 250ms 消抖
+    agg.ingestCommandStarted("p1", "1", "codex --resume", "codex");
+    advance(100);
+    // 距首次 launch 恰 250ms → 可见（若 timer 被重置此刻仍隐藏）
+    expect(agg.snapshot().activities).toHaveLength(1);
+    agg.dispose();
+  });
+
+  it("不同 agent 重 launch → 换新层, 重新 250ms 消抖", () => {
+    const agg = createForegroundActivityAggregator({ now });
+    agg.agentLaunched("1", "p1", "codex");
+    advance(150);
+    agg.agentLaunched("1", "p1", "claude");
+    // 首层的 250ms 已到, 但层已被替换 → 仍隐藏
+    advance(100);
+    expect(agg.snapshot().activities).toHaveLength(0);
+    // 新层自建立起 250ms 后可见
+    advance(150);
+    const a = agg.snapshot().activities[0] as AgentActivity;
+    expect(a.agentId).toBe("claude");
     agg.dispose();
   });
 
@@ -124,13 +156,15 @@ describe("ForegroundActivityAggregator", () => {
     agg.dispose();
   });
 
-  it("ingestCommandStarted with agent match → agent activity source=launch", () => {
+  it("ingestCommandStarted with agent match → 250ms 后 launch-source agent activity", () => {
     const agg = createForegroundActivityAggregator({ now });
     agg.ingestCommandStarted("p1", "1", "codex --resume", "codex");
+    advance(250);
     const a = agg.snapshot().activities[0] as AgentActivity;
     expect(a.kind).toBe("agent");
     expect(a.agentId).toBe("codex");
     expect(a.source).toBe("launch");
+    expect(a.status).toBeUndefined();
     agg.dispose();
   });
 
@@ -147,17 +181,23 @@ describe("ForegroundActivityAggregator", () => {
     agg.dispose();
   });
 
-  it("ingestCommandFinished 正常退出 → 清活动, 5s 冷却", () => {
+  it("ingestCommandFinished 正常退出 → 清活动, hook 冷却只拦迟到 hook 不拦新命令", () => {
     const agg = createForegroundActivityAggregator({ now });
     agg.ingestCommandStarted("p1", "1", "ls", null);
     expect(agg.snapshot().activities).toHaveLength(1);
     agg.ingestCommandFinished("p1", 0);
     expect(agg.snapshot().activities).toHaveLength(0);
-    // 5s 冷却期内新命令被拦
+    // 相邻命令 <5s：新 OSC 证据不受 hook 冷却拦截, 立即可见
     agg.ingestCommandStarted("p1", "1", "pwd", null);
+    expect(agg.snapshot().activities).toHaveLength(1);
+    agg.ingestCommandFinished("p1", 0);
     expect(agg.snapshot().activities).toHaveLength(0);
+    // 命令收尾后迟到 hook（ToolStart 属 SESSION_CREATING）5s 内被拦
+    agg.ingestAgentEvent(hookEvent("ToolStart"));
+    expect(agg.snapshot().activities).toHaveLength(0);
+    // 冷却过期后 PromptSubmit 重建 hook 会话
     advance(5001);
-    agg.ingestCommandStarted("p1", "1", "pwd", null);
+    agg.ingestAgentEvent(hookEvent("PromptSubmit"));
     expect(agg.snapshot().activities).toHaveLength(1);
     agg.dispose();
   });
@@ -165,6 +205,7 @@ describe("ForegroundActivityAggregator", () => {
   it("ingestCommandFinished 悬挂退出码 (147) → 保留活动（Ctrl+Z）", () => {
     const agg = createForegroundActivityAggregator({ now });
     agg.agentLaunched("1", "p1", "codex");
+    advance(250);
     expect(agg.snapshot().activities).toHaveLength(1);
     agg.ingestCommandFinished("p1", 147);
     // 悬挂不视为 agent 退出
@@ -192,6 +233,7 @@ describe("ForegroundActivityAggregator", () => {
   it("taskLaunched 覆盖已有 agent activity（用户显式操作优先）", () => {
     const agg = createForegroundActivityAggregator({ now });
     agg.agentLaunched("1", "p1", "codex");
+    advance(250);
     expect((agg.snapshot().activities[0] as AgentActivity).kind).toBe("agent");
     agg.taskLaunched("p1", "1", { taskId: "t1", label: "npm build" });
     const a = agg.snapshot().activities[0];
@@ -329,22 +371,42 @@ describe("ForegroundActivityAggregator", () => {
     agg.dispose();
   });
 
-  it("回归: agentLaunched 清 hookTtlTimer (relaunch 后 30min 不再触发衰减)", () => {
+  it("回归: agentLaunched 异 agent 清 hook 层 → 投影为新 agent launch", () => {
     const agg = createForegroundActivityAggregator({ now });
-    // 建立 hook agent activity + tool status → TTL timer armed
+    // 建立 hook agent activity (claude) + tool status
     agg.ingestAgentEvent(hookEvent("PromptSubmit"));
     agg.ingestAgentEvent(hookEvent("ToolStart"));
-    let a = agg.snapshot().activities[0] as AgentActivity;
-    expect(a.status).toBe("tool");
-    // agentLaunched 覆盖 → status 保持 tool (agent kind, 只更新 agentId + 清 TTL)
+    const before = agg.snapshot().activities[0] as AgentActivity;
+    expect(before.status).toBe("tool");
+    expect(before.agentId).toBe("claude");
+    // 异 agent 启动 → 旧 hook 证据作废 (clearAgentHookActivitiesBySession)
     agg.agentLaunched("1", "p1", "codex");
-    a = agg.snapshot().activities[0] as AgentActivity;
-    expect(a.agentId).toBe("codex");
+    // hook 层已清, 新 launch 层 250ms 消抖内隐藏 → 无 activity
+    expect(agg.snapshot().activities).toHaveLength(0);
+    advance(250);
+    const after = agg.snapshot().activities[0] as AgentActivity;
+    expect(after.kind).toBe("agent");
+    expect(after.source).toBe("launch");
+    expect(after.agentId).toBe("codex");
+    expect(after.status).toBeUndefined();
+    agg.dispose();
+  });
+
+  it("回归: agentLaunched 同 agent 保留 hook 层 (证据与 TTL 不被 relaunch 清除)", () => {
+    const agg = createForegroundActivityAggregator({ now });
+    agg.ingestAgentEvent(hookEvent("PromptSubmit"));
+    agg.ingestAgentEvent(hookEvent("ToolStart"));
+    // 同 agent 重启（如 claude --resume）→ hook 证据延续, 不清层
+    agg.agentLaunched("1", "p1", "claude");
+    let a = agg.snapshot().activities[0] as AgentActivity;
+    expect(a.source).toBe("hook");
+    expect(a.agentId).toBe("claude");
     expect(a.status).toBe("tool");
-    // 30min 后不应回落 ready (老 TTL 已清)
-    advance(30 * 60 * 1000 + 100);
+    // hook TTL 不因 relaunch 重置：30min 静默照常衰减 ready
+    advance(30 * 60 * 1000);
     a = agg.snapshot().activities[0] as AgentActivity;
-    expect(a.status).toBe("tool");
+    expect(a.source).toBe("hook");
+    expect(a.status).toBe("ready");
     agg.dispose();
   });
 
@@ -376,6 +438,37 @@ describe("ForegroundActivityAggregator", () => {
     agg.dispose();
   });
 
+  it("回归: panelClosed 后 5s 内 SessionStart 不得重建 (panel 死亡冷却不豁免)", () => {
+    const agg = createForegroundActivityAggregator({ now });
+    agg.ingestAgentEvent(hookEvent("PromptSubmit"));
+    expect(agg.snapshot().activities).toHaveLength(1);
+    agg.panelClosed("p1");
+    expect(agg.snapshot().activities).toHaveLength(0);
+    // 幽灵防复活：panel 冷却期内 SessionStart 也被拦（过消抖窗仍无 activity）
+    agg.ingestAgentEvent(hookEvent("SessionStart"));
+    advance(250);
+    expect(agg.snapshot().activities).toHaveLength(0);
+    // panel 冷却过期后 SessionStart 才能重建
+    advance(4751);
+    agg.ingestAgentEvent(hookEvent("SessionStart"));
+    advance(250);
+    expect(agg.snapshot().activities).toHaveLength(1);
+    agg.dispose();
+  });
+
+  it("回归: SessionEnd 后 1.5s 内新 shell 命令立即可见 (hook 冷却不拦命令)", () => {
+    const agg = createForegroundActivityAggregator({ now });
+    agg.ingestAgentEvent(hookEvent("PromptSubmit"));
+    agg.ingestAgentEvent(hookEvent("SessionEnd"));
+    expect(agg.snapshot().activities).toHaveLength(0);
+    // hook 收尾冷却只 gate hook 层——新 shell 命令是新鲜 OSC 证据
+    agg.ingestCommandStarted("p1", "1", "ls -la", null);
+    const snap = agg.snapshot();
+    expect(snap.activities).toHaveLength(1);
+    expect(snap.activities[0]?.kind).toBe("shell");
+    agg.dispose();
+  });
+
   it("回归: windowClosed 清 taskLingerTimer (无残留 timer)", () => {
     const agg = createForegroundActivityAggregator({ now });
     agg.taskLaunched("p1", "1", { taskId: "t1", label: "test" });
@@ -391,6 +484,7 @@ describe("ForegroundActivityAggregator", () => {
   it("回归: commandStart/Finished hook stub 无副作用 no-op (保 discriminated union)", () => {
     const agg = createForegroundActivityAggregator({ now });
     agg.agentLaunched("1", "p1", "codex");
+    advance(250);
     expect(agg.snapshot().activities).toHaveLength(1);
     // stub 通道不应改变 activity 状态
     agg.ingestCommandStartHook({
@@ -409,6 +503,96 @@ describe("ForegroundActivityAggregator", () => {
     });
     expect(agg.snapshot().activities).toHaveLength(1);
     expect(agg.snapshot().activities[0]?.kind).toBe("agent");
+    agg.dispose();
+  });
+
+  it("回归: omp update → agent match 250ms 后可见且无 status, 正常退出清空", () => {
+    const agg = createForegroundActivityAggregator({ now });
+    agg.ingestCommandStarted("p1", "1", "omp update", "omp");
+    // 消抖期内隐藏
+    expect(agg.snapshot().activities).toHaveLength(0);
+    advance(250);
+    const a = agg.snapshot().activities[0] as AgentActivity;
+    expect(a.kind).toBe("agent");
+    expect(a.agentId).toBe("omp");
+    expect(a.source).toBe("launch");
+    expect(a.status).toBeUndefined();
+    agg.ingestCommandFinished("p1", 0);
+    expect(agg.snapshot().activities).toHaveLength(0);
+    agg.dispose();
+  });
+
+  it("回归: 瞬时命令不闪条 — 消抖期内退出全程不可见, 消抖 timer 不复活", () => {
+    const agg = createForegroundActivityAggregator({ now });
+    agg.agentLaunched("1", "p1", "codex");
+    expect(agg.snapshot().activities).toHaveLength(0);
+    advance(200);
+    expect(agg.snapshot().activities).toHaveLength(0);
+    agg.ingestCommandFinished("p1", 0);
+    expect(agg.snapshot().activities).toHaveLength(0);
+    // 消抖 timer 不得在层清除后复活条目
+    advance(250);
+    expect(agg.snapshot().activities).toHaveLength(0);
+    agg.dispose();
+  });
+
+  it("hook 证据优先于 launch 先验: PromptSubmit 立即可见并压过消抖中的 launch", () => {
+    const agg = createForegroundActivityAggregator({ now });
+    agg.agentLaunched("1", "p1", "codex");
+    agg.ingestAgentEvent(hookEvent("PromptSubmit"));
+    // hook 证据立即显形, 无须等 launch 消抖
+    const a = agg.snapshot().activities[0] as AgentActivity;
+    expect(a.kind).toBe("agent");
+    expect(a.source).toBe("hook");
+    expect(a.status).toBe("processing");
+    expect(a.agentId).toBe("claude");
+    agg.dispose();
+  });
+
+  it("回归: fg 不摧毁挂起会话 — Ctrl+Z 后 shell 命令只盖 command 层", () => {
+    const agg = createForegroundActivityAggregator({ now });
+    agg.ingestAgentEvent(hookEvent("PromptSubmit"));
+    expect((agg.snapshot().activities[0] as AgentActivity).status).toBe(
+      "processing"
+    );
+    // Ctrl+Z 悬挂：双层保留
+    agg.ingestCommandFinished("p1", 147);
+    // `fg`（无 agent match）只覆盖 command 层, hook 证据保留
+    agg.ingestCommandStarted("p1", "1", "fg", null);
+    const a = agg.snapshot().activities[0] as AgentActivity;
+    expect(a.kind).toBe("agent");
+    expect(a.source).toBe("hook");
+    expect(a.status).toBe("processing");
+    agg.dispose();
+  });
+
+  it("SessionEnd 只清 hook 层: 投影回落 launch icon-only, 命令退出后全清", () => {
+    const agg = createForegroundActivityAggregator({ now });
+    agg.agentLaunched("1", "p1", "codex");
+    advance(250);
+    agg.ingestAgentEvent(hookEvent("PromptSubmit"));
+    let a = agg.snapshot().activities[0] as AgentActivity;
+    expect(a.source).toBe("hook");
+    agg.ingestAgentEvent(hookEvent("SessionEnd"));
+    // hook 清除, command 层保留 → 回落 launch 先验（无 status）
+    a = agg.snapshot().activities[0] as AgentActivity;
+    expect(a.kind).toBe("agent");
+    expect(a.source).toBe("launch");
+    expect(a.agentId).toBe("codex");
+    expect(a.status).toBeUndefined();
+    // 前台命令最终退出 → 全清
+    agg.ingestCommandFinished("p1", 0);
+    expect(agg.snapshot().activities).toHaveLength(0);
+    agg.dispose();
+  });
+
+  it("task 压住 hook 投影: task 在场时 hook 事件仍建 hook 层但投影为 task", () => {
+    const agg = createForegroundActivityAggregator({ now });
+    agg.taskLaunched("p1", "1", { taskId: "t1", label: "npm build" });
+    agg.ingestAgentEvent(hookEvent("PromptSubmit"));
+    const snap = agg.snapshot();
+    expect(snap.activities).toHaveLength(1);
+    expect(snap.activities[0]?.kind).toBe("task");
     agg.dispose();
   });
 });

--- a/tests/unit/main/jsonl-observer.test.ts
+++ b/tests/unit/main/jsonl-observer.test.ts
@@ -155,4 +155,118 @@ describe("jsonl-observer", () => {
 
     observer.dispose();
   }, 20_000);
+
+  it("半行不丢：无换行尾部半行不派发不报错, 补齐后完整派发", async () => {
+    writeFileSync(jsonlPath, "");
+
+    const received: AgentHookEventPayload[] = [];
+    const errors: unknown[] = [];
+    const observer = createJsonlObserver({
+      filePath: jsonlPath,
+      onAgentEvent(event) {
+        received.push(event);
+      },
+      onCommandFinished() {
+        // 未消费——本 case 只测 agentEvent 路径。
+      },
+      onCommandStart() {
+        // 未消费——本 case 只测 agentEvent 路径。
+      },
+      onError(err) {
+        errors.push(err);
+      },
+    });
+
+    // 完整行 A + 无换行的半行 B（写端不保证原子换行边界）
+    const lineB = eventLine(1);
+    const half = lineB.slice(0, Math.floor(lineB.length / 2));
+    appendFileSync(jsonlPath, `${eventLine(0)}\n${half}`);
+    await observer.pollNow();
+
+    // 只收到 A；半行 B 既不派发也不触发 onError（offset 停在 A 行尾）
+    expect(received.map((e) => e.event)).toEqual(["evt-0"]);
+    expect(errors).toHaveLength(0);
+
+    // 写端补齐 B 尾部 + 换行 → 下轮完整派发, 不拆坏不丢事件
+    appendFileSync(jsonlPath, `${lineB.slice(half.length)}\n`);
+    await observer.pollNow();
+
+    expect(received.map((e) => e.event)).toEqual(["evt-0", "evt-1"]);
+    expect(errors).toHaveLength(0);
+
+    observer.dispose();
+  }, 20_000);
+
+  it("截断重建不丢：size < offset 时 offset 归 0 并继续读当前内容", async () => {
+    writeFileSync(jsonlPath, "");
+
+    const received: AgentHookEventPayload[] = [];
+    const observer = createJsonlObserver({
+      filePath: jsonlPath,
+      onAgentEvent(event) {
+        received.push(event);
+      },
+      onCommandFinished() {
+        // 未消费——本 case 只测 agentEvent 路径。
+      },
+      onCommandStart() {
+        // 未消费——本 case 只测 agentEvent 路径。
+      },
+    });
+
+    // 写入长行 A（用 sessionId 撑大字节数——schema 严格且 event 上限 64 字符）
+    // → offset 推进到 A 行尾
+    const longLine = JSON.stringify({
+      v: 1,
+      kind: "agentEvent",
+      agent: "claude",
+      event: "evt-long",
+      panelId: "panel-1",
+      windowId: "w-1",
+      sessionId: "s".repeat(120),
+    });
+    appendFileSync(jsonlPath, `${longLine}\n`);
+    await observer.pollNow();
+    expect(received.map((e) => e.event)).toEqual(["evt-long"]);
+
+    // 文件被截断重建为更短的新合法行 C（size < offset）
+    writeFileSync(jsonlPath, `${eventLine(7)}\n`);
+    await observer.pollNow();
+
+    // 重建后的合法事件不得丢（只重置 offset 不读会永久跳过 C）
+    expect(received.map((e) => e.event)).toEqual(["evt-long", "evt-7"]);
+
+    observer.dispose();
+  }, 20_000);
+
+  it("坏行容错：坏 JSON 行触发 onError 但不阻断同批合法行", async () => {
+    writeFileSync(jsonlPath, "");
+
+    const received: AgentHookEventPayload[] = [];
+    const errors: unknown[] = [];
+    const observer = createJsonlObserver({
+      filePath: jsonlPath,
+      onAgentEvent(event) {
+        received.push(event);
+      },
+      onCommandFinished() {
+        // 未消费——本 case 只测 agentEvent 路径。
+      },
+      onCommandStart() {
+        // 未消费——本 case 只测 agentEvent 路径。
+      },
+      onError(err) {
+        errors.push(err);
+      },
+    });
+
+    // 坏 JSON 行夹在两条合法行之间, 同批到达
+    appendFileSync(jsonlPath, `${eventLine(0)}\n{not-json\n${eventLine(1)}\n`);
+    await observer.pollNow();
+
+    expect(received.map((e) => e.event)).toEqual(["evt-0", "evt-1"]);
+    expect(errors).toHaveLength(1);
+
+    observer.dispose();
+  }, 20_000);
 });

--- a/tests/unit/renderer/agent-status-item.test.tsx
+++ b/tests/unit/renderer/agent-status-item.test.tsx
@@ -1,0 +1,147 @@
+import type {
+  AgentActivity,
+  ForegroundActivityBroadcast,
+} from "@shared/contracts/foreground-activity.ts";
+import { render } from "@testing-library/react";
+import i18next from "i18next";
+import { isValidElement } from "react";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { initI18n } from "@/i18n/index.ts";
+import { registerAgentStatusItem } from "@/panel-kits/terminal/agent-status-item.tsx";
+import { terminalStatusItemRegistry } from "@/panel-kits/terminal/terminal-status-bar.tsx";
+import { useForegroundActivityStore } from "@/stores/foreground-activity.store.ts";
+
+const PANEL_ID = "p1";
+
+function agentBroadcast(
+  overrides: Partial<AgentActivity> = {}
+): ForegroundActivityBroadcast {
+  return {
+    activities: [
+      {
+        agentId: "omp",
+        kind: "agent",
+        panelId: PANEL_ID,
+        source: "launch",
+        spawnedAt: 1,
+        subagentCount: 0,
+        updatedAt: 1,
+        windowId: "1",
+        ...overrides,
+      },
+    ],
+    ts: 1,
+  };
+}
+
+/** 经注册项 render 渲染(AgentStatusItemView 未导出, registry 是公开入口)。 */
+function renderItem() {
+  const item = terminalStatusItemRegistry
+    .list()
+    .find((entry) => entry.id === "core.agent-status");
+  if (!item) {
+    throw new Error("core.agent-status 未注册");
+  }
+  const node = item.render({
+    context: undefined,
+    cwd: null,
+    panelId: PANEL_ID,
+    title: null,
+  });
+  if (!isValidElement(node)) {
+    throw new Error("core.agent-status render 未返回 ReactElement");
+  }
+  return render(node);
+}
+
+describe("AgentStatusItem 渲染契约", () => {
+  let dispose: (() => void) | undefined;
+
+  beforeAll(async () => {
+    await initI18n();
+    dispose = registerAgentStatusItem();
+  });
+
+  afterAll(() => {
+    dispose?.();
+  });
+
+  beforeEach(() => {
+    // jsdom 无 matchMedia(仿 settings-plugins.test.tsx);matches:true 走
+    // prefers-reduced-motion 静态分支,避免测试期 rAF 动画循环。
+    vi.stubGlobal("matchMedia", () => ({
+      addEventListener: vi.fn(),
+      matches: true,
+      removeEventListener: vi.fn(),
+    }));
+    useForegroundActivityStore.setState({ activities: {}, ts: 0 });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("activity 缺席时渲染 null", () => {
+    const { container } = renderItem();
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("launch 先验(无 status)→ icon-only:品牌图标 + sr-only 名称,无 badge", () => {
+    useForegroundActivityStore.getState().apply(agentBroadcast());
+
+    const { container } = renderItem();
+    const root = container.querySelector('[data-testid="agent-status-item"]');
+
+    expect(root).not.toBeNull();
+    expect(root?.getAttribute("data-agent-status")).toBe("none");
+    expect(root?.querySelector("svg")).not.toBeNull();
+    expect(root?.querySelector("[data-activity-badge]")).toBeNull();
+    expect(root?.querySelector(".sr-only")?.textContent).toBeTruthy();
+  });
+
+  it("hook 证据 ready → data-agent-status=ready 且 badge 出静态状态文案", () => {
+    useForegroundActivityStore
+      .getState()
+      .apply(agentBroadcast({ stateStartedAt: 1, status: "ready" }));
+
+    const { container } = renderItem();
+    const root = container.querySelector('[data-testid="agent-status-item"]');
+
+    expect(root?.getAttribute("data-agent-status")).toBe("ready");
+    const badge = root?.querySelector("[data-activity-badge]");
+    expect(badge).not.toBeNull();
+    // 不锁具体语言:与当前 locale 下 ready 文案一致即可(错映射到别的状态词会红)。
+    expect(badge?.textContent).toBe(i18next.t("terminal.agentStatus.ready"));
+    // ready 是静态文案分支,不走 shimmer。
+    expect(badge?.querySelector("[data-agent-status-text]")).toBeNull();
+    expect(badge?.querySelector("[data-activity-badge-text]")).not.toBeNull();
+  });
+
+  it("processing → shimmer 分支(AgentShimmerText 逐字符渲染)", () => {
+    useForegroundActivityStore
+      .getState()
+      .apply(agentBroadcast({ stateStartedAt: 1, status: "processing" }));
+
+    const { container } = renderItem();
+    const root = container.querySelector('[data-testid="agent-status-item"]');
+
+    expect(root?.getAttribute("data-agent-status")).toBe("processing");
+    const shimmer = root?.querySelector(
+      "[data-activity-badge] [data-agent-status-text]"
+    );
+    expect(shimmer).not.toBeNull();
+    expect(
+      shimmer?.querySelectorAll("[data-shimmer-char]").length
+    ).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## 问题

终端状态栏的 agent 状态不完全正确,典型症状:`omp update` 全程显示「等待输入」。

根因:旧模型把「检测到 agent 二进制在跑」(OSC 133 / launcher 先验)与「hook 证据说会话处于什么状态」压扁成每 panel 单条目、单一必填 `status`,launch 路径只能编造 `"ready"`。同一结构病还导致:`fg` 把挂起 agent 条目打成 shell、`agentLaunched` 继承陈旧 status、相邻命令 <5s 被冷却吞掉。

## 方案:双层活动模型

对齐 loomdesk 的「分层事实」(pty_command ⊥ agent_hook),保留 Pier 更强的「每 panel 恰一条投影」契约:

- **command 层**(OSC/launcher/task)⊥ **hook 层**(JSONL 事件),互不覆写;投影优先级 `task > hook(可见) > launch(可见) > shell`。
- `AgentActivity.status` 改 optional,**唯 hook 证据可写**;无证据 → renderer 只出品牌图标(icon-only)。
- launch 层 250ms 消抖;冷却拆两种(panel 死亡冷却拦一切、命令收尾冷却只拦迟到 hook);`agentLaunched` 清异 agent hook 层。
- jsonl-observer 按字节找最后换行消费:半行不拆坏不丢,截断重建后 offset 归零继续读。

## 集成事件映射修正(上游源码核验)

| 集成 | 修正 | 证据 |
|---|---|---|
| opencode / mimo-code | 补 `session.status`(busy/retry→running, idle→Stop) | sst/opencode SDK `EventSessionStatus` |
| gemini | 补 `Notification→PermissionRequest`(waiting 态此前不可达) | gemini-cli `HookEventName.Notification` / `NotificationType.ToolPermission` |
| qwen-code | 补 `PermissionRequest`/`SubagentStart`/`SubagentStop`;timeout 显式 10_000(毫秒单位,默认写 5 = 5ms 链路必死) | QwenLM/qwen-code hooks types + docs |
| cline | 补 `TaskComplete→Stop`(缺失时正常完成卡 tool 态 30min)、`PreCompact→processing` | loomdesk 基准映射 |

同轮核验反向证实 Pier 现状正确、无需改动:amp(dotted 事件是现行 Plugin API)、antigravity(官方仅 PreInvocation/PostToolUse/Stop 可证)。

## 行为变化

- `omp update` / `omp --version` 等非会话子命令:只有品牌图标,无状态文案;瞬时命令不闪条。
- 交互式 agent:hook(如 omp 扩展 load-time SessionStart)秒出「等待输入」,体验不变。
- `fg` 恢复挂起会话后 agent 状态延续;相邻命令 <5s 正常呈现。

## 验证

- 单测 208/208(聚合器 41 项含 mutation 推演、observer 半行/截断回归、新 renderer 组件测试 4 项、matcher 子命令形状 pin、5 个集成事件表 pin)。
- 真实 App 冒烟(Playwright + built Electron):events.jsonl → observer → 聚合器 → IPC → DOM 全链路,SessionStart→ready、PromptSubmit→processing、SessionEnd→消失全过。
- `pnpm check` 全绿(tsc / ultracite / depcruise 576 模块无违规 / file-size)。

留档的低置信残留(未改):devin/grok 上游 schema 非公开;cursor 三个心跳事件仅影响状态新鲜度。
