### PR TITLE
Preserve terminal titles for active agent tabs

### DIFF
--- a/src/renderer/panel-kits/terminal/terminal-panel.tsx
+++ b/src/renderer/panel-kits/terminal/terminal-panel.tsx
@@ -187,7 +187,8 @@ export function TerminalPanel(props: IDockviewPanelProps) {
   const effectiveCwd = effectiveContext?.cwd ?? null;
   const effectiveTitle = sequenceTitle ?? savedSession?.title ?? null;
   const activity = useForegroundActivityStore((s) => s.activities[panelId]);
-  // agent 会话呈现 overlay 叠在最外层：icon/title 换 agent 的, 会话消失自动回退。
+  // agent 会话呈现 overlay 叠在最外层：icon/status 换 agent, title 保留 agent
+  // TUI 设置的终端标题；会话消失自动回退。
   // Task exit chrome overlay 由 activity 单源提供（foreground-activity 广播），
   // 老 TERMINAL_TAB_CHROME_PATCHED 通路已下线。3 层：base → restore-patch → activity。
   const effectiveTab = mergeTabChrome(
@@ -195,7 +196,7 @@ export function TerminalPanel(props: IDockviewPanelProps) {
       savedSession?.tab ?? activeLaunch.tab,
       restoredTaskTabPatch(savedSession?.task)
     ),
-    activityTabChromeOverlay(activity)
+    activityTabChromeOverlay(activity, effectiveTitle)
   );
   const statusContext = {
     context: effectiveContext,

--- a/src/renderer/panel-kits/terminal/terminal-tab-chrome.ts
+++ b/src/renderer/panel-kits/terminal/terminal-tab-chrome.ts
@@ -100,13 +100,14 @@ export function terminalPanelDescriptor(args: {
  * tab-chrome-patch 持久化管线）——reload 后经 snapshot pull 自动恢复,
  * 活动消失即自动回退。
  *
- * - `agent` kind: 状态点从 agent status 派生, icon/title 换 agent
+ * - `agent` kind: 状态点从 agent status 派生, icon 换 agent, title 优先保留终端标题
  * - `task` kind: running 显示 running 状态点; success/failure/cancelled
  *   映射到相应的 tab status; label 作为 title
  * - `shell` / `idle` / undefined: 无 overlay, 走 tab 默认呈现
  */
 export function activityTabChromeOverlay(
-  activity: ForegroundActivity | undefined
+  activity: ForegroundActivity | undefined,
+  terminalTitle?: string | null
 ): Partial<PanelTabChrome> | null {
   if (!activity) {
     return null;
@@ -119,7 +120,7 @@ export function activityTabChromeOverlay(
     return {
       ...state,
       icon: { id: agentTabIconId(activity.agentId) },
-      title: entry?.label ?? activity.agentId,
+      title: terminalTitle?.trim() || entry?.label || activity.agentId,
     };
   }
   if (activity.kind === "task") {

--- a/tests/unit/cwd-derive.test.ts
+++ b/tests/unit/cwd-derive.test.ts
@@ -1,6 +1,10 @@
+import type { ForegroundActivity } from "@shared/contracts/foreground-activity.ts";
 import { describe, expect, it } from "vitest";
 import { resolveLong } from "@/components/common/document-title.tsx";
-import { basename } from "@/panel-kits/terminal/terminal-tab-chrome.ts";
+import {
+  activityTabChromeOverlay,
+  basename,
+} from "@/panel-kits/terminal/terminal-tab-chrome.ts";
 
 describe("basename", () => {
   it('handles "/" root', () => {
@@ -45,5 +49,36 @@ describe("resolveLong", () => {
         },
       })
     ).toBe("Claude Code");
+  });
+});
+
+describe("activityTabChromeOverlay", () => {
+  const agentActivity = {
+    agentId: "claude",
+    kind: "agent",
+    panelId: "terminal-1",
+    source: "hook",
+    spawnedAt: 1,
+    stateStartedAt: 1,
+    status: "processing",
+    subagentCount: 0,
+    updatedAt: 2,
+    windowId: "1",
+  } satisfies ForegroundActivity;
+
+  it("uses the terminal title for agent tabs when present", () => {
+    expect(
+      activityTabChromeOverlay(agentActivity, "Fix parser crash")
+    ).toMatchObject({
+      icon: { id: "agent:claude" },
+      state: { status: "running" },
+      title: "Fix parser crash",
+    });
+  });
+
+  it("falls back to the agent label when the terminal title is empty", () => {
+    expect(activityTabChromeOverlay(agentActivity, "  ")).toMatchObject({
+      title: "Claude",
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Keep the TUI-provided terminal title visible on active agent tabs instead of replacing it with the agent label
- Pass the effective terminal title into the tab chrome overlay so agent state only overrides the icon and status
- Add unit coverage for title selection and fallback behavior

## Testing
- Added unit tests for `activityTabChromeOverlay` to verify terminal-title precedence and empty-title fallback
- Not run (not requested)