### PR TITLE
feat: guard app quit when work is running

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig } from "@playwright/test";
 
+process.env.PIER_TEST_DISABLE_QUIT_CONFIRMATION = "1";
+
 // Pier main 进程使用 worktree-specific userData (dev-profile.mjs 派的固定路径).
 // 多个 electron.launch 并发会触发 chromium SingletonLock 冲突, 必须串行。
 export default defineConfig({

--- a/src/main/app-quit/quit-confirmation.ts
+++ b/src/main/app-quit/quit-confirmation.ts
@@ -1,0 +1,78 @@
+import {
+  type AppQuitConfirmationRequest,
+  type AppQuitDecisionPayload,
+  appQuitDecisionPayloadSchema,
+  type QuitActivitySummary,
+} from "@shared/contracts/app-quit.ts";
+
+export const APP_QUIT_RENDERER_RESPONSE_TIMEOUT_MS = 30_000;
+export const DEFAULT_APP_QUIT_CONFIRMATION_TIMEOUT_MS =
+  APP_QUIT_RENDERER_RESPONSE_TIMEOUT_MS + 500;
+
+export type RendererQuitConfirmationSendRequest = (
+  request: AppQuitConfirmationRequest
+) => Promise<unknown> | unknown;
+
+export interface AppQuitConfirmationArgs {
+  createQuitId?: () => string;
+  sendRequest: RendererQuitConfirmationSendRequest;
+  summaries: readonly QuitActivitySummary[];
+  timeoutMs?: number;
+}
+
+let nextQuitIdSequence = 0;
+
+function createDefaultQuitId(): string {
+  nextQuitIdSequence += 1;
+  return `quit-${Date.now()}-${nextQuitIdSequence}`;
+}
+
+function parseRendererDecision(
+  quitId: string,
+  payload: unknown
+): AppQuitDecisionPayload | null {
+  const parsed = appQuitDecisionPayloadSchema.safeParse(payload);
+  if (!parsed.success || parsed.data.quitId !== quitId) {
+    return null;
+  }
+
+  return parsed.data;
+}
+
+async function requestRendererDecision(
+  request: AppQuitConfirmationRequest,
+  sendRequest: RendererQuitConfirmationSendRequest,
+  timeoutMs: number
+): Promise<unknown> {
+  const timeout = Promise.withResolvers<null>();
+  let timeoutHandle: NodeJS.Timeout | undefined;
+  timeoutHandle = setTimeout(() => timeout.resolve(null), timeoutMs);
+  try {
+    return await Promise.race([
+      Promise.resolve().then(() => sendRequest(request)),
+      timeout.promise,
+    ]);
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timeoutHandle);
+  }
+}
+
+export async function showAppQuitConfirmation(
+  args: AppQuitConfirmationArgs
+): Promise<boolean> {
+  const quitId = (args.createQuitId ?? createDefaultQuitId)();
+  const request: AppQuitConfirmationRequest = {
+    quitId,
+    summaries: args.summaries,
+  };
+  const payload = await requestRendererDecision(
+    request,
+    args.sendRequest,
+    args.timeoutMs ?? DEFAULT_APP_QUIT_CONFIRMATION_TIMEOUT_MS
+  );
+  const decision = parseRendererDecision(quitId, payload);
+
+  return decision?.decision === "quit";
+}

--- a/src/main/app-quit/quit-controller.ts
+++ b/src/main/app-quit/quit-controller.ts
@@ -1,0 +1,102 @@
+import type { ForegroundActivity } from "@shared/contracts/foreground-activity.ts";
+import type { AppQuitConfirmationMode } from "@shared/contracts/preferences.ts";
+import type { AppWindow } from "../windows/app-window.ts";
+import {
+  type QuitActivitySummary,
+  shouldConfirmBeforeQuit,
+  summarizeDangerousQuitActivities,
+} from "./quit-decision.ts";
+
+export type QuitPhase = "idle" | "confirming" | "quitting";
+
+export interface PreventableQuitEvent {
+  preventDefault(): void;
+}
+
+export interface AppQuitControllerDeps {
+  confirmQuit: (args: {
+    parent: AppWindow | null;
+    summaries: readonly QuitActivitySummary[];
+  }) => Promise<boolean>;
+  finalCleanup: () => void;
+  flushBeforeQuit: () => Promise<void>;
+  getActivities: () => readonly ForegroundActivity[];
+  getDialogParent: () => AppWindow | null;
+  logFailure: (error: unknown) => void;
+  proceedToQuit: () => void;
+  readConfirmationMode: () => Promise<AppQuitConfirmationMode>;
+  shouldBypassQuitConfirmationForTests?: () => boolean;
+}
+
+export interface AppQuitController {
+  getPhase: () => QuitPhase;
+  handleBeforeQuit: (event: PreventableQuitEvent) => void;
+}
+
+function canShowQuitConfirmation(
+  parent: AppWindow | null
+): parent is AppWindow {
+  return parent !== null && !parent.isDestroyed();
+}
+
+export function createAppQuitController(
+  deps: AppQuitControllerDeps
+): AppQuitController {
+  let phase: QuitPhase = "idle";
+
+  async function runQuitFlow(): Promise<void> {
+    try {
+      const mode = await deps.readConfirmationMode();
+      const summaries = summarizeDangerousQuitActivities(deps.getActivities());
+      const shouldConfirm =
+        !deps.shouldBypassQuitConfirmationForTests?.() &&
+        shouldConfirmBeforeQuit(mode, summaries.length);
+      if (shouldConfirm) {
+        const parent = deps.getDialogParent();
+        if (canShowQuitConfirmation(parent)) {
+          const confirmed = await deps.confirmQuit({
+            parent,
+            summaries,
+          });
+          if (!confirmed) {
+            phase = "idle";
+            return;
+          }
+        }
+      }
+
+      phase = "quitting";
+      await deps.flushBeforeQuit();
+      deps.proceedToQuit();
+    } catch (error) {
+      deps.logFailure(error);
+      phase = "idle";
+    }
+  }
+
+  return {
+    getPhase: () => phase,
+    handleBeforeQuit: (event) => {
+      if (phase === "quitting") {
+        deps.finalCleanup();
+        return;
+      }
+
+      event.preventDefault();
+
+      if (phase === "confirming") {
+        const parent = deps.getDialogParent();
+        if (parent && !parent.isDestroyed()) {
+          parent.focus();
+        }
+        return;
+      }
+
+      phase = "confirming";
+      runQuitFlow().catch((error) => {
+        deps.logFailure(error);
+        phase = "idle";
+      });
+    },
+  };
+}

--- a/src/main/app-quit/quit-decision.ts
+++ b/src/main/app-quit/quit-decision.ts
@@ -1,0 +1,88 @@
+import type { QuitActivitySummary } from "@shared/contracts/app-quit.ts";
+import type { ForegroundActivity } from "@shared/contracts/foreground-activity.ts";
+import type { AppQuitConfirmationMode } from "@shared/contracts/preferences.ts";
+
+export type { QuitActivitySummary } from "@shared/contracts/app-quit.ts";
+
+export function isDangerousQuitActivity(activity: ForegroundActivity): boolean {
+  switch (activity.kind) {
+    case "agent":
+    case "shell":
+      return true;
+    case "task":
+      return activity.status === "running";
+    case "idle":
+      return false;
+    default: {
+      const exhaustive: never = activity;
+      return exhaustive;
+    }
+  }
+}
+
+export function summarizeQuitActivity(
+  activity: ForegroundActivity
+): QuitActivitySummary | null {
+  switch (activity.kind) {
+    case "shell": {
+      const commandLine = activity.commandLine?.trim() ?? "";
+      return {
+        kind: "shell",
+        label: commandLine || "Shell command",
+        panelId: activity.panelId,
+        ...(commandLine ? { commandLine } : {}),
+        windowId: activity.windowId,
+      };
+    }
+    case "agent":
+      return {
+        kind: "agent",
+        label: activity.agentId,
+        panelId: activity.panelId,
+        windowId: activity.windowId,
+      };
+    case "task":
+      if (activity.status !== "running") {
+        return null;
+      }
+      return {
+        kind: "task",
+        label: activity.label,
+        panelId: activity.panelId,
+        windowId: activity.windowId,
+      };
+    case "idle":
+      return null;
+    default: {
+      const exhaustive: never = activity;
+      return exhaustive;
+    }
+  }
+}
+
+export function summarizeDangerousQuitActivities(
+  activities: readonly ForegroundActivity[]
+): QuitActivitySummary[] {
+  return activities.flatMap((activity) => {
+    const summary = summarizeQuitActivity(activity);
+    return summary ? [summary] : [];
+  });
+}
+
+export function shouldConfirmBeforeQuit(
+  mode: AppQuitConfirmationMode,
+  dangerousActivityCount: number
+): boolean {
+  switch (mode) {
+    case "always":
+      return true;
+    case "hasActivity":
+      return dangerousActivityCount > 0;
+    case "never":
+      return false;
+    default: {
+      const exhaustive: never = mode;
+      return exhaustive;
+    }
+  }
+}

--- a/src/main/app-quit/quit-renderer-transport.ts
+++ b/src/main/app-quit/quit-renderer-transport.ts
@@ -1,0 +1,102 @@
+import type {
+  AppQuitConfirmationRequest,
+  AppQuitDecisionPayload,
+} from "@shared/contracts/app-quit.ts";
+import { appQuitDecisionPayloadSchema } from "@shared/contracts/app-quit.ts";
+import { PIER_BROADCAST } from "@shared/ipc-channels.ts";
+import type { AppWindow } from "../windows/app-window.ts";
+import { APP_QUIT_RENDERER_RESPONSE_TIMEOUT_MS } from "./quit-confirmation.ts";
+
+interface PendingQuitDecision {
+  resolve: (payload: AppQuitDecisionPayload) => void;
+  timeout: NodeJS.Timeout;
+}
+
+export interface AppQuitRendererTransportDeps {
+  getFallbackWindow: () => AppWindow | null;
+  prepareWindow?: (window: AppWindow) => void;
+  timeoutMs?: number;
+}
+
+export interface AppQuitRendererTransport {
+  handleDecision(payload: unknown): boolean;
+  sendRequest(
+    parent: AppWindow | null,
+    request: AppQuitConfirmationRequest
+  ): Promise<AppQuitDecisionPayload>;
+}
+
+function cancelDecision(quitId: string): AppQuitDecisionPayload {
+  return { decision: "cancel", quitId };
+}
+
+function isUsableWindow(window: AppWindow | null): window is AppWindow {
+  return (
+    window !== null &&
+    !window.isDestroyed() &&
+    !window.webContents.isDestroyed()
+  );
+}
+
+export function createAppQuitRendererTransport(
+  deps: AppQuitRendererTransportDeps
+): AppQuitRendererTransport {
+  const pending = new Map<string, PendingQuitDecision>();
+  const timeoutMs = deps.timeoutMs ?? APP_QUIT_RENDERER_RESPONSE_TIMEOUT_MS;
+
+  function resolvePending(payload: AppQuitDecisionPayload): boolean {
+    const entry = pending.get(payload.quitId);
+    if (!entry) {
+      return false;
+    }
+
+    pending.delete(payload.quitId);
+    clearTimeout(entry.timeout);
+    entry.resolve(payload);
+    return true;
+  }
+
+  function sendRequest(
+    parent: AppWindow | null,
+    request: AppQuitConfirmationRequest
+  ): Promise<AppQuitDecisionPayload> {
+    const target = isUsableWindow(parent) ? parent : deps.getFallbackWindow();
+    if (!isUsableWindow(target)) {
+      return Promise.resolve(cancelDecision(request.quitId));
+    }
+
+    const previous = pending.get(request.quitId);
+    if (previous) {
+      resolvePending(cancelDecision(request.quitId));
+    }
+
+    const deferred = Promise.withResolvers<AppQuitDecisionPayload>();
+    const timeout = setTimeout(() => {
+      resolvePending(cancelDecision(request.quitId));
+    }, timeoutMs);
+    pending.set(request.quitId, {
+      resolve: deferred.resolve,
+      timeout,
+    });
+
+    try {
+      deps.prepareWindow?.(target);
+      target.webContents.send(PIER_BROADCAST.APP_QUIT_REQUESTED, request);
+    } catch {
+      resolvePending(cancelDecision(request.quitId));
+    }
+
+    return deferred.promise;
+  }
+
+  function handleDecision(payload: unknown): boolean {
+    const parsed = appQuitDecisionPayloadSchema.safeParse(payload);
+    if (!parsed.success) {
+      return false;
+    }
+
+    return resolvePending(parsed.data);
+  }
+
+  return { handleDecision, sendRequest };
+}

--- a/src/main/app-quit/quit-test-runtime.ts
+++ b/src/main/app-quit/quit-test-runtime.ts
@@ -1,0 +1,12 @@
+const TEST_DISABLE_QUIT_CONFIRMATION = "1";
+
+export function shouldBypassQuitConfirmationForTests(
+  env: Readonly<Record<string, string | undefined>> = process.env
+): boolean {
+  return (
+    env.PIER_TEST_DISABLE_QUIT_CONFIRMATION ===
+      TEST_DISABLE_QUIT_CONFIRMATION ||
+    env.PLAYWRIGHT_TEST === TEST_DISABLE_QUIT_CONFIRMATION ||
+    env.VITEST === "true"
+  );
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,5 +1,5 @@
 import { join } from "node:path";
-import { PIER_BROADCAST } from "@shared/ipc-channels.ts";
+import { PIER, PIER_BROADCAST } from "@shared/ipc-channels.ts";
 import { app, ipcMain, nativeImage } from "electron";
 import {
   type RegisteredLocalControl,
@@ -7,6 +7,10 @@ import {
 } from "./adapters/cli/register-local-control.ts";
 import { appCore } from "./app-core/app-core.ts";
 import { installAppMenu } from "./app-menu.ts";
+import { showAppQuitConfirmation } from "./app-quit/quit-confirmation.ts";
+import { createAppQuitController } from "./app-quit/quit-controller.ts";
+import { createAppQuitRendererTransport } from "./app-quit/quit-renderer-transport.ts";
+import { shouldBypassQuitConfirmationForTests } from "./app-quit/quit-test-runtime.ts";
 import { installCsp } from "./csp.ts";
 import {
   handleAssetProtocol,
@@ -17,6 +21,7 @@ import { registerAgentsIpc } from "./ipc/agents.ts";
 import { registerCommandIpc } from "./ipc/command.ts";
 import {
   closeForegroundActivityResources,
+  foregroundActivityService,
   registerForegroundActivityIpc,
 } from "./ipc/foreground-activity.ts";
 import { registerGitWatchIpc } from "./ipc/git-watch.ts";
@@ -42,7 +47,6 @@ const isDev = isDevRuntime();
 const isMac = process.platform === "darwin";
 const DEV_USER_DATA_ROOT = "Pier-dev";
 let localControl: RegisteredLocalControl | null = null;
-let didFlushBeforeQuit = false;
 const windowZoom = createWindowZoomController({
   listWindows: () => windowManager.getAll(),
   readPreferences: () => appCore.services.preferences.read(),
@@ -117,6 +121,10 @@ function getMenuTargetWindow(): AppWindow | null {
   );
 }
 
+function getQuitDialogParentWindow(): AppWindow | null {
+  return getMenuTargetWindow();
+}
+
 function createFreshWindowFromMenu(): void {
   appCore.services.window.create({ mode: "fresh" }).catch((error) => {
     console.error(
@@ -170,6 +178,80 @@ function toggleCommandPaletteFromMenu(target: AppWindow | null): void {
   target.webContents.focus();
   target.webContents.send(PIER_BROADCAST.COMMAND_PALETTE_TOGGLE_REQUEST);
 }
+
+function prepareQuitDialogWindow(target: AppWindow): void {
+  if (target.isMinimized()) {
+    target.restore();
+  }
+  if (isMac) {
+    app.focus({ steal: true });
+  }
+  target.focus();
+  target.webContents.focus();
+}
+
+async function flushBeforeQuitConfirmed(): Promise<void> {
+  try {
+    closeForegroundActivityResources();
+  } catch (error) {
+    console.error(
+      "[foreground-activity] failed to close resources before quit:",
+      error instanceof Error ? error.message : String(error)
+    );
+  }
+
+  await Promise.all([
+    appCore.services.window.flushOpenWindows().catch((error) => {
+      console.error(
+        "[window] failed to flush windows before quit:",
+        error instanceof Error ? error.message : String(error)
+      );
+    }),
+    appCore.services.secrets.flush().catch((error) => {
+      console.error(
+        "[secrets] failed to flush before quit:",
+        error instanceof Error ? error.message : String(error)
+      );
+    }),
+  ]);
+}
+
+const appQuitRendererTransport = createAppQuitRendererTransport({
+  getFallbackWindow: getQuitDialogParentWindow,
+  prepareWindow: prepareQuitDialogWindow,
+});
+
+const appQuitController = createAppQuitController({
+  confirmQuit: ({ parent, summaries }) =>
+    showAppQuitConfirmation({
+      sendRequest: (request) =>
+        appQuitRendererTransport.sendRequest(parent, request),
+      summaries,
+    }),
+  finalCleanup: () => {
+    windowManager.destroyAllForQuit();
+    appCore.pluginHost.dispose();
+    localControl?.close().catch(() => {
+      // ignore: app 正在退出
+    });
+    localControl = null;
+  },
+  flushBeforeQuit: flushBeforeQuitConfirmed,
+  getActivities: () => foregroundActivityService.snapshot().activities,
+  getDialogParent: getQuitDialogParentWindow,
+  logFailure: (error) => {
+    console.error(
+      "[app-quit] failed before quit:",
+      error instanceof Error ? error.message : String(error)
+    );
+  },
+  proceedToQuit: () => app.quit(),
+  readConfirmationMode: async () => {
+    const preferences = await appCore.services.preferences.read();
+    return preferences.confirmOnQuit;
+  },
+  shouldBypassQuitConfirmationForTests,
+});
 
 registerAssetScheme();
 
@@ -265,6 +347,9 @@ app.whenReady().then(async () => {
   registerMenuIpc(ipcMain);
   registerAgentsIpc(ipcMain);
   registerForegroundActivityIpc(ipcMain);
+  ipcMain.handle(PIER.APP_QUIT_DECISION, (_event, payload: unknown) => {
+    appQuitRendererTransport.handleDecision(payload);
+  });
   registerSecretsIpc(ipcMain, appCore.services.secrets);
   registerRendererCommandIpc(ipcMain);
   // 注册打包字体给 CoreText, 必须早于任何 terminal 创建, 否则 ghostty 找不到非系统字体.
@@ -333,40 +418,8 @@ app.on("window-all-closed", () => {
 });
 
 app.on("before-quit", (event) => {
-  if (!didFlushBeforeQuit) {
-    event.preventDefault();
-    didFlushBeforeQuit = true;
-    // JSONL observer dispose 是同步操作, 抽出 Promise.all 避免无谓的 Promise 包装。
-    try {
-      closeForegroundActivityResources();
-    } catch (error) {
-      console.error(
-        "[foreground-activity] failed to close resources before quit:",
-        error instanceof Error ? error.message : String(error)
-      );
-    }
-    Promise.all([
-      appCore.services.window.flushOpenWindows().catch((error) => {
-        console.error(
-          "[window] failed to flush windows before quit:",
-          error instanceof Error ? error.message : String(error)
-        );
-      }),
-      appCore.services.secrets.flush().catch((error) => {
-        console.error(
-          "[secrets] failed to flush before quit:",
-          error instanceof Error ? error.message : String(error)
-        );
-      }),
-    ]).finally(() => {
-      app.quit();
-    });
+  if (!gotTheLock) {
     return;
   }
-  windowManager.destroyAllForQuit();
-  appCore.pluginHost.dispose();
-  localControl?.close().catch(() => {
-    // ignore: app 正在退出
-  });
-  localControl = null;
+  appQuitController.handleBeforeQuit(event);
 });

--- a/src/main/state/preferences.ts
+++ b/src/main/state/preferences.ts
@@ -1,5 +1,6 @@
 import { join } from "node:path";
 import {
+  DEFAULT_APP_QUIT_CONFIRMATION_MODE,
   DEFAULT_GIT_AUTO_FETCH_ENABLED,
   DEFAULT_GIT_AUTO_FETCH_INTERVAL_MINUTES,
   DEFAULT_TERMINAL_CURSOR_BLINK,
@@ -35,6 +36,7 @@ const DEFAULTS: ProjectPreferences = {
   terminalScrollbackMb: DEFAULT_TERMINAL_SCROLLBACK_MB,
   terminalPasteProtection: DEFAULT_TERMINAL_PASTE_PROTECTION,
   terminalNewCwdPolicy: DEFAULT_TERMINAL_NEW_CWD_POLICY,
+  confirmOnQuit: DEFAULT_APP_QUIT_CONFIRMATION_MODE,
   windowZoomLevel: DEFAULT_WINDOW_ZOOM_LEVEL,
   userKeymap: [],
   defaultAgentId: null,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,4 +1,8 @@
 import type { AgentKind, DetectAgentsResult } from "@shared/contracts/agent.ts";
+import type {
+  AppQuitConfirmationRequest,
+  AppQuitDecisionPayload,
+} from "@shared/contracts/app-quit.ts";
 import type { MruState } from "@shared/contracts/command-palette-mru.ts";
 import type {
   MenuPopupOptions,
@@ -115,6 +119,13 @@ export interface PierCommandPaletteAPI {
   onToggleRequest: (cb: () => void) => () => void;
 }
 
+export interface PierAppQuitAPI {
+  decide: (decision: AppQuitDecisionPayload) => Promise<void>;
+  onRequested: (
+    cb: (request: AppQuitConfirmationRequest) => void
+  ) => () => void;
+}
+
 export interface PierPluginsAPI {
   disable: (id: string) => Promise<PluginRegistryEntry>;
   enable: (id: string) => Promise<PluginRegistryEntry>;
@@ -200,6 +211,7 @@ export interface PierEnvAPI {
 export interface PierWindowAPI {
   agents: PierAgentsAPI;
   ai: PierAiAPI;
+  appQuit: PierAppQuitAPI;
   closeWindow: (windowId: string) => Promise<void>;
   commandPalette: PierCommandPaletteAPI;
   commandPaletteMru: PierCommandPaletteMruAPI;
@@ -233,6 +245,12 @@ const agentsApi: PierAgentsAPI = {
   prepareLaunch: (agentId: AgentKind) =>
     ipcRenderer.invoke("pier:agents:prepareLaunch", agentId),
   refresh: () => ipcRenderer.invoke("pier:agents:refresh"),
+};
+
+const appQuitApi: PierAppQuitAPI = {
+  decide: (decision) =>
+    ipcRenderer.invoke(PIER.APP_QUIT_DECISION, decision).then(() => undefined),
+  onRequested: (cb) => subscribeIpc(PIER_BROADCAST.APP_QUIT_REQUESTED, cb),
 };
 
 const preferencesApi: PierPreferencesAPI = {
@@ -375,6 +393,7 @@ const tasksApi: PierTasksAPI = {
 
 const api: PierWindowAPI = {
   agents: agentsApi,
+  appQuit: appQuitApi,
   foregroundActivity: foregroundActivityApi,
   ai: aiApi,
   closeWindow: (windowId) =>

--- a/src/renderer/components/common/app-quit-dialog-bridge.tsx
+++ b/src/renderer/components/common/app-quit-dialog-bridge.tsx
@@ -1,0 +1,119 @@
+import type {
+  AppQuitConfirmationRequest,
+  AppQuitDecisionPayload,
+  QuitActivitySummary,
+} from "@shared/contracts/app-quit.ts";
+import type { TFunction } from "i18next";
+import { useEffect, useRef } from "react";
+import { useT } from "@/i18n/use-t.ts";
+import { showAppConfirm } from "@/stores/app-dialog.store.ts";
+
+const MAX_VISIBLE_ACTIVITIES = 8;
+const MAX_DETAIL_LINE_LENGTH = 180;
+
+function truncateDetailLine(line: string): string {
+  if (line.length <= MAX_DETAIL_LINE_LENGTH) {
+    return line;
+  }
+
+  return `${line.slice(0, MAX_DETAIL_LINE_LENGTH - 1)}…`;
+}
+
+function formatSummary(summary: QuitActivitySummary): string {
+  const command = summary.commandLine ? ` — ${summary.commandLine}` : "";
+  return `• ${summary.kind}: ${summary.label}${command}`;
+}
+
+function formatQuitDialogBody(
+  t: TFunction,
+  summaries: readonly QuitActivitySummary[]
+): string {
+  if (summaries.length === 0) {
+    return t("dialog.appQuit.noActivityDetail");
+  }
+
+  const visibleSummaries = summaries.slice(0, MAX_VISIBLE_ACTIVITIES);
+  const lines = [
+    t("dialog.appQuit.activityMessage", { count: summaries.length }),
+    ...visibleSummaries.map((summary) =>
+      truncateDetailLine(formatSummary(summary))
+    ),
+  ];
+
+  if (summaries.length > MAX_VISIBLE_ACTIVITIES) {
+    lines.push(
+      t("dialog.appQuit.overflow", {
+        count: summaries.length - MAX_VISIBLE_ACTIVITIES,
+      })
+    );
+  }
+
+  lines.push(t("dialog.appQuit.activityDetailSuffix"));
+
+  return lines.join("\n");
+}
+
+function toDecisionPayload(
+  quitId: string,
+  decision: AppQuitDecisionPayload["decision"]
+): AppQuitDecisionPayload {
+  return { decision, quitId };
+}
+
+export function AppQuitDialogBridge() {
+  const t = useT();
+  const currentQuitIdRef = useRef<string | null>(null);
+  const tRef = useRef(t);
+  tRef.current = t;
+
+  useEffect(() => {
+    function sendDecision(
+      quitId: string,
+      decision: AppQuitDecisionPayload["decision"]
+    ): void {
+      window.pier.appQuit
+        .decide(toDecisionPayload(quitId, decision))
+        .catch((error: unknown) => {
+          console.error(
+            "[app-quit] failed to send renderer decision:",
+            error instanceof Error ? error.message : String(error)
+          );
+        });
+    }
+
+    async function showRequest(
+      request: AppQuitConfirmationRequest
+    ): Promise<void> {
+      const previousQuitId = currentQuitIdRef.current;
+      if (previousQuitId && previousQuitId !== request.quitId) {
+        sendDecision(previousQuitId, "cancel");
+      }
+      currentQuitIdRef.current = request.quitId;
+
+      const confirmed = await showAppConfirm({
+        body: formatQuitDialogBody(tRef.current, request.summaries),
+        cancelLabel: tRef.current("dialog.appQuit.cancel"),
+        confirmLabel: tRef.current("dialog.appQuit.quit"),
+        title: tRef.current("dialog.appQuit.title"),
+      });
+
+      if (currentQuitIdRef.current !== request.quitId) {
+        return;
+      }
+
+      currentQuitIdRef.current = null;
+      sendDecision(request.quitId, confirmed ? "quit" : "cancel");
+    }
+
+    return window.pier.appQuit.onRequested((request) => {
+      showRequest(request).catch((error: unknown) => {
+        console.error(
+          "[app-quit] failed to show renderer confirmation:",
+          error instanceof Error ? error.message : String(error)
+        );
+      });
+    });
+  }, []);
+
+  return null;
+}

--- a/src/renderer/components/common/app-shell.tsx
+++ b/src/renderer/components/common/app-shell.tsx
@@ -1,4 +1,5 @@
 import { AppDialogHost } from "@/components/common/app-dialog-host.tsx";
+import { AppQuitDialogBridge } from "@/components/common/app-quit-dialog-bridge.tsx";
 import { CommandPalette } from "@/components/common/command-palette.tsx";
 import { DocumentTitle } from "@/components/common/document-title.tsx";
 import { ForegroundActivityBridge } from "@/components/common/foreground-activity-bridge.tsx";
@@ -23,6 +24,7 @@ export function AppShell() {
       <ShellKeybindings />
       <CommandPalette />
       <SettingsDialog />
+      <AppQuitDialogBridge />
       <AppDialogHost />
       <PluginOverlayHost />
       <TerminalDebugSnapshotBridge />

--- a/src/renderer/i18n/locales/en/dialog.ts
+++ b/src/renderer/i18n/locales/en/dialog.ts
@@ -1,4 +1,15 @@
 export const dialog = {
+  appQuit: {
+    activityDetailSuffix: "Quitting will terminate these processes.",
+    activityMessage_one: "{{count}} activity is still running.",
+    activityMessage_other: "{{count}} activities are still running.",
+    cancel: "Cancel",
+    noActivityDetail:
+      "Pier will save the current window layout before quitting.",
+    overflow: "And {{count}} more…",
+    quit: "Quit",
+    title: "Quit Pier?",
+  },
   cancel: "Cancel",
   ok: "OK",
 } as const;

--- a/src/renderer/i18n/locales/en/settings.ts
+++ b/src/renderer/i18n/locales/en/settings.ts
@@ -66,6 +66,9 @@ export const settings = {
     terminalNewCwdPolicy: "New Terminal Directory",
     terminalNewCwdPolicyDesc:
       "Choose which directory new or split terminals use",
+    quitConfirmation: "Quit Confirmation",
+    quitConfirmationDesc:
+      "Choose when Pier confirms before quitting with Cmd+Q.",
     worktreeRootPath: "Worktree Directory",
     worktreeRootPathDesc:
       "Leave empty to use a {project}.worktree directory next to the main project.",
@@ -85,6 +88,11 @@ export const settings = {
       activeTerminal: "Inherit active terminal",
       shellDefault: "Use shell default",
     },
+  },
+  quitConfirmation: {
+    hasActivity: "When activity is running",
+    always: "Always",
+    never: "Never",
   },
   keybindings: {
     change: "Change Shortcut",

--- a/src/renderer/i18n/locales/zh-CN/dialog.ts
+++ b/src/renderer/i18n/locales/zh-CN/dialog.ts
@@ -1,4 +1,13 @@
 export const dialog = {
+  appQuit: {
+    activityDetailSuffix: "退出会终止这些进程。",
+    activityMessage: "仍有 {{count}} 个活动正在运行。",
+    cancel: "取消",
+    noActivityDetail: "退出前会保存当前窗口布局。",
+    overflow: "以及另外 {{count}} 个活动……",
+    quit: "退出",
+    title: "退出 Pier？",
+  },
   cancel: "取消",
   ok: "确定",
 } as const;

--- a/src/renderer/i18n/locales/zh-CN/settings.ts
+++ b/src/renderer/i18n/locales/zh-CN/settings.ts
@@ -62,6 +62,8 @@ export const settings = {
     terminalPasteProtectionDesc: "粘贴可能直接执行的内容前先确认",
     terminalNewCwdPolicy: "新终端目录",
     terminalNewCwdPolicyDesc: "控制新建或拆分终端时使用哪个工作目录",
+    quitConfirmation: "退出确认",
+    quitConfirmationDesc: "选择按 Cmd+Q 退出 Pier 前何时确认。",
     worktreeRootPath: "工作树目录",
     worktreeRootPathDesc: "留空时使用与主项目同级的 {项目名}.worktree 目录。",
     worktreeRootPathPlaceholder: "~/Projects/pier.worktree",
@@ -80,6 +82,11 @@ export const settings = {
       activeTerminal: "继承当前终端",
       shellDefault: "使用 shell 默认目录",
     },
+  },
+  quitConfirmation: {
+    hasActivity: "有运行中活动时确认",
+    always: "总是确认",
+    never: "从不确认",
   },
   keybindings: {
     change: "更改快捷键",

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -24,6 +24,7 @@ import { bootstrapBuiltinPlugins } from "./lib/plugins/bootstrap.ts";
 import { registerTerminalActions } from "./panel-kits/terminal/register-actions.ts";
 import { initAgentDetection } from "./stores/agent-detect.store.ts";
 import { initAgentPreferences } from "./stores/agent-preferences.store.ts";
+import { initAppQuitPreferences } from "./stores/app-quit-preferences.store.ts";
 import { initCommandPaletteMru } from "./stores/command-palette-mru.store.ts";
 import { initFont } from "./stores/font.store.ts";
 import { initKeybindingPreferences } from "./stores/keybinding-preferences.store.ts";
@@ -62,6 +63,7 @@ async function bootstrap() {
       initFont(),
       initZoom(),
       initTerminalPreferences(),
+      initAppQuitPreferences(),
       initAgentPreferences(),
       initTerminalStatusBarPrefs(),
       initWorktreePreferences(),

--- a/src/renderer/pages/settings/components/terminal-section.tsx
+++ b/src/renderer/pages/settings/components/terminal-section.tsx
@@ -1,6 +1,7 @@
 import { Card, CardContent } from "@pier/ui/card.tsx";
 import { FieldDescription, FieldSeparator, FieldSet } from "@pier/ui/field.tsx";
 import type {
+  AppQuitConfirmationMode,
   TerminalCursorStyle,
   TerminalNewCwdPolicy,
 } from "@shared/contracts/preferences.ts";
@@ -10,6 +11,7 @@ import { InputRow } from "@/pages/settings/components/rows/input-row.tsx";
 import { SelectRow } from "@/pages/settings/components/rows/select-row.tsx";
 import { SwitchRow } from "@/pages/settings/components/rows/switch-row.tsx";
 import { TerminalStatusBarBlock } from "@/pages/settings/components/terminal-status-bar-block.tsx";
+import { useAppQuitPreferencesStore } from "@/stores/app-quit-preferences.store.ts";
 import { useTerminalPreferencesStore } from "@/stores/terminal-preferences.store.ts";
 
 const SCROLLBACK_MIN = 10;
@@ -23,6 +25,11 @@ const NEW_CWD_POLICY_OPTIONS = [
   "activeTerminal",
   "shellDefault",
 ] satisfies TerminalNewCwdPolicy[];
+const QUIT_CONFIRMATION_OPTIONS = [
+  "hasActivity",
+  "always",
+  "never",
+] satisfies AppQuitConfirmationMode[];
 
 function clampScrollback(raw: string, fallback: number): number {
   const n = Number.parseInt(raw, 10);
@@ -83,6 +90,7 @@ export function TerminalSection() {
   const terminalNewCwdPolicy = useTerminalPreferencesStore(
     (s) => s.terminalNewCwdPolicy
   );
+  const confirmOnQuit = useAppQuitPreferencesStore((s) => s.confirmOnQuit);
   const setTerminalCursorStyle = useTerminalPreferencesStore(
     (s) => s.setTerminalCursorStyle
   );
@@ -94,6 +102,9 @@ export function TerminalSection() {
   );
   const setTerminalNewCwdPolicy = useTerminalPreferencesStore(
     (s) => s.setTerminalNewCwdPolicy
+  );
+  const setConfirmOnQuit = useAppQuitPreferencesStore(
+    (s) => s.setConfirmOnQuit
   );
 
   return (
@@ -155,6 +166,21 @@ export function TerminalSection() {
                 }))}
                 triggerWidth="w-[180px]"
                 value={terminalNewCwdPolicy}
+              />
+              <FieldSeparator />
+              <SelectRow<AppQuitConfirmationMode>
+                description={t("settings.row.quitConfirmationDesc")}
+                id="settings-quit-confirmation"
+                label={t("settings.row.quitConfirmation")}
+                onChange={(next) => {
+                  setConfirmOnQuit(next).catch(() => undefined);
+                }}
+                options={QUIT_CONFIRMATION_OPTIONS.map((value) => ({
+                  value,
+                  label: t(`settings.quitConfirmation.${value}`),
+                }))}
+                triggerWidth="w-[180px]"
+                value={confirmOnQuit}
               />
             </FieldSet>
           </CardContent>

--- a/src/renderer/stores/app-quit-preferences.store.ts
+++ b/src/renderer/stores/app-quit-preferences.store.ts
@@ -1,0 +1,79 @@
+import type { AppQuitConfirmationMode } from "@shared/contracts/preferences.ts";
+import { create } from "zustand";
+
+interface AppQuitPreferenceSnapshot {
+  confirmOnQuit: AppQuitConfirmationMode;
+}
+
+interface AppQuitPreferencesState extends AppQuitPreferenceSnapshot {
+  _hydrate: (snapshot: AppQuitPreferenceSnapshot) => void;
+  setConfirmOnQuit: (next: AppQuitConfirmationMode) => Promise<void>;
+}
+
+export const useAppQuitPreferencesStore = create<AppQuitPreferencesState>(
+  (set) => ({
+    confirmOnQuit: "hasActivity",
+
+    _hydrate(snapshot) {
+      set({
+        confirmOnQuit: snapshot.confirmOnQuit,
+      });
+    },
+
+    async setConfirmOnQuit(next) {
+      try {
+        const merged = await window.pier.preferences.update({
+          confirmOnQuit: next,
+        });
+        useAppQuitPreferencesStore.getState()._hydrate({
+          confirmOnQuit: merged.confirmOnQuit as AppQuitConfirmationMode,
+        });
+      } catch (err) {
+        console.error(
+          "[app-quit-preferences.store] setConfirmOnQuit failed:",
+          err
+        );
+      }
+    },
+  })
+);
+
+let preferencesListenerAttached = false;
+let detachPreferencesListener: (() => void) | null = null;
+
+function attachPreferencesListener(): void {
+  if (preferencesListenerAttached || typeof window === "undefined") {
+    return;
+  }
+  const detach = window.pier?.preferences?.onChanged?.((next) => {
+    useAppQuitPreferencesStore.getState()._hydrate({
+      confirmOnQuit: next.confirmOnQuit as AppQuitConfirmationMode,
+    });
+  });
+  if (!detach) {
+    return;
+  }
+  detachPreferencesListener = detach;
+  preferencesListenerAttached = true;
+}
+
+export function detachAppQuitPreferencesListener(): void {
+  detachPreferencesListener?.();
+  detachPreferencesListener = null;
+  preferencesListenerAttached = false;
+}
+
+export async function initAppQuitPreferences(): Promise<void> {
+  attachPreferencesListener();
+  try {
+    const snapshot = await window.pier.preferences.read();
+    useAppQuitPreferencesStore.getState()._hydrate({
+      confirmOnQuit: snapshot.confirmOnQuit as AppQuitConfirmationMode,
+    });
+  } catch (err) {
+    console.error(
+      "[app-quit-preferences.store] init IPC failed; keeping defaults:",
+      err
+    );
+  }
+}

--- a/src/shared/contracts/app-quit.ts
+++ b/src/shared/contracts/app-quit.ts
@@ -1,0 +1,36 @@
+import { z } from "zod";
+
+export const quitActivitySummarySchema = z
+  .object({
+    commandLine: z.string().min(1).max(4096).optional(),
+    kind: z.enum(["agent", "shell", "task"]),
+    label: z.string().min(1),
+    panelId: z.string().min(1),
+    windowId: z.string().min(1),
+  })
+  .strict();
+
+export type QuitActivitySummary = z.infer<typeof quitActivitySummarySchema>;
+
+export const appQuitConfirmationRequestSchema = z
+  .object({
+    quitId: z.string().min(1),
+    summaries: z.array(quitActivitySummarySchema),
+  })
+  .strict();
+
+export interface AppQuitConfirmationRequest {
+  readonly quitId: string;
+  readonly summaries: readonly QuitActivitySummary[];
+}
+
+export const appQuitDecisionPayloadSchema = z
+  .object({
+    decision: z.enum(["quit", "cancel"]),
+    quitId: z.string().min(1),
+  })
+  .strict();
+
+export type AppQuitDecisionPayload = z.infer<
+  typeof appQuitDecisionPayloadSchema
+>;

--- a/src/shared/contracts/preferences.ts
+++ b/src/shared/contracts/preferences.ts
@@ -11,6 +11,11 @@ export const terminalNewCwdPolicySchema = z.enum([
   "activeTerminal",
   "shellDefault",
 ]);
+export const appQuitConfirmationModeSchema = z.enum([
+  "always",
+  "hasActivity",
+  "never",
+]);
 export const keybindingScopeSchema = z.union([
   z.literal("global"),
   z.string().regex(/^(panel|overlay):[A-Za-z0-9._:-]+$/),
@@ -57,6 +62,7 @@ export const DEFAULT_TERMINAL_CURSOR_BLINK = true;
 export const DEFAULT_TERMINAL_SCROLLBACK_MB = 64;
 export const DEFAULT_TERMINAL_PASTE_PROTECTION = true;
 export const DEFAULT_TERMINAL_NEW_CWD_POLICY = "activeTerminal";
+export const DEFAULT_APP_QUIT_CONFIRMATION_MODE = "hasActivity";
 export const DEFAULT_WINDOW_ZOOM_LEVEL = 0;
 export const MIN_WINDOW_ZOOM_LEVEL = -3;
 export const MAX_WINDOW_ZOOM_LEVEL = 5;
@@ -85,6 +91,9 @@ export const projectPreferencesSchema = z.object({
     .default(DEFAULT_TERMINAL_PASTE_PROTECTION),
   terminalNewCwdPolicy: terminalNewCwdPolicySchema.default(
     DEFAULT_TERMINAL_NEW_CWD_POLICY
+  ),
+  confirmOnQuit: appQuitConfirmationModeSchema.default(
+    DEFAULT_APP_QUIT_CONFIRMATION_MODE
   ),
   windowZoomLevel: z
     .number()
@@ -127,6 +136,9 @@ export type ResolvedTheme = z.infer<typeof resolvedThemeSchema>;
 export type StylePresetId = z.infer<typeof stylePresetIdSchema>;
 export type TerminalCursorStyle = z.infer<typeof terminalCursorStyleSchema>;
 export type TerminalNewCwdPolicy = z.infer<typeof terminalNewCwdPolicySchema>;
+export type AppQuitConfirmationMode = z.infer<
+  typeof appQuitConfirmationModeSchema
+>;
 export type KeybindingScopePreference = z.infer<typeof keybindingScopeSchema>;
 export type UserKeymapEntry = z.infer<typeof userKeymapEntrySchema>;
 export type ProjectPreferences = z.infer<typeof projectPreferencesSchema>;

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -6,6 +6,7 @@
 export const PIER = {
   // command router facade
   COMMAND_EXECUTE: "pier://command:execute",
+  APP_QUIT_DECISION: "pier://app-quit:decision",
   // git watch (订阅/退订;事件本身经 PIER_BROADCAST.GIT_CHANGED 广播)
   GIT_WATCH_START: "pier://git:watch-start",
   GIT_WATCH_STOP: "pier://git:watch-stop",
@@ -46,6 +47,8 @@ export const PIER_BROADCAST = {
   TERMINAL_STATUS_BAR_PREFS_CHANGED: "pier://terminal-status-bar:prefs-changed",
   // 插件设置变更广播 (main → renderer, payload PluginSettingsChangedPayload).
   PLUGIN_SETTINGS_CHANGED: "pier://plugin-settings:changed",
+  // 应用退出确认请求 (main → renderer, payload AppQuitConfirmationRequest).
+  APP_QUIT_REQUESTED: "pier://app-quit:requested",
   // 前台面板活动统一广播 (main → 所有 renderer, payload ForegroundActivityBroadcast).
   // Unified aggregator: agent/task/shell/idle 四态归一, per-panel 唯一 activity。
   FOREGROUND_ACTIVITY_CHANGED: "pier://foreground-activity:changed",

--- a/tests/unit/main/app-quit-confirmation.test.ts
+++ b/tests/unit/main/app-quit-confirmation.test.ts
@@ -1,0 +1,212 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { showAppQuitConfirmation } from "../../../src/main/app-quit/quit-confirmation.ts";
+import type { QuitActivitySummary } from "../../../src/main/app-quit/quit-decision.ts";
+
+interface RendererQuitConfirmationRequest {
+  readonly quitId: string;
+  readonly summaries: readonly QuitActivitySummary[];
+}
+
+type RendererQuitConfirmationSendRequest = (
+  request: RendererQuitConfirmationRequest
+) => Promise<unknown> | unknown;
+
+interface RendererMediatedQuitConfirmationArgs {
+  readonly createQuitId: () => string;
+  readonly sendRequest: RendererQuitConfirmationSendRequest;
+  readonly summaries: readonly QuitActivitySummary[];
+  readonly timeoutMs?: number;
+}
+
+const showRendererQuitConfirmation = showAppQuitConfirmation as unknown as (
+  args: RendererMediatedQuitConfirmationArgs
+) => Promise<boolean>;
+
+function shellSummary(index = 1): QuitActivitySummary {
+  return {
+    kind: "shell",
+    label: `shell ${index}`,
+    panelId: `panel-${index}`,
+    commandLine: `cmd ${index}`,
+    windowId: "window-1",
+  };
+}
+
+function showConfirmation({
+  createQuitId = () => "quit-1",
+  sendRequest,
+  summaries = [shellSummary()],
+  timeoutMs,
+}: {
+  createQuitId?: () => string;
+  sendRequest: RendererQuitConfirmationSendRequest;
+  summaries?: readonly QuitActivitySummary[];
+  timeoutMs?: number;
+}): Promise<boolean> {
+  return showRendererQuitConfirmation({
+    createQuitId,
+    sendRequest,
+    summaries,
+    ...(timeoutMs === undefined ? {} : { timeoutMs }),
+  });
+}
+
+describe("showAppQuitConfirmation renderer transport", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("sends a correlated quit request with raw summaries through the injected renderer transport", async () => {
+    const summaries = [shellSummary(1), shellSummary(2)];
+    const sendRequest = vi.fn(
+      async (request: RendererQuitConfirmationRequest) => ({
+        quitId: request.quitId,
+        decision: "cancel",
+      })
+    );
+
+    await expect(
+      showConfirmation({
+        createQuitId: () => "quit-transport-1",
+        sendRequest,
+        summaries,
+      })
+    ).resolves.toBe(false);
+
+    expect(sendRequest).toHaveBeenCalledTimes(1);
+    expect(sendRequest).toHaveBeenCalledWith({
+      quitId: "quit-transport-1",
+      summaries,
+    });
+  });
+
+  it("transports every summary field unchanged so the renderer dialog owns presentation", async () => {
+    const longCommand = `pnpm test ${"x".repeat(260)}`;
+    const summaries: readonly QuitActivitySummary[] = [
+      {
+        kind: "shell",
+        label: "shell with a long command",
+        panelId: "panel-shell",
+        commandLine: longCommand,
+        windowId: "window-shell",
+      },
+      {
+        kind: "agent",
+        label: "agent-42",
+        panelId: "panel-agent",
+        windowId: "window-agent",
+      },
+      {
+        kind: "task",
+        label: "build:watch",
+        panelId: "panel-task",
+        windowId: "window-task",
+      },
+      ...Array.from({ length: 7 }, (_, index) => shellSummary(index + 2)),
+    ];
+    let sentRequest: RendererQuitConfirmationRequest | undefined;
+    const sendRequest = vi.fn((request: RendererQuitConfirmationRequest) => {
+      sentRequest = request;
+      return { quitId: request.quitId, decision: "cancel" };
+    });
+
+    await showConfirmation({ sendRequest, summaries });
+
+    expect(sentRequest?.summaries).toEqual(summaries);
+    expect(sentRequest?.summaries).toHaveLength(10);
+    expect(sentRequest?.summaries[0]).toMatchObject({
+      commandLine: longCommand,
+      label: "shell with a long command",
+      panelId: "panel-shell",
+      windowId: "window-shell",
+    });
+  });
+
+  it("returns true only for a quit decision matching the generated quit id", async () => {
+    const sendRequest = vi.fn(
+      async (request: RendererQuitConfirmationRequest) => ({
+        quitId: request.quitId,
+        decision: "quit",
+      })
+    );
+
+    await expect(showConfirmation({ sendRequest })).resolves.toBe(true);
+  });
+
+  it("returns false for a matching cancel decision", async () => {
+    const sendRequest = vi.fn(
+      async (request: RendererQuitConfirmationRequest) => ({
+        quitId: request.quitId,
+        decision: "cancel",
+      })
+    );
+
+    await expect(showConfirmation({ sendRequest })).resolves.toBe(false);
+  });
+
+  it("does not accept a quit decision correlated to a different quit request", async () => {
+    const sendRequest = vi.fn(async () => ({
+      quitId: "other-quit",
+      decision: "quit",
+    }));
+
+    await expect(
+      showConfirmation({
+        createQuitId: () => "expected-quit",
+        sendRequest,
+      })
+    ).resolves.toBe(false);
+  });
+
+  it.each([
+    {
+      name: "unknown decision",
+      payload: { quitId: "quit-1", decision: "restart" },
+    },
+    { name: "missing decision", payload: { quitId: "quit-1" } },
+    { name: "missing quit id", payload: { decision: "quit" } },
+    { name: "non-object payload", payload: "quit" },
+    { name: "null payload", payload: null },
+  ] as const)("returns false for $name from the renderer", async ({
+    payload,
+  }) => {
+    const sendRequest = vi.fn(async () => payload);
+
+    await expect(showConfirmation({ sendRequest })).resolves.toBe(false);
+  });
+
+  it("returns false when the renderer request cannot be sent", async () => {
+    const sendRequest = vi.fn(() => {
+      throw new Error("renderer unavailable");
+    });
+
+    await expect(showConfirmation({ sendRequest })).resolves.toBe(false);
+  });
+
+  it("honors a caller-supplied defensive timeout when the renderer does not answer", async () => {
+    vi.useFakeTimers();
+    const sendRequest = vi.fn(() => Promise.withResolvers<never>().promise);
+
+    const result = showConfirmation({ sendRequest, timeoutMs: 50 });
+
+    await vi.advanceTimersByTimeAsync(49);
+    await expect(
+      Promise.race([result, Promise.resolve("still-pending" as const)])
+    ).resolves.toBe("still-pending");
+
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(result).resolves.toBe(false);
+  });
+
+  it("does not use the transport response window as its default timeout", async () => {
+    vi.useFakeTimers();
+    const sendRequest = vi.fn(() => Promise.withResolvers<never>().promise);
+
+    const result = showConfirmation({ sendRequest });
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    await expect(
+      Promise.race([result, Promise.resolve("still-pending" as const)])
+    ).resolves.toBe("still-pending");
+  });
+});

--- a/tests/unit/main/app-quit-controller.test.ts
+++ b/tests/unit/main/app-quit-controller.test.ts
@@ -1,0 +1,413 @@
+import type {
+  ForegroundActivity,
+  IdleActivity,
+  ShellActivity,
+  TaskActivity,
+} from "@shared/contracts/foreground-activity.ts";
+import type { AppQuitConfirmationMode } from "@shared/contracts/preferences.ts";
+import { describe, expect, it, vi } from "vitest";
+import {
+  type AppQuitController,
+  type AppQuitControllerDeps,
+  createAppQuitController,
+  type PreventableQuitEvent,
+} from "../../../src/main/app-quit/quit-controller.ts";
+import type { AppWindow } from "../../../src/main/windows/app-window.ts";
+
+const BASE_ACTIVITY = {
+  panelId: "panel-1",
+  windowId: "window-1",
+  spawnedAt: 100,
+  updatedAt: 200,
+} as const;
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  reject: (reason?: unknown) => void;
+  resolve: (value: T | PromiseLike<T>) => void;
+}
+
+type TestableAppQuitControllerDeps = AppQuitControllerDeps & {
+  shouldBypassQuitConfirmationForTests: () => boolean;
+};
+
+interface ControllerHarness {
+  controller: AppQuitController;
+  deps: TestableAppQuitControllerDeps;
+  operations: string[];
+}
+
+function deferred<T>(): Deferred<T> {
+  let reject: (reason?: unknown) => void = () => undefined;
+  let resolve: (value: T | PromiseLike<T>) => void = () => undefined;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+
+  return { promise, reject, resolve };
+}
+
+async function flushAsyncWork(): Promise<void> {
+  for (let index = 0; index < 8; index += 1) {
+    await Promise.resolve();
+  }
+}
+
+function quitEvent(): PreventableQuitEvent {
+  return {
+    preventDefault: vi.fn(),
+  };
+}
+
+function idleActivity(): IdleActivity {
+  return {
+    kind: "idle",
+    ...BASE_ACTIVITY,
+  };
+}
+
+function shellActivity(commandLine = "pnpm test"): ShellActivity {
+  return {
+    kind: "shell",
+    ...BASE_ACTIVITY,
+    commandLine,
+  };
+}
+
+function taskActivity(status: TaskActivity["status"]): TaskActivity {
+  return {
+    kind: "task",
+    ...BASE_ACTIVITY,
+    taskId: "task-1",
+    label: "Build release",
+    status,
+  };
+}
+
+function fakeParentWindow({ destroyed = false } = {}): AppWindow {
+  return {
+    focus: vi.fn(),
+    isDestroyed: () => destroyed,
+  } as unknown as AppWindow;
+}
+
+function createHarness(
+  overrides: Partial<TestableAppQuitControllerDeps> = {}
+): ControllerHarness {
+  const operations: string[] = [];
+  const deps: TestableAppQuitControllerDeps = {
+    confirmQuit: vi.fn(() => Promise.resolve(true)),
+    finalCleanup: vi.fn(() => {
+      operations.push("cleanup");
+    }),
+    flushBeforeQuit: vi.fn(() => {
+      operations.push("flush");
+      return Promise.resolve();
+    }),
+    getActivities: vi.fn((): readonly ForegroundActivity[] => []),
+    getDialogParent: vi.fn(() => null),
+    logFailure: vi.fn(),
+    proceedToQuit: vi.fn(() => {
+      operations.push("proceed");
+    }),
+    readConfirmationMode: vi.fn(
+      (): Promise<AppQuitConfirmationMode> => Promise.resolve("hasActivity")
+    ),
+    shouldBypassQuitConfirmationForTests: vi.fn(() => false),
+  };
+  Object.assign(deps, overrides);
+
+  return {
+    controller: createAppQuitController(deps),
+    deps,
+    operations,
+  };
+}
+
+describe("createAppQuitController", () => {
+  it("synchronously prevents the first before-quit event", () => {
+    const readGate = deferred<AppQuitConfirmationMode>();
+    const { controller } = createHarness({
+      readConfirmationMode: vi.fn(() => readGate.promise),
+    });
+    const event = quitEvent();
+
+    controller.handleBeforeQuit(event);
+
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect(controller.getPhase()).toBe("confirming");
+  });
+
+  it("skips confirmation for hasActivity mode when no dangerous activity is running, then flushes before proceeding", async () => {
+    const { controller, deps, operations } = createHarness({
+      getActivities: vi.fn((): readonly ForegroundActivity[] => [
+        idleActivity(),
+        taskActivity("success"),
+      ]),
+    });
+    const event = quitEvent();
+
+    controller.handleBeforeQuit(event);
+    await vi.waitFor(() => {
+      expect(deps.proceedToQuit).toHaveBeenCalledTimes(1);
+    });
+
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect(deps.confirmQuit).not.toHaveBeenCalled();
+    expect(deps.flushBeforeQuit).toHaveBeenCalledTimes(1);
+    expect(operations).toEqual(["flush", "proceed"]);
+    expect(controller.getPhase()).toBe("quitting");
+  });
+
+  it("returns to idle without flushing or proceeding when dangerous activity confirmation is cancelled", async () => {
+    const parent = fakeParentWindow();
+    const { controller, deps } = createHarness({
+      confirmQuit: vi.fn(async () => false),
+      getActivities: vi.fn((): readonly ForegroundActivity[] => [
+        shellActivity("pnpm dev"),
+      ]),
+      getDialogParent: vi.fn(() => parent),
+    });
+
+    controller.handleBeforeQuit(quitEvent());
+    await vi.waitFor(() => {
+      expect(controller.getPhase()).toBe("idle");
+    });
+
+    expect(deps.confirmQuit).toHaveBeenCalledWith({
+      parent,
+      summaries: [
+        {
+          kind: "shell",
+          label: "pnpm dev",
+          panelId: BASE_ACTIVITY.panelId,
+          commandLine: "pnpm dev",
+          windowId: BASE_ACTIVITY.windowId,
+        },
+      ],
+    });
+    expect(deps.flushBeforeQuit).not.toHaveBeenCalled();
+    expect(deps.proceedToQuit).not.toHaveBeenCalled();
+  });
+
+  it("flushes before proceeding when dangerous activity confirmation is accepted", async () => {
+    const parent = fakeParentWindow();
+    const { controller, deps, operations } = createHarness({
+      confirmQuit: vi.fn(async () => true),
+      getActivities: vi.fn((): readonly ForegroundActivity[] => [
+        shellActivity("pnpm build"),
+      ]),
+      getDialogParent: vi.fn(() => parent),
+    });
+
+    controller.handleBeforeQuit(quitEvent());
+    await vi.waitFor(() => {
+      expect(deps.proceedToQuit).toHaveBeenCalledTimes(1);
+    });
+
+    expect(deps.confirmQuit).toHaveBeenCalledWith({
+      parent,
+      summaries: [
+        {
+          kind: "shell",
+          label: "pnpm build",
+          panelId: BASE_ACTIVITY.panelId,
+          commandLine: "pnpm build",
+          windowId: BASE_ACTIVITY.windowId,
+        },
+      ],
+    });
+    expect(deps.flushBeforeQuit).toHaveBeenCalledTimes(1);
+    expect(operations).toEqual(["flush", "proceed"]);
+    expect(controller.getPhase()).toBe("quitting");
+  });
+
+  it("bypasses confirmation for automated test runs while still flushing before proceeding", async () => {
+    const parent = fakeParentWindow();
+    const shouldBypassQuitConfirmationForTests = vi.fn(() => true);
+    const { controller, deps, operations } = createHarness({
+      confirmQuit: vi.fn(async () => true),
+      getActivities: vi.fn((): readonly ForegroundActivity[] => [
+        shellActivity("pnpm dev"),
+      ]),
+      getDialogParent: vi.fn(() => parent),
+      readConfirmationMode: vi.fn(
+        async (): Promise<AppQuitConfirmationMode> => "hasActivity"
+      ),
+      shouldBypassQuitConfirmationForTests,
+    });
+    const event = quitEvent();
+
+    controller.handleBeforeQuit(event);
+    await vi.waitFor(() => {
+      expect(deps.proceedToQuit).toHaveBeenCalledTimes(1);
+    });
+
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect(deps.confirmQuit).not.toHaveBeenCalled();
+    expect(shouldBypassQuitConfirmationForTests).toHaveBeenCalledTimes(1);
+    expect(deps.flushBeforeQuit).toHaveBeenCalledTimes(1);
+    expect(operations).toEqual(["flush", "proceed"]);
+    expect(controller.getPhase()).toBe("quitting");
+  });
+
+  it.each([
+    {
+      activities: [] as readonly ForegroundActivity[],
+      mode: "always" as const,
+      name: "always mode has no dialog parent",
+      parent: null,
+    },
+    {
+      activities: [shellActivity("pnpm dev")] as readonly ForegroundActivity[],
+      mode: "hasActivity" as const,
+      name: "hasActivity mode has a destroyed dialog parent",
+      parent: fakeParentWindow({ destroyed: true }),
+    },
+  ])("skips confirmation and proceeds when confirmation is required but $name", async ({
+    activities,
+    mode,
+    parent,
+  }) => {
+    const { controller, deps, operations } = createHarness({
+      confirmQuit: vi.fn(async () => false),
+      getActivities: vi.fn(() => activities),
+      getDialogParent: vi.fn(() => parent),
+      readConfirmationMode: vi.fn(async () => mode),
+    });
+    const event = quitEvent();
+
+    controller.handleBeforeQuit(event);
+    await vi.waitFor(() => {
+      expect(deps.proceedToQuit).toHaveBeenCalledTimes(1);
+    });
+
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect(deps.confirmQuit).not.toHaveBeenCalled();
+    expect(deps.flushBeforeQuit).toHaveBeenCalledTimes(1);
+    expect(operations).toEqual(["flush", "proceed"]);
+    expect(controller.getPhase()).toBe("quitting");
+    if (parent) {
+      expect(parent.focus).not.toHaveBeenCalled();
+    }
+  });
+
+  it("only prevents default and focuses an existing parent when before-quit fires while confirmation is already open", async () => {
+    const confirmGate = deferred<boolean>();
+    const parent = fakeParentWindow();
+    const { controller, deps } = createHarness({
+      confirmQuit: vi.fn(() => confirmGate.promise),
+      getActivities: vi.fn((): readonly ForegroundActivity[] => [
+        shellActivity("pnpm dev"),
+      ]),
+      getDialogParent: vi.fn(() => parent),
+    });
+    const firstEvent = quitEvent();
+    const secondEvent = quitEvent();
+
+    controller.handleBeforeQuit(firstEvent);
+    controller.handleBeforeQuit(secondEvent);
+    await flushAsyncWork();
+
+    expect(firstEvent.preventDefault).toHaveBeenCalledTimes(1);
+    expect(secondEvent.preventDefault).toHaveBeenCalledTimes(1);
+    expect(parent.focus).toHaveBeenCalledTimes(1);
+    expect(deps.confirmQuit).toHaveBeenCalledTimes(1);
+    expect(deps.flushBeforeQuit).not.toHaveBeenCalled();
+    expect(deps.proceedToQuit).not.toHaveBeenCalled();
+    expect(controller.getPhase()).toBe("confirming");
+  });
+
+  it("does not focus a destroyed parent when before-quit fires while confirmation is already open", async () => {
+    const confirmGate = deferred<boolean>();
+    const parent = fakeParentWindow({ destroyed: true });
+    const { controller } = createHarness({
+      confirmQuit: vi.fn(() => confirmGate.promise),
+      getActivities: vi.fn((): readonly ForegroundActivity[] => [
+        shellActivity("pnpm dev"),
+      ]),
+      getDialogParent: vi.fn(() => parent),
+    });
+    const secondEvent = quitEvent();
+
+    controller.handleBeforeQuit(quitEvent());
+    controller.handleBeforeQuit(secondEvent);
+    await flushAsyncWork();
+
+    expect(secondEvent.preventDefault).toHaveBeenCalledTimes(1);
+    expect(parent.focus).not.toHaveBeenCalled();
+  });
+
+  it("allows a repeated before-quit event through during the quitting phase and performs final cleanup only", async () => {
+    const flushGate = deferred<void>();
+    const { controller, deps } = createHarness({
+      flushBeforeQuit: vi.fn(() => flushGate.promise),
+    });
+    const repeatedEvent = quitEvent();
+
+    controller.handleBeforeQuit(quitEvent());
+    await vi.waitFor(() => {
+      expect(controller.getPhase()).toBe("quitting");
+    });
+
+    controller.handleBeforeQuit(repeatedEvent);
+
+    expect(repeatedEvent.preventDefault).not.toHaveBeenCalled();
+    expect(deps.finalCleanup).toHaveBeenCalledTimes(1);
+    expect(deps.readConfirmationMode).toHaveBeenCalledTimes(1);
+    expect(deps.confirmQuit).not.toHaveBeenCalled();
+    expect(deps.flushBeforeQuit).toHaveBeenCalledTimes(1);
+    expect(deps.proceedToQuit).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      name: "preference read",
+      makeOverrides: (error: Error): Partial<AppQuitControllerDeps> => ({
+        readConfirmationMode: vi.fn(() => Promise.reject(error)),
+      }),
+      expectSkippedFlush: true,
+    },
+    {
+      name: "confirmation",
+      makeOverrides: (error: Error): Partial<AppQuitControllerDeps> => {
+        const parent = fakeParentWindow();
+        return {
+          confirmQuit: vi.fn(() => Promise.reject(error)),
+          getActivities: vi.fn((): readonly ForegroundActivity[] => [
+            shellActivity("pnpm dev"),
+          ]),
+          getDialogParent: vi.fn(() => parent),
+        };
+      },
+      expectSkippedFlush: true,
+    },
+    {
+      name: "flush",
+      makeOverrides: (error: Error): Partial<AppQuitControllerDeps> => ({
+        flushBeforeQuit: vi.fn(() => Promise.reject(error)),
+      }),
+      expectSkippedFlush: false,
+    },
+  ] as const)("logs $name errors, returns to idle, and does not proceed", async ({
+    makeOverrides,
+    expectSkippedFlush,
+  }) => {
+    const error = new Error("quit failed");
+    const { controller, deps } = createHarness(makeOverrides(error));
+
+    controller.handleBeforeQuit(quitEvent());
+    await vi.waitFor(() => {
+      expect(controller.getPhase()).toBe("idle");
+    });
+
+    expect(deps.logFailure).toHaveBeenCalledWith(error);
+    expect(deps.proceedToQuit).not.toHaveBeenCalled();
+    if (expectSkippedFlush) {
+      expect(deps.flushBeforeQuit).not.toHaveBeenCalled();
+    } else {
+      expect(deps.flushBeforeQuit).toHaveBeenCalledTimes(1);
+    }
+  });
+});

--- a/tests/unit/main/app-quit-decision.test.ts
+++ b/tests/unit/main/app-quit-decision.test.ts
@@ -1,0 +1,230 @@
+import type {
+  ActivityStatus,
+  AgentActivity,
+  ForegroundActivity,
+  IdleActivity,
+  ShellActivity,
+  TaskActivity,
+} from "@shared/contracts/foreground-activity.ts";
+import { describe, expect, it } from "vitest";
+import {
+  isDangerousQuitActivity,
+  shouldConfirmBeforeQuit,
+  summarizeDangerousQuitActivities,
+  summarizeQuitActivity,
+} from "../../../src/main/app-quit/quit-decision.ts";
+
+const BASE_ACTIVITY = {
+  panelId: "panel-1",
+  windowId: "window-1",
+  spawnedAt: 100,
+  updatedAt: 200,
+} as const;
+
+const AGENT_SOURCES = [
+  "hook",
+  "launch",
+] satisfies readonly AgentActivity["source"][];
+const AGENT_STATUSES = [
+  undefined,
+  "ready",
+  "processing",
+  "tool",
+  "waiting",
+  "error",
+] satisfies readonly (ActivityStatus | undefined)[];
+
+function shellActivity(commandLine = "npm test"): ShellActivity {
+  return {
+    kind: "shell",
+    ...BASE_ACTIVITY,
+    commandLine,
+  };
+}
+
+function agentActivity({
+  source = "hook",
+  status = "processing",
+}: {
+  source?: AgentActivity["source"];
+  status?: AgentActivity["status"];
+} = {}): AgentActivity {
+  const activity: AgentActivity = {
+    kind: "agent",
+    ...BASE_ACTIVITY,
+    agentId: "codex",
+    source,
+    subagentCount: 0,
+  };
+
+  if (status !== undefined) {
+    activity.status = status;
+  }
+
+  return activity;
+}
+
+function taskActivity(
+  status: TaskActivity["status"] = "running"
+): TaskActivity {
+  return {
+    kind: "task",
+    ...BASE_ACTIVITY,
+    taskId: "task-1",
+    label: "Build release",
+    status,
+  };
+}
+
+function idleActivity(): IdleActivity {
+  return {
+    kind: "idle",
+    ...BASE_ACTIVITY,
+  };
+}
+
+describe("shouldConfirmBeforeQuit", () => {
+  it.each([
+    { mode: "never", count: 3, expected: false },
+    { mode: "always", count: 0, expected: true },
+    { mode: "hasActivity", count: 0, expected: false },
+    { mode: "hasActivity", count: 1, expected: true },
+  ] as const)("returns $expected for mode=$mode with $count dangerous activities", ({
+    mode,
+    count,
+    expected,
+  }) => {
+    expect(shouldConfirmBeforeQuit(mode, count)).toBe(expected);
+  });
+});
+
+describe("isDangerousQuitActivity", () => {
+  it("treats shell activity as dangerous", () => {
+    expect(isDangerousQuitActivity(shellActivity("pnpm test"))).toBe(true);
+  });
+
+  it.each(
+    AGENT_SOURCES.flatMap((source) =>
+      AGENT_STATUSES.map((status) => ({
+        source,
+        status,
+      }))
+    )
+  )("treats agent activity as dangerous for source=$source status=$status", ({
+    source,
+    status,
+  }) => {
+    expect(isDangerousQuitActivity(agentActivity({ source, status }))).toBe(
+      true
+    );
+  });
+
+  it.each([
+    { status: "running", expected: true },
+    { status: "success", expected: false },
+    { status: "failure", expected: false },
+    { status: "cancelled", expected: false },
+  ] as const)("returns $expected for task status=$status", ({
+    status,
+    expected,
+  }) => {
+    expect(isDangerousQuitActivity(taskActivity(status))).toBe(expected);
+  });
+
+  it("treats idle activity as not dangerous", () => {
+    expect(isDangerousQuitActivity(idleActivity())).toBe(false);
+  });
+});
+
+describe("summarizeQuitActivity", () => {
+  it("trims shell command lines and preserves the trimmed command in the summary", () => {
+    expect(summarizeQuitActivity(shellActivity("  pnpm test:unit  "))).toEqual({
+      kind: "shell",
+      label: "pnpm test:unit",
+      panelId: BASE_ACTIVITY.panelId,
+      commandLine: "pnpm test:unit",
+      windowId: BASE_ACTIVITY.windowId,
+    });
+  });
+
+  it.each([
+    "",
+    "   \t\n  ",
+  ])("uses the fallback shell label and omits commandLine for blank command %j", (commandLine) => {
+    expect(summarizeQuitActivity(shellActivity(commandLine))).toEqual({
+      kind: "shell",
+      label: "Shell command",
+      panelId: BASE_ACTIVITY.panelId,
+      windowId: BASE_ACTIVITY.windowId,
+    });
+  });
+
+  it("summarizes agent activity with the agent id and panel/window ids", () => {
+    expect(
+      summarizeQuitActivity(
+        agentActivity({ source: "launch", status: undefined })
+      )
+    ).toEqual({
+      kind: "agent",
+      label: "codex",
+      panelId: BASE_ACTIVITY.panelId,
+      windowId: BASE_ACTIVITY.windowId,
+    });
+  });
+
+  it("summarizes running task activity with the task label and panel/window ids", () => {
+    expect(summarizeQuitActivity(taskActivity("running"))).toEqual({
+      kind: "task",
+      label: "Build release",
+      panelId: BASE_ACTIVITY.panelId,
+      windowId: BASE_ACTIVITY.windowId,
+    });
+  });
+
+  it.each([
+    { name: "successful task", activity: taskActivity("success") },
+    { name: "failed task", activity: taskActivity("failure") },
+    { name: "cancelled task", activity: taskActivity("cancelled") },
+    { name: "idle panel", activity: idleActivity() },
+  ] satisfies readonly {
+    name: string;
+    activity: ForegroundActivity;
+  }[])("returns null for $name", ({ activity }) => {
+    expect(summarizeQuitActivity(activity)).toBeNull();
+  });
+});
+
+describe("summarizeDangerousQuitActivities", () => {
+  it("filters out non-dangerous activities and returns summaries for dangerous activities", () => {
+    const activities: ForegroundActivity[] = [
+      idleActivity(),
+      taskActivity("success"),
+      shellActivity("  pnpm build  "),
+      taskActivity("running"),
+      agentActivity({ source: "hook", status: "ready" }),
+      taskActivity("cancelled"),
+    ];
+
+    expect(summarizeDangerousQuitActivities(activities)).toEqual([
+      {
+        kind: "shell",
+        label: "pnpm build",
+        panelId: BASE_ACTIVITY.panelId,
+        commandLine: "pnpm build",
+        windowId: BASE_ACTIVITY.windowId,
+      },
+      {
+        kind: "task",
+        label: "Build release",
+        panelId: BASE_ACTIVITY.panelId,
+        windowId: BASE_ACTIVITY.windowId,
+      },
+      {
+        kind: "agent",
+        label: "codex",
+        panelId: BASE_ACTIVITY.panelId,
+        windowId: BASE_ACTIVITY.windowId,
+      },
+    ]);
+  });
+});

--- a/tests/unit/main/app-quit-test-runtime.test.ts
+++ b/tests/unit/main/app-quit-test-runtime.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { shouldBypassQuitConfirmationForTests } from "../../../src/main/app-quit/quit-test-runtime.ts";
+
+describe("shouldBypassQuitConfirmationForTests", () => {
+  it.each([
+    { name: "empty env", env: {}, expected: false },
+    {
+      name: "explicit Pier test bypass enabled",
+      env: { PIER_TEST_DISABLE_QUIT_CONFIRMATION: "1" },
+      expected: true,
+    },
+    {
+      name: "explicit Pier test bypass disabled",
+      env: { PIER_TEST_DISABLE_QUIT_CONFIRMATION: "0" },
+      expected: false,
+    },
+    {
+      name: "Playwright test runtime enabled",
+      env: { PLAYWRIGHT_TEST: "1" },
+      expected: true,
+    },
+    {
+      name: "Vitest runtime enabled",
+      env: { VITEST: "true" },
+      expected: true,
+    },
+    {
+      name: "unsupported Vitest numeric flag",
+      env: { VITEST: "1" },
+      expected: false,
+    },
+  ] as const)("returns $expected for $name", ({ env, expected }) => {
+    expect(shouldBypassQuitConfirmationForTests(env)).toBe(expected);
+  });
+});

--- a/tests/unit/main/preferences-state.test.ts
+++ b/tests/unit/main/preferences-state.test.ts
@@ -84,6 +84,22 @@ describe("preferences state", () => {
     expect(prefs).not.toHaveProperty("worktreeBranchPrefix");
   });
 
+  it("fills quit confirmation when reading an older preferences file", async () => {
+    await writePreferences({
+      theme: "light",
+      stylePresetId: "pierre",
+      language: "zh-CN",
+      uiFontFamily: "",
+      monoFontFamily: "",
+      monoFontSize: 13,
+    });
+    const { readPreferences } = await importPreferencesState();
+
+    await expect(readPreferences()).resolves.toMatchObject({
+      confirmOnQuit: "hasActivity",
+    });
+  });
+
   it("drops the legacy wt worktree branch prefix when normalizing stored preferences", async () => {
     await writePreferences(legacyPreferencesWithBranchPrefix("wt/"));
     const { readPreferences } = await importPreferencesState();

--- a/tests/unit/main/window-lifecycle-invariants.test.ts
+++ b/tests/unit/main/window-lifecycle-invariants.test.ts
@@ -11,16 +11,44 @@ const WINDOW_MANAGER_SOURCE = readFileSync(
   "utf8"
 );
 
-const BEFORE_QUIT_FLUSH_RE =
-  /app\.on\("before-quit",\s*\(event\) => \{[\s\S]{0,500}?event\.preventDefault\(\);[\s\S]{0,500}?appCore\.services\.window\s*\.flushOpenWindows\(\)[\s\S]{0,500}?app\.quit\(\);/;
+const APP_QUIT_CONTROLLER_CREATION_RE =
+  /const\s+appQuitController\s*=\s*createAppQuitController\(\s*\{/;
+const APP_QUIT_CONTROLLER_FLUSH_INJECTION_RE =
+  /createAppQuitController\(\{[\s\S]{0,2500}?flushBeforeQuit:\s*flushBeforeQuitConfirmed\b/;
+const FLUSH_BEFORE_QUIT_WINDOWS_RE =
+  /async function flushBeforeQuitConfirmed\(\): Promise<void> \{[\s\S]{0,1200}?appCore\.services\.window\s*\.flushOpenWindows\(\)/;
+const FLUSH_BEFORE_QUIT_SECRETS_RE =
+  /async function flushBeforeQuitConfirmed\(\): Promise<void> \{[\s\S]{0,1200}?appCore\.services\.secrets\.flush\(\)/;
+const FINAL_CLEANUP_DESTROYS_WINDOWS_RE =
+  /createAppQuitController\(\{[\s\S]{0,2500}?finalCleanup:\s*\(\)\s*=>\s*\{[\s\S]{0,500}?windowManager\.destroyAllForQuit\(\)/;
+const BEFORE_QUIT_GUARDS_SECOND_INSTANCE_RE =
+  /app\.on\("before-quit",\s*\(event\) => \{\s*if \(\s*!gotTheLock\s*\) \{\s*return;\s*\}\s*appQuitController\.handleBeforeQuit\(event\);\s*\}\);/;
 const CLOSE_GUARD_FLUSH_RE =
   /window\.host\.on\("close",\s*\(event:[\s\S]{0,80}?\) => \{[\s\S]{0,700}?event\.preventDefault\(\);[\s\S]{0,700}?this\.flushBeforeClose\(window,/;
 const QUIT_DESTROY_SKIPS_CLOSE_RE =
   /if \(\s*!this\.isDestroyingAllForQuit[\s\S]{0,200}?this\.closeFlushDone\.has\(window\)/;
 
 describe("window lifecycle persistence invariants", () => {
-  it("flushes all open window layouts before Cmd+Q destroys windows", () => {
-    expect(MAIN_SOURCE).toMatch(BEFORE_QUIT_FLUSH_RE);
+  it("creates an app quit controller for Cmd+Q", () => {
+    expect(MAIN_SOURCE).toMatch(APP_QUIT_CONTROLLER_CREATION_RE);
+  });
+
+  it("injects a flushBeforeQuit path that flushes window layouts", () => {
+    expect(MAIN_SOURCE).toMatch(APP_QUIT_CONTROLLER_FLUSH_INJECTION_RE);
+    expect(MAIN_SOURCE).toMatch(FLUSH_BEFORE_QUIT_WINDOWS_RE);
+  });
+
+  it("injects a flushBeforeQuit path that flushes secrets", () => {
+    expect(MAIN_SOURCE).toMatch(APP_QUIT_CONTROLLER_FLUSH_INJECTION_RE);
+    expect(MAIN_SOURCE).toMatch(FLUSH_BEFORE_QUIT_SECRETS_RE);
+  });
+
+  it("injects finalCleanup that destroys all windows for quit", () => {
+    expect(MAIN_SOURCE).toMatch(FINAL_CLEANUP_DESTROYS_WINDOWS_RE);
+  });
+
+  it("does not run the app quit controller for a second-instance quit", () => {
+    expect(MAIN_SOURCE).toMatch(BEFORE_QUIT_GUARDS_SECOND_INSTANCE_RE);
   });
 
   it("flushes the current window before user close proceeds", () => {

--- a/tests/unit/preferences-schema.test.ts
+++ b/tests/unit/preferences-schema.test.ts
@@ -121,6 +121,39 @@ describe("projectPreferencesSchema — terminal preferences", () => {
   });
 });
 
+describe("projectPreferencesSchema - app quit", () => {
+  it("defaults quit confirmation to running activity", () => {
+    expect(projectPreferencesSchema.parse({}).confirmOnQuit).toBe(
+      "hasActivity"
+    );
+  });
+
+  it("accepts planned quit confirmation modes", () => {
+    expect(
+      projectPreferencesSchema.parse({ confirmOnQuit: "always" }).confirmOnQuit
+    ).toBe("always");
+    expect(
+      projectPreferencesSchema.parse({ confirmOnQuit: "hasActivity" })
+        .confirmOnQuit
+    ).toBe("hasActivity");
+    expect(
+      projectPreferencesSchema.parse({ confirmOnQuit: "never" }).confirmOnQuit
+    ).toBe("never");
+  });
+
+  it("rejects unsupported quit confirmation modes", () => {
+    expect(() =>
+      projectPreferencesSchema.parse({ confirmOnQuit: "whenRunning" })
+    ).toThrow();
+    expect(() =>
+      projectPreferencesSchema.parse({ confirmOnQuit: true })
+    ).toThrow();
+    expect(() =>
+      projectPreferencesSchema.parse({ confirmOnQuit: null })
+    ).toThrow();
+  });
+});
+
 describe("projectPreferencesSchema — user keymap", () => {
   it("默认没有用户快捷键覆盖", () => {
     const parsed = projectPreferencesSchema.parse({});

--- a/tests/unit/renderer/app-quit-dialog-bridge.test.tsx
+++ b/tests/unit/renderer/app-quit-dialog-bridge.test.tsx
@@ -1,0 +1,326 @@
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import i18next from "i18next";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AppDialogHost } from "@/components/common/app-dialog-host.tsx";
+import { AppQuitDialogBridge } from "@/components/common/app-quit-dialog-bridge.tsx";
+import { initI18n } from "@/i18n/index.ts";
+import { resetAppDialogForTests } from "@/stores/app-dialog.store.ts";
+import { useKeybindingScope } from "@/stores/keybinding-scope.store.ts";
+import { resetTerminalInputRoutingForTests } from "@/stores/terminal-input-routing-slice.ts";
+
+interface QuitActivitySummary {
+  commandLine?: string;
+  kind: "agent" | "shell" | "task";
+  label: string;
+  panelId: string;
+  windowId: string;
+}
+
+interface AppQuitRequestPayload {
+  quitId: string;
+  summaries: readonly QuitActivitySummary[];
+}
+
+type AppQuitDecision = "cancel" | "quit";
+
+type AppQuitRequestListener = (payload: AppQuitRequestPayload) => void;
+
+const THREE_ACTIVITIES_TEXT_RE = /3 activities are still running\./;
+const ONE_ACTIVITY_TEXT_RE = /1 activity is still running\./;
+const BLANK_LINE_TEXT_RE = /\n\s*\n/;
+const SHELL_SUMMARY_TEXT_RE = /shell: Vite dev server — pnpm dev -- --host/;
+const AGENT_SUMMARY_TEXT_RE = /agent: codex-agent/;
+const TASK_SUMMARY_TEXT_RE = /task: Build web/;
+const QUIT_TERMINATES_TEXT_RE = /Quitting will terminate these processes\./;
+const STILL_RUNNING_TEXT_RE = /still running/;
+const OLD_SERVER_TEXT_RE = /shell: old server/;
+const NEW_AGENT_TEXT_RE = /agent: new agent/;
+
+function shellSummary(overrides: Partial<QuitActivitySummary> = {}) {
+  return {
+    commandLine: "pnpm dev -- --host",
+    kind: "shell" as const,
+    label: "Vite dev server",
+    panelId: "terminal-panel",
+    windowId: "main-window",
+    ...overrides,
+  };
+}
+
+function agentSummary(overrides: Partial<QuitActivitySummary> = {}) {
+  return {
+    kind: "agent" as const,
+    label: "codex-agent",
+    panelId: "agent-panel",
+    windowId: "main-window",
+    ...overrides,
+  };
+}
+
+function taskSummary(overrides: Partial<QuitActivitySummary> = {}) {
+  return {
+    kind: "task" as const,
+    label: "Build web",
+    panelId: "task-panel",
+    windowId: "main-window",
+    ...overrides,
+  };
+}
+
+function installAppQuitApi() {
+  const bridge: { listener?: AppQuitRequestListener } = {};
+  const dispose = vi.fn();
+  const decide = vi.fn(
+    async (_decision: { decision: AppQuitDecision; quitId: string }) =>
+      undefined
+  );
+  const onRequested = vi.fn((listener: AppQuitRequestListener) => {
+    bridge.listener = listener;
+    return dispose;
+  });
+
+  Object.defineProperty(window, "pier", {
+    configurable: true,
+    value: {
+      appQuit: {
+        decide,
+        onRequested,
+      },
+      onWindowLayoutPulse: vi.fn(() => vi.fn()),
+      terminal: { applyInputRouting: vi.fn() },
+    },
+  });
+
+  return { bridge, decide, dispose, onRequested };
+}
+
+function renderBridgeAndHost() {
+  return render(
+    <>
+      <AppQuitDialogBridge />
+      <AppDialogHost />
+    </>
+  );
+}
+
+function sendQuitRequest(
+  listener: AppQuitRequestListener | undefined,
+  payload: AppQuitRequestPayload
+) {
+  expect(listener).toBeDefined();
+  act(() => {
+    listener?.(payload);
+  });
+}
+
+describe("AppQuitDialogBridge", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    resetTerminalInputRoutingForTests();
+    await initI18n();
+    await i18next.changeLanguage("en");
+    useKeybindingScope.setState({
+      activePanelComponent: null,
+      activePanelId: null,
+      activePanelKind: null,
+      overlayStack: [],
+    });
+  });
+
+  afterEach(() => {
+    act(() => {
+      resetAppDialogForTests();
+    });
+    cleanup();
+    Reflect.deleteProperty(window, "pier");
+  });
+
+  it("shows dangerous quit activity summaries and sends quit when the user confirms", async () => {
+    const { bridge, decide, onRequested } = installAppQuitApi();
+    renderBridgeAndHost();
+
+    expect(onRequested).toHaveBeenCalledOnce();
+
+    sendQuitRequest(bridge.listener, {
+      quitId: "quit-dangerous",
+      summaries: [shellSummary(), agentSummary(), taskSummary()],
+    });
+
+    expect(await screen.findByText("Quit Pier?")).toBeVisible();
+    expect(screen.getByText(THREE_ACTIVITIES_TEXT_RE)).toBeVisible();
+    expect(screen.getByText(SHELL_SUMMARY_TEXT_RE)).toBeVisible();
+    expect(screen.getByText(AGENT_SUMMARY_TEXT_RE)).toBeVisible();
+    expect(screen.getByText(TASK_SUMMARY_TEXT_RE)).toBeVisible();
+    expect(screen.getByText(QUIT_TERMINATES_TEXT_RE)).toBeVisible();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Quit" })).toBeVisible();
+
+    fireEvent.click(screen.getByRole("button", { name: "Quit" }));
+
+    await waitFor(() => {
+      expect(decide).toHaveBeenCalledWith({
+        decision: "quit",
+        quitId: "quit-dangerous",
+      });
+    });
+  });
+
+  it("keeps the single dangerous activity body compact while preserving quit details", async () => {
+    const { bridge, decide } = installAppQuitApi();
+    renderBridgeAndHost();
+
+    sendQuitRequest(bridge.listener, {
+      quitId: "quit-single-activity",
+      summaries: [shellSummary()],
+    });
+
+    const description = await screen.findByText(ONE_ACTIVITY_TEXT_RE);
+    const bodyText = description.textContent ?? "";
+
+    expect(bodyText).toContain("1 activity is still running.");
+    expect(bodyText).toContain("• shell: Vite dev server — pnpm dev -- --host");
+    expect(bodyText).toContain("Quitting will terminate these processes.");
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    await waitFor(() => {
+      expect(decide).toHaveBeenCalledWith({
+        decision: "cancel",
+        quitId: "quit-single-activity",
+      });
+    });
+    expect(bodyText).not.toMatch(BLANK_LINE_TEXT_RE);
+  });
+
+  it("explains that the window layout will be saved when no activities are running", async () => {
+    const { bridge, decide } = installAppQuitApi();
+    renderBridgeAndHost();
+
+    sendQuitRequest(bridge.listener, {
+      quitId: "quit-empty",
+      summaries: [],
+    });
+
+    expect(await screen.findByText("Quit Pier?")).toBeVisible();
+    expect(
+      screen.getByText(
+        "Pier will save the current window layout before quitting."
+      )
+    ).toBeVisible();
+    expect(screen.queryByText(STILL_RUNNING_TEXT_RE)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    await waitFor(() => {
+      expect(decide).toHaveBeenCalledWith({
+        decision: "cancel",
+        quitId: "quit-empty",
+      });
+    });
+  });
+
+  it("sends cancel when the user cancels, presses Escape, or the dialog closes", async () => {
+    const cancelCase = installAppQuitApi();
+    const firstRender = renderBridgeAndHost();
+    sendQuitRequest(cancelCase.bridge.listener, {
+      quitId: "quit-cancel-button",
+      summaries: [shellSummary()],
+    });
+    expect(await screen.findByText("Quit Pier?")).toBeVisible();
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    await waitFor(() => {
+      expect(cancelCase.decide).toHaveBeenCalledWith({
+        decision: "cancel",
+        quitId: "quit-cancel-button",
+      });
+    });
+    firstRender.unmount();
+    act(() => {
+      resetAppDialogForTests();
+    });
+
+    const escapeCase = installAppQuitApi();
+    const secondRender = renderBridgeAndHost();
+    sendQuitRequest(escapeCase.bridge.listener, {
+      quitId: "quit-escape",
+      summaries: [agentSummary()],
+    });
+    expect(await screen.findByText("Quit Pier?")).toBeVisible();
+
+    fireEvent.keyDown(document, { code: "Escape", key: "Escape" });
+
+    await waitFor(() => {
+      expect(escapeCase.decide).toHaveBeenCalledWith({
+        decision: "cancel",
+        quitId: "quit-escape",
+      });
+    });
+    secondRender.unmount();
+    act(() => {
+      resetAppDialogForTests();
+    });
+
+    const closeCase = installAppQuitApi();
+    renderBridgeAndHost();
+    sendQuitRequest(closeCase.bridge.listener, {
+      quitId: "quit-close",
+      summaries: [taskSummary()],
+    });
+    expect(await screen.findByText("Quit Pier?")).toBeVisible();
+
+    act(() => {
+      resetAppDialogForTests();
+    });
+
+    await waitFor(() => {
+      expect(closeCase.decide).toHaveBeenCalledWith({
+        decision: "cancel",
+        quitId: "quit-close",
+      });
+    });
+  });
+
+  it("replaces an in-flight request with one dialog and cancels the old quit id", async () => {
+    const { bridge, decide } = installAppQuitApi();
+    renderBridgeAndHost();
+
+    sendQuitRequest(bridge.listener, {
+      quitId: "quit-old",
+      summaries: [shellSummary({ label: "old server" })],
+    });
+    expect(await screen.findByText("Quit Pier?")).toBeVisible();
+    expect(screen.getByText(OLD_SERVER_TEXT_RE)).toBeVisible();
+
+    sendQuitRequest(bridge.listener, {
+      quitId: "quit-new",
+      summaries: [agentSummary({ label: "new agent" })],
+    });
+
+    await waitFor(() => {
+      expect(decide).toHaveBeenCalledWith({
+        decision: "cancel",
+        quitId: "quit-old",
+      });
+    });
+    expect(screen.queryByText(OLD_SERVER_TEXT_RE)).not.toBeInTheDocument();
+    expect(screen.getByText(NEW_AGENT_TEXT_RE)).toBeVisible();
+    expect(screen.getAllByRole("alertdialog")).toHaveLength(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Quit" }));
+
+    await waitFor(() => {
+      expect(decide).toHaveBeenCalledWith({
+        decision: "quit",
+        quitId: "quit-new",
+      });
+    });
+  });
+});

--- a/tests/unit/renderer/settings-dialog-plugin-fallback.test.tsx
+++ b/tests/unit/renderer/settings-dialog-plugin-fallback.test.tsx
@@ -6,6 +6,7 @@ import { SettingsDialog } from "@/pages/settings/settings-dialog.tsx";
 import { usePluginRegistryStore } from "@/stores/plugin-registry.store.ts";
 import { usePluginSettingsStore } from "@/stores/plugin-settings.store.ts";
 import { useSettingsDialogStore } from "@/stores/settings-dialog.store.ts";
+import { makeFakePreferences } from "../../setup/preferences-fixture.ts";
 
 function entry(id: string, enabled = true): PluginRegistryEntry {
   return {
@@ -72,23 +73,10 @@ function pierMock() {
     },
     preferences: {
       onChanged: vi.fn(() => () => undefined),
-      read: vi.fn(async () => ({
-        agentCommandOverrides: {},
-        agentDefaultArgs: {},
-        agentDefaultEnv: {},
-        defaultAgentId: null,
-        disabledAgentIds: [],
-        language: "system",
-        stylePreset: "pierre",
-        terminalCursorBlink: true,
-        terminalCursorStyle: "block",
-        terminalNewCwdPolicy: "activeTerminal",
-        terminalPasteProtection: true,
-        terminalScrollbackMb: 64,
-        theme: "system",
-        userKeymap: {},
-      })),
-      update: vi.fn(async (patch: Record<string, unknown>) => patch),
+      read: vi.fn(() => Promise.resolve(makeFakePreferences())),
+      update: vi.fn((patch: Parameters<typeof makeFakePreferences>[0]) =>
+        Promise.resolve(makeFakePreferences(patch))
+      ),
     },
     settings: {
       onOpenRequest: vi.fn(() => () => undefined),

--- a/tests/unit/renderer/settings-dialog-quit-confirmation.test.tsx
+++ b/tests/unit/renderer/settings-dialog-quit-confirmation.test.tsx
@@ -1,0 +1,194 @@
+import type { PluginRegistryEntry } from "@shared/contracts/plugin.ts";
+import type { AppQuitConfirmationMode } from "@shared/contracts/preferences.ts";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { initI18n } from "@/i18n/index.ts";
+import { SettingsDialog } from "@/pages/settings/settings-dialog.tsx";
+import { useAppQuitPreferencesStore } from "@/stores/app-quit-preferences.store.ts";
+import { usePluginRegistryStore } from "@/stores/plugin-registry.store.ts";
+import { usePluginSettingsStore } from "@/stores/plugin-settings.store.ts";
+import { useSettingsDialogStore } from "@/stores/settings-dialog.store.ts";
+import { useTerminalPreferencesStore } from "@/stores/terminal-preferences.store.ts";
+import { makeFakePreferences } from "../../setup/preferences-fixture.ts";
+
+const originalScrollIntoView = Element.prototype.scrollIntoView;
+
+const REGISTRY_INITIAL_STATE = {
+  diagnostics: [],
+  error: null,
+  initialized: false,
+  plugins: [] as PluginRegistryEntry[],
+};
+
+const PLUGIN_SETTINGS_INITIAL_STATE = {
+  error: null,
+  initialized: false,
+  values: {},
+};
+
+const DIALOG_INITIAL_STATE = {
+  activeSection: "appearance",
+  isOpen: false,
+};
+
+const TERMINAL_INITIAL_STATE = {
+  terminalCursorBlink: true,
+  terminalCursorStyle: "block" as const,
+  terminalNewCwdPolicy: "activeTerminal" as const,
+  terminalPasteProtection: true,
+  terminalScrollbackMb: 64,
+};
+
+const APP_QUIT_INITIAL_STATE = {
+  confirmOnQuit: "hasActivity" as const,
+};
+
+function pierMock() {
+  return {
+    pluginSettings: {
+      getAll: vi.fn(async () => ({ values: {}, version: 1 })),
+      onChanged: vi.fn(() => () => undefined),
+      reset: vi.fn(async () => ({ values: {}, version: 1 })),
+      set: vi.fn(async (key: string, value: unknown) => ({
+        values: { [key]: value },
+        version: 1,
+      })),
+    },
+    preferences: {
+      onChanged: vi.fn(() => () => undefined),
+      read: vi.fn(async () => makeFakePreferences()),
+      update: vi.fn(
+        async (patch: { confirmOnQuit?: AppQuitConfirmationMode }) =>
+          makeFakePreferences(patch)
+      ),
+    },
+    settings: {
+      onOpenRequest: vi.fn(() => () => undefined),
+    },
+  };
+}
+
+function openTerminalSettings(
+  initialMode: AppQuitConfirmationMode = "hasActivity"
+) {
+  useAppQuitPreferencesStore.setState({
+    confirmOnQuit: initialMode,
+  } as never);
+  act(() => {
+    useSettingsDialogStore.setState({
+      activeSection: "terminal",
+      isOpen: true,
+    });
+  });
+  render(<SettingsDialog />);
+}
+
+async function chooseQuitConfirmation(label: string) {
+  fireEvent.click(screen.getByRole("combobox", { name: "Quit Confirmation" }));
+  fireEvent.click(await screen.findByRole("option", { name: label }));
+}
+
+describe("SettingsDialog — Terminal quit confirmation preference", () => {
+  beforeEach(async () => {
+    Element.prototype.scrollIntoView = vi.fn();
+    await initI18n();
+    usePluginRegistryStore.setState(REGISTRY_INITIAL_STATE);
+    usePluginSettingsStore.setState(PLUGIN_SETTINGS_INITIAL_STATE);
+    useSettingsDialogStore.setState(DIALOG_INITIAL_STATE);
+    useTerminalPreferencesStore.setState(TERMINAL_INITIAL_STATE as never);
+    useAppQuitPreferencesStore.setState(APP_QUIT_INITIAL_STATE as never);
+    Object.defineProperty(window, "pier", {
+      configurable: true,
+      value: pierMock(),
+    });
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: vi.fn((query: string) => ({
+        addEventListener: vi.fn(),
+        addListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+        matches: false,
+        media: query,
+        onchange: null,
+        removeEventListener: vi.fn(),
+        removeListener: vi.fn(),
+      })),
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    if (originalScrollIntoView) {
+      Element.prototype.scrollIntoView = originalScrollIntoView;
+    } else {
+      Reflect.deleteProperty(Element.prototype, "scrollIntoView");
+    }
+    usePluginRegistryStore.setState(REGISTRY_INITIAL_STATE);
+    usePluginSettingsStore.setState(PLUGIN_SETTINGS_INITIAL_STATE);
+    useSettingsDialogStore.setState(DIALOG_INITIAL_STATE);
+    useTerminalPreferencesStore.setState(TERMINAL_INITIAL_STATE as never);
+    useAppQuitPreferencesStore.setState(APP_QUIT_INITIAL_STATE as never);
+  });
+
+  it("renders the quit confirmation control and its three user-facing modes", async () => {
+    openTerminalSettings();
+
+    expect(
+      screen.getByRole("combobox", { name: "Quit Confirmation" })
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("combobox", { name: "Quit Confirmation" })
+    );
+
+    expect(
+      await screen.findByRole("option", { name: "When activity is running" })
+    ).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Always" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Never" })).toBeInTheDocument();
+  });
+
+  it("persists Always as confirmOnQuit always", async () => {
+    openTerminalSettings();
+
+    await chooseQuitConfirmation("Always");
+
+    await waitFor(() => {
+      expect(window.pier.preferences.update).toHaveBeenCalledWith({
+        confirmOnQuit: "always",
+      });
+    });
+  });
+
+  it("persists When activity is running as confirmOnQuit hasActivity", async () => {
+    openTerminalSettings("always");
+
+    await chooseQuitConfirmation("When activity is running");
+
+    await waitFor(() => {
+      expect(window.pier.preferences.update).toHaveBeenCalledWith({
+        confirmOnQuit: "hasActivity",
+      });
+    });
+  });
+
+  it("persists Never as confirmOnQuit never", async () => {
+    openTerminalSettings();
+
+    await chooseQuitConfirmation("Never");
+
+    await waitFor(() => {
+      expect(window.pier.preferences.update).toHaveBeenCalledWith({
+        confirmOnQuit: "never",
+      });
+    });
+  });
+});

--- a/tests/unit/renderer/settings-dialog-workspace.test.tsx
+++ b/tests/unit/renderer/settings-dialog-workspace.test.tsx
@@ -15,6 +15,7 @@ import { usePluginRegistryStore } from "@/stores/plugin-registry.store.ts";
 import { usePluginSettingsStore } from "@/stores/plugin-settings.store.ts";
 import { useSettingsDialogStore } from "@/stores/settings-dialog.store.ts";
 import { useWorktreePreferencesStore } from "@/stores/worktree-preferences.store.ts";
+import { makeFakePreferences } from "../../setup/preferences-fixture.ts";
 
 const REGISTRY_INITIAL_STATE = {
   diagnostics: [],
@@ -60,12 +61,16 @@ function pierMock() {
     },
     preferences: {
       onChanged: vi.fn(() => () => undefined),
-      read: vi.fn(async () => ({
-        worktreeRootPath: "/existing/worktrees",
-      })),
-      update: vi.fn(async (patch: { worktreeRootPath?: string }) => ({
-        worktreeRootPath: patch.worktreeRootPath ?? "/existing/worktrees",
-      })),
+      read: vi.fn(async () =>
+        makeFakePreferences({
+          worktreeRootPath: "/existing/worktrees",
+        })
+      ),
+      update: vi.fn(async (patch: { worktreeRootPath?: string }) =>
+        makeFakePreferences({
+          worktreeRootPath: patch.worktreeRootPath ?? "/existing/worktrees",
+        })
+      ),
     },
     settings: {
       onOpenRequest: vi.fn(() => () => undefined),

--- a/tests/unit/renderer/stores/app-quit-preferences.store.test.ts
+++ b/tests/unit/renderer/stores/app-quit-preferences.store.test.ts
@@ -1,0 +1,92 @@
+import type { AppQuitConfirmationMode } from "@shared/contracts/preferences.ts";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  detachAppQuitPreferencesListener,
+  initAppQuitPreferences,
+  useAppQuitPreferencesStore,
+} from "@/stores/app-quit-preferences.store.ts";
+
+interface AppQuitPreferenceSnapshot {
+  confirmOnQuit: AppQuitConfirmationMode;
+}
+
+type PreferencesChangedCallback = (next: AppQuitPreferenceSnapshot) => void;
+
+describe("useAppQuitPreferencesStore", () => {
+  let changedCallback: PreferencesChangedCallback | null;
+  const detachMock = vi.fn();
+  const readMock = vi.fn<() => Promise<AppQuitPreferenceSnapshot>>();
+  const updateMock =
+    vi.fn<
+      (patch: {
+        confirmOnQuit?: AppQuitConfirmationMode;
+      }) => Promise<AppQuitPreferenceSnapshot>
+    >();
+
+  beforeEach(() => {
+    changedCallback = null;
+    detachAppQuitPreferencesListener();
+    detachMock.mockReset();
+    readMock.mockReset();
+    updateMock.mockReset();
+    useAppQuitPreferencesStore.setState({
+      confirmOnQuit: "hasActivity",
+    } as never);
+    vi.stubGlobal("window", {
+      ...window,
+      pier: {
+        preferences: {
+          onChanged: (cb: PreferencesChangedCallback) => {
+            changedCallback = cb;
+            return detachMock;
+          },
+          read: readMock,
+          update: updateMock,
+        },
+      },
+    });
+  });
+
+  afterEach(() => {
+    detachAppQuitPreferencesListener();
+    vi.unstubAllGlobals();
+  });
+
+  it("initAppQuitPreferences hydrates confirmOnQuit from preferences.read", async () => {
+    readMock.mockResolvedValue({
+      confirmOnQuit: "never",
+    });
+
+    await initAppQuitPreferences();
+
+    expect(readMock).toHaveBeenCalledTimes(1);
+    expect(useAppQuitPreferencesStore.getState().confirmOnQuit).toBe("never");
+    expect(changedCallback).not.toBeNull();
+  });
+
+  it("setConfirmOnQuit writes the selected mode and hydrates from the merged snapshot", async () => {
+    updateMock.mockResolvedValue({
+      confirmOnQuit: "always",
+    });
+
+    await useAppQuitPreferencesStore.getState().setConfirmOnQuit("always");
+
+    expect(updateMock).toHaveBeenCalledWith({
+      confirmOnQuit: "always",
+    });
+    expect(useAppQuitPreferencesStore.getState().confirmOnQuit).toBe("always");
+  });
+
+  it("preferences.onChanged broadcasts synchronize confirmOnQuit", async () => {
+    readMock.mockResolvedValue({
+      confirmOnQuit: "hasActivity",
+    });
+    await initAppQuitPreferences();
+
+    changedCallback?.({
+      confirmOnQuit: "always",
+    });
+
+    expect(useAppQuitPreferencesStore.getState().confirmOnQuit).toBe("always");
+  });
+});


### PR DESCRIPTION
## Summary
- Add Cmd+Q/app quit confirmation when foreground agent, task, or shell work would be terminated.
- Wire main/preload/renderer IPC through a shadcn confirmation dialog and settings preference.
- Add test-runtime bypass for Playwright plus unit/component/e2e coverage.

## Test Plan
- pnpm exec vitest run tests/unit/main/app-quit-test-runtime.test.ts tests/unit/main/app-quit-controller.test.ts tests/unit/main/window-lifecycle-invariants.test.ts tests/unit/main/app-quit-confirmation.test.ts tests/unit/renderer/app-quit-dialog-bridge.test.tsx tests/component/app-dialog-host.test.tsx
- pnpm typecheck
- pnpm lint
- pnpm check:file-size
- pnpm build:electron
- pnpm exec playwright test --config playwright.config.ts tests/e2e/terminal-task-status.spec.ts -g restart

## Review
- 8 parallel reviewer agents reported no actionable findings.