### PR TITLE
fix(foreground-activity): scope agent hook sessions

### DIFF
--- a/src/main/services/foreground-activity/aggregator-hook-scopes.ts
+++ b/src/main/services/foreground-activity/aggregator-hook-scopes.ts
@@ -1,0 +1,189 @@
+import type { AgentHookEventPayload } from "@shared/contracts/agent-session.ts";
+import type { ActivityStatus } from "@shared/contracts/foreground-activity.ts";
+import {
+  logAgentEventDropped,
+  refreshHookProjectionWithLog,
+  setHookScopeStatusWithLog,
+} from "./aggregator-tracing.ts";
+import {
+  type HookLayer,
+  type HookScope,
+  type HookScopeIdentity,
+  type PanelSlot,
+  SESSION_END_COOLDOWN_MS,
+  SUBAGENT_EVENTS,
+} from "./entry.ts";
+
+export function isInCooldown(
+  map: Map<string, number>,
+  key: string,
+  now: () => number
+): boolean {
+  const until = map.get(key);
+  if (until === undefined) {
+    return false;
+  }
+  if (now() >= until) {
+    map.delete(key);
+    return false;
+  }
+  return true;
+}
+
+interface HookScopeCoordinatorOpts {
+  endHookSession: (key: string) => void;
+  hookCooldownUntil: Map<string, number>;
+  now: () => number;
+  panelCooldownUntil: Map<string, number>;
+  scheduleEmit: () => void;
+  slots: Map<string, PanelSlot>;
+}
+
+export interface HookScopeCoordinator {
+  allowsAgentEventAfterCooldowns: (
+    key: string,
+    event: AgentHookEventPayload,
+    identity: HookScopeIdentity
+  ) => boolean;
+  clearCooldownsForPanel: (panelId: string) => void;
+  handleSessionEnd: (
+    key: string,
+    event: AgentHookEventPayload,
+    identity: HookScopeIdentity
+  ) => boolean;
+  noteStatusEvent: (
+    key: string,
+    hook: HookLayer,
+    scope: HookScope,
+    event: AgentHookEventPayload,
+    status: ActivityStatus,
+    at: number
+  ) => void;
+  pruneExpiredCooldowns: () => void;
+}
+
+export function createHookScopeCoordinator({
+  endHookSession,
+  hookCooldownUntil,
+  now,
+  panelCooldownUntil,
+  scheduleEmit,
+  slots,
+}: HookScopeCoordinatorOpts): HookScopeCoordinator {
+  const hookScopeCooldownUntil = new Map<string, number>();
+
+  function scopeCooldownKey(panelId: string, scopeKey: string): string {
+    return `${panelId}\0${scopeKey}`;
+  }
+
+  function clearCooldownsForPanel(panelId: string): void {
+    const prefix = `${panelId}\0`;
+    for (const key of hookScopeCooldownUntil.keys()) {
+      if (key.startsWith(prefix)) {
+        hookScopeCooldownUntil.delete(key);
+      }
+    }
+  }
+
+  function pruneExpiredCooldowns(): void {
+    for (const [id, until] of hookScopeCooldownUntil) {
+      if (now() >= until) {
+        hookScopeCooldownUntil.delete(id);
+      }
+    }
+  }
+
+  function endHookScope(
+    key: string,
+    scopeKey: string,
+    agent: AgentHookEventPayload["agent"]
+  ): void {
+    const cooldownKey = scopeCooldownKey(key, scopeKey);
+    hookScopeCooldownUntil.set(cooldownKey, now() + SESSION_END_COOLDOWN_MS);
+    const hook = slots.get(key)?.hook ?? null;
+    if (!hook?.scopes.delete(scopeKey)) {
+      return;
+    }
+    if (hook.scopes.size === 0) {
+      endHookSession(key);
+      return;
+    }
+    refreshHookProjectionWithLog(key, hook, now(), agent);
+    scheduleEmit();
+  }
+
+  function allowsAgentEventAfterCooldowns(
+    key: string,
+    event: AgentHookEventPayload,
+    identity: HookScopeIdentity
+  ): boolean {
+    if (isInCooldown(panelCooldownUntil, key, now)) {
+      logAgentEventDropped("suppressed-panel-cooldown", key, event.event);
+      return false;
+    }
+    if (event.event === "SessionStart") {
+      hookCooldownUntil.delete(key);
+      if (identity.isolated) {
+        hookScopeCooldownUntil.delete(scopeCooldownKey(key, identity.key));
+      }
+      return true;
+    }
+    if (isInCooldown(hookCooldownUntil, key, now)) {
+      logAgentEventDropped("suppressed-hook-cooldown", key, event.event);
+      return false;
+    }
+    if (
+      identity.isolated &&
+      isInCooldown(
+        hookScopeCooldownUntil,
+        scopeCooldownKey(key, identity.key),
+        now
+      )
+    ) {
+      logAgentEventDropped("suppressed-hook-cooldown", key, event.event);
+      return false;
+    }
+    return true;
+  }
+
+  function handleSessionEnd(
+    key: string,
+    event: AgentHookEventPayload,
+    identity: HookScopeIdentity
+  ): boolean {
+    if (event.event !== "SessionEnd") {
+      return false;
+    }
+    if (identity.isolated) {
+      endHookScope(key, identity.key, event.agent);
+      return true;
+    }
+    endHookSession(key);
+    return true;
+  }
+
+  function noteStatusEvent(
+    key: string,
+    hook: HookLayer,
+    scope: HookScope,
+    event: AgentHookEventPayload,
+    status: ActivityStatus,
+    at: number
+  ): void {
+    hook.agentId = event.agent;
+    if (SUBAGENT_EVENTS.has(event.event)) {
+      scope.updatedAt = at;
+      refreshHookProjectionWithLog(key, hook, at, event.agent);
+      return;
+    }
+    setHookScopeStatusWithLog(key, hook, scope, status, at, event.agent);
+  }
+
+  return {
+    allowsAgentEventAfterCooldowns,
+    clearCooldownsForPanel,
+    handleSessionEnd,
+    noteStatusEvent,
+    pruneExpiredCooldowns,
+  };
+}

--- a/src/main/services/foreground-activity/aggregator-tracing.ts
+++ b/src/main/services/foreground-activity/aggregator-tracing.ts
@@ -1,8 +1,8 @@
 import type { AgentKind } from "@shared/contracts/agent.ts";
 import type { ActivityStatus } from "@shared/contracts/foreground-activity.ts";
 import { createLogger } from "@shared/logger.ts";
-import type { HookLayer } from "./entry.ts";
-import { setHookStatus } from "./entry.ts";
+import type { HookLayer, HookScope } from "./entry.ts";
+import { refreshHookProjection, setHookScopeStatus } from "./entry.ts";
 
 /**
  * aggregator 模块的日志辅助函数。
@@ -53,21 +53,40 @@ export function logAgentEventDropped(
  * 更新 hook status 并在变化时记日志（setHookStatus 的日志包装）。
  * 抽出来避免 ingestAgentEvent 内嵌套过深触发复杂度上限。
  */
-export function setHookStatusWithLog(
+export function setHookScopeStatusWithLog(
   key: string,
   hook: HookLayer,
+  scope: HookScope,
   status: ActivityStatus,
   at: number,
   agent: AgentKind
 ): void {
   const prevStatus = hook.status;
-  setHookStatus(hook, status, at);
-  if (prevStatus !== status) {
+  setHookScopeStatus(hook, scope, status, at);
+  if (prevStatus !== hook.status) {
     log.debug("hook-status-change", {
       panelId: key,
       agent,
       prev: prevStatus,
-      next: status,
+      next: hook.status,
+    });
+  }
+}
+
+export function refreshHookProjectionWithLog(
+  key: string,
+  hook: HookLayer,
+  at: number,
+  agent: AgentKind
+): void {
+  const prevStatus = hook.status;
+  refreshHookProjection(hook, at);
+  if (prevStatus !== hook.status) {
+    log.debug("hook-status-change", {
+      panelId: key,
+      agent,
+      prev: prevStatus,
+      next: hook.status,
     });
   }
 }

--- a/src/main/services/foreground-activity/aggregator.ts
+++ b/src/main/services/foreground-activity/aggregator.ts
@@ -5,13 +5,16 @@ import type {
 } from "@shared/contracts/foreground-activity.ts";
 import { activityStatusForHookEvent } from "@shared/contracts/foreground-activity.ts";
 import {
+  createHookScopeCoordinator,
+  isInCooldown,
+} from "./aggregator-hook-scopes.ts";
+import {
   logAgentEventDropped,
   logClearForeignHook,
   logCommandFinished,
   logEndHookSession,
   logPtyExitedTaskRetain,
   logRouting,
-  setHookStatusWithLog,
 } from "./aggregator-tracing.ts";
 import {
   type AgentLaunchLayer,
@@ -22,7 +25,9 @@ import {
   clearHookTimers,
   clearSlotTimers,
   EMIT_DEBOUNCE_MS,
+  getOrCreateHookScope,
   type HookLayer,
+  hookScopeIdentity,
   newAgentLaunchLayer,
   newHookLayer,
   newShellLayer,
@@ -31,7 +36,6 @@ import {
   projectSlot,
   SESSION_CREATING_EVENTS,
   SESSION_END_COOLDOWN_MS,
-  SUBAGENT_EVENTS,
   SUSPENDED_JOB_EXIT_CODES,
   type TimerCtx,
   VISIBILITY_DEBOUNCE_MS,
@@ -83,18 +87,6 @@ export function createForegroundActivityAggregator(
 
   const timerCtx: TimerCtx = { now, scheduleEmit, slots };
 
-  function isInCooldown(map: Map<string, number>, key: string): boolean {
-    const until = map.get(key);
-    if (until === undefined) {
-      return false;
-    }
-    if (now() >= until) {
-      map.delete(key);
-      return false;
-    }
-    return true;
-  }
-
   function slotFor(key: string): PanelSlot {
     let slot = slots.get(key);
     if (!slot) {
@@ -121,6 +113,7 @@ export function createForegroundActivityAggregator(
       clearSlotTimers(slot);
       slots.delete(key);
     }
+    hookScopes.clearCooldownsForPanel(key);
     cooldown.map.set(key, now() + cooldown.ms);
     return slot !== undefined;
   }
@@ -133,6 +126,7 @@ export function createForegroundActivityAggregator(
         }
       }
     }
+    hookScopes.pruneExpiredCooldowns();
   }
 
   /** launch 层 250ms 消抖显形（`omp --version` 瞬时命令不闪条）。 */
@@ -196,11 +190,21 @@ export function createForegroundActivityAggregator(
       }
       dropSlotIfEmpty(key);
     }
+    hookScopes.clearCooldownsForPanel(key);
     hookCooldownUntil.set(key, now() + SESSION_END_COOLDOWN_MS);
     if (hook) {
       scheduleEmit();
     }
   }
+
+  const hookScopes = createHookScopeCoordinator({
+    endHookSession,
+    hookCooldownUntil,
+    now,
+    panelCooldownUntil,
+    scheduleEmit,
+    slots,
+  });
 
   /**
    * 取得/新建 hook 层。幽灵门控：终结类迟到事件（Stop/ToolComplete/
@@ -276,7 +280,7 @@ export function createForegroundActivityAggregator(
       const key = panelId;
       // 只查 panel 死亡冷却：命令收尾的 hook 冷却不拦新命令——
       // 相邻命令 <5s 也必须正常呈现（loomdesk ingestCommandStart 同语义）。
-      if (isInCooldown(panelCooldownUntil, key)) {
+      if (isInCooldown(panelCooldownUntil, key, now)) {
         return;
       }
       const slot = slotFor(key);
@@ -317,20 +321,11 @@ export function createForegroundActivityAggregator(
       const key = event.panelId;
       const slotBefore = slots.get(key);
       logRouting(event.event, event.agent, key, slotBefore?.hook ?? null);
-      if (isInCooldown(panelCooldownUntil, key)) {
-        // panel 已死：SessionStart 也不得复活幽灵。
-        logAgentEventDropped("suppressed-panel-cooldown", key, event.event);
+      const identity = hookScopeIdentity(event);
+      if (!hookScopes.allowsAgentEventAfterCooldowns(key, event, identity)) {
         return;
       }
-      if (event.event === "SessionStart") {
-        // 会话开端豁免 hook 收尾冷却。
-        hookCooldownUntil.delete(key);
-      } else if (isInCooldown(hookCooldownUntil, key)) {
-        logAgentEventDropped("suppressed-hook-cooldown", key, event.event);
-        return;
-      }
-      if (event.event === "SessionEnd") {
-        endHookSession(key);
+      if (hookScopes.handleSessionEnd(key, event, identity)) {
         return;
       }
       const status = activityStatusForHookEvent(event.event);
@@ -344,18 +339,14 @@ export function createForegroundActivityAggregator(
         logAgentEventDropped("ghost-rejected", key, event.event);
         return;
       }
-      if (!applyTurnBookkeeping(hook, event.event)) {
+      const scope = getOrCreateHookScope(hook, identity, at);
+      if (!applyTurnBookkeeping(scope, event.event)) {
         logAgentEventDropped("absorbed", key, event.event, {
-          frozenStatus: hook.status,
+          frozenStatus: scope.status,
         });
         return;
       }
-      hook.agentId = event.agent;
-      if (SUBAGENT_EVENTS.has(event.event)) {
-        hook.updatedAt = at;
-      } else {
-        setHookStatusWithLog(key, hook, status, at, event.agent);
-      }
+      hookScopes.noteStatusEvent(key, hook, scope, event, status, at);
       armHookTtlTimer(key, timerCtx);
       scheduleEmit();
     },

--- a/src/main/services/foreground-activity/entry.ts
+++ b/src/main/services/foreground-activity/entry.ts
@@ -62,22 +62,50 @@ export const SESSION_CREATING_EVENTS = new Set([
 ]);
 /** 子代理事件只做计数, 不改父状态（防 tool→processing 闪跳）。 */
 export const SUBAGENT_EVENTS = new Set(["SubagentStart", "SubagentStop"]);
+/**
+ * 这些集成在 agent 扩展运行时内直接写 JSONL, `pid` 是扩展宿主进程号。
+ * Claude/Codex 等 JSON command hook 里的 `pid` 来自 Pier emit 脚本 `$$`,
+ * 不是 agent 会话进程, 不得放进此表。
+ */
+export const PROCESS_SCOPED_HOOK_AGENTS: ReadonlySet<AgentKind> = new Set([
+  "amp",
+  "kilo",
+  "mimo-code",
+  "omp",
+  "opencode",
+  "pi",
+]);
+export const PANEL_HOOK_SCOPE_KEY = "panel";
 /** Ctrl+Z 悬挂族：128 + {SIGSTOP,SIGTSTP} = 145,146,147,148。 */
 export const SUSPENDED_JOB_EXIT_CODES: ReadonlySet<number> = new Set([
   145, 146, 147, 148,
 ]);
+
+export interface HookScopeIdentity {
+  isolated: boolean;
+  key: string;
+}
+
+export interface HookScope {
+  key: string;
+  stateStartedAt: number;
+  status: ActivityStatus;
+  subagentCount: number;
+  turnEnded: boolean;
+  updatedAt: number;
+}
 
 /** hook 层——agent 会话证据。字段只由 hook 事件（及 TTL 衰减）改写。 */
 export interface HookLayer {
   agentId: AgentKind;
   /** SessionStart 消抖隐藏期为 true——不参与投影。 */
   hidden: boolean;
+  scopes: Map<string, HookScope>;
   spawnedAt: number;
   stateStartedAt: number;
   status: ActivityStatus;
   subagentCount: number;
   ttlTimer: NodeJS.Timeout | null;
-  turnEnded: boolean;
   updatedAt: number;
   visibilityTimer: NodeJS.Timeout | null;
   windowId: string;
@@ -157,6 +185,96 @@ export function clearSlotTimers(slot: PanelSlot): void {
   }
 }
 
+export function hookScopeIdentity(
+  event: AgentHookEventPayload
+): HookScopeIdentity {
+  const sessionId = event.sessionId?.trim();
+  if (sessionId) {
+    return { isolated: true, key: `session:${sessionId}` };
+  }
+  if (
+    PROCESS_SCOPED_HOOK_AGENTS.has(event.agent) &&
+    typeof event.pid === "number"
+  ) {
+    return { isolated: true, key: `process:${event.pid}` };
+  }
+  return { isolated: false, key: PANEL_HOOK_SCOPE_KEY };
+}
+
+export function newHookScope(key: string, at: number): HookScope {
+  return {
+    key,
+    stateStartedAt: at,
+    status: "ready",
+    subagentCount: 0,
+    turnEnded: false,
+    updatedAt: at,
+  };
+}
+
+export function getOrCreateHookScope(
+  hook: HookLayer,
+  identity: HookScopeIdentity,
+  at: number
+): HookScope {
+  const existing = hook.scopes.get(identity.key);
+  if (existing) {
+    return existing;
+  }
+  const scope = newHookScope(identity.key, at);
+  hook.scopes.set(identity.key, scope);
+  return scope;
+}
+
+const STATUS_PRIORITY: Record<ActivityStatus, number> = {
+  error: 4,
+  processing: 2,
+  ready: 1,
+  tool: 3,
+  waiting: 5,
+};
+
+function preferredScope(current: HookScope, candidate: HookScope): HookScope {
+  const currentPriority = STATUS_PRIORITY[current.status];
+  const candidatePriority = STATUS_PRIORITY[candidate.status];
+  if (candidatePriority !== currentPriority) {
+    return candidatePriority > currentPriority ? candidate : current;
+  }
+  return candidate.updatedAt >= current.updatedAt ? candidate : current;
+}
+
+export function refreshHookProjection(hook: HookLayer, at?: number): void {
+  let selected: HookScope | null = null;
+  let maxUpdatedAt = hook.updatedAt;
+  let subagentCount = 0;
+  for (const scope of hook.scopes.values()) {
+    selected = selected ? preferredScope(selected, scope) : scope;
+    maxUpdatedAt = Math.max(maxUpdatedAt, scope.updatedAt);
+    subagentCount += scope.subagentCount;
+  }
+  if (!selected) {
+    return;
+  }
+  hook.status = selected.status;
+  hook.stateStartedAt = selected.stateStartedAt;
+  hook.subagentCount = subagentCount;
+  hook.updatedAt = Math.max(maxUpdatedAt, at ?? 0);
+}
+
+export function setHookScopeStatus(
+  hook: HookLayer,
+  scope: HookScope,
+  status: ActivityStatus,
+  at: number
+): void {
+  if (scope.status !== status) {
+    scope.status = status;
+    scope.stateStartedAt = at;
+  }
+  scope.updatedAt = at;
+  refreshHookProjection(hook, at);
+}
+
 /** hook 静默 30min 后 processing/tool/waiting/error → ready 衰减。 */
 export function armHookTtlTimer(key: string, ctx: TimerCtx): void {
   const hook = ctx.slots.get(key)?.hook;
@@ -173,11 +291,17 @@ export function armHookTtlTimer(key: string, ctx: TimerCtx): void {
       return;
     }
     current.ttlTimer = null;
-    if (current.status !== "ready") {
+    if (
+      current.status !== "ready" ||
+      [...current.scopes.values()].some((scope) => scope.status !== "ready")
+    ) {
       const at = ctx.now();
-      current.status = "ready";
-      current.stateStartedAt = at;
-      current.updatedAt = at;
+      for (const scope of current.scopes.values()) {
+        scope.status = "ready";
+        scope.stateStartedAt = at;
+        scope.updatedAt = at;
+      }
+      refreshHookProjection(current, at);
       ctx.scheduleEmit();
     }
   }, HOOK_FRESH_TTL_MS);
@@ -193,9 +317,9 @@ export function newHookLayer(
     spawnedAt: at,
     stateStartedAt: at,
     status: "ready",
+    scopes: new Map(),
     subagentCount: 0,
     ttlTimer: null,
-    turnEnded: false,
     updatedAt: at,
     visibilityTimer: null,
     windowId: event.windowId,
@@ -254,39 +378,26 @@ export function newTaskLayer(
  * PermissionRequest 豁免吸收——权限弹窗是回合复活的证据。
  */
 export function applyTurnBookkeeping(
-  hook: HookLayer,
+  scope: HookScope,
   eventName: string
 ): boolean {
   if (TURN_BOUNDARY_EVENTS.has(eventName)) {
-    hook.turnEnded = true;
-    hook.subagentCount = 0;
+    scope.turnEnded = true;
+    scope.subagentCount = 0;
   } else if (TURN_RESET_EVENTS.has(eventName)) {
-    hook.turnEnded = false;
-    hook.subagentCount = 0;
+    scope.turnEnded = false;
+    scope.subagentCount = 0;
   } else if (eventName === "PermissionRequest") {
-    hook.turnEnded = false;
-  } else if (hook.turnEnded) {
+    scope.turnEnded = false;
+  } else if (scope.turnEnded) {
     return false;
   }
   if (eventName === "SubagentStart") {
-    hook.subagentCount += 1;
+    scope.subagentCount += 1;
   } else if (eventName === "SubagentStop") {
-    hook.subagentCount = Math.max(0, hook.subagentCount - 1);
+    scope.subagentCount = Math.max(0, scope.subagentCount - 1);
   }
   return true;
-}
-
-/** hook 层设置 status（同 status 内保 stateStartedAt 稳定）。 */
-export function setHookStatus(
-  hook: HookLayer,
-  status: ActivityStatus,
-  at: number
-): void {
-  if (hook.status !== status) {
-    hook.status = status;
-    hook.stateStartedAt = at;
-  }
-  hook.updatedAt = at;
 }
 
 /**

--- a/tests/unit/main/foreground-activity-aggregator.test.ts
+++ b/tests/unit/main/foreground-activity-aggregator.test.ts
@@ -21,6 +21,21 @@ function hookEvent(
   };
 }
 
+function agentHookEvent(
+  args: Partial<AgentHookEventPayload> & {
+    event: string;
+  }
+): AgentHookEventPayload {
+  return {
+    v: 1,
+    kind: "agentEvent",
+    agent: "claude",
+    panelId: "p1",
+    windowId: "1",
+    ...args,
+  };
+}
+
 describe("ForegroundActivityAggregator", () => {
   let clock = 0;
   const now = (): number => clock;
@@ -153,6 +168,104 @@ describe("ForegroundActivityAggregator", () => {
     agg.ingestAgentEvent(hookEvent("SessionStart"));
     advance(250);
     expect(agg.snapshot().activities).toHaveLength(1);
+    agg.dispose();
+  });
+
+  it("Pi 扩展运行时: 单个 pid SessionEnd 不清掉仍活跃的同 panel pid", () => {
+    const agg = createForegroundActivityAggregator({ now });
+    agg.ingestAgentEvent(
+      agentHookEvent({ agent: "pi", event: "SessionStart", pid: 1001 })
+    );
+    agg.ingestAgentEvent(
+      agentHookEvent({ agent: "pi", event: "PromptSubmit", pid: 1001 })
+    );
+    agg.ingestAgentEvent(
+      agentHookEvent({ agent: "pi", event: "SessionStart", pid: 1002 })
+    );
+    agg.ingestAgentEvent(
+      agentHookEvent({ agent: "pi", event: "PromptSubmit", pid: 1002 })
+    );
+    let a = agg.snapshot().activities[0] as AgentActivity;
+    expect(a.agentId).toBe("pi");
+    expect(a.status).toBe("processing");
+
+    agg.ingestAgentEvent(
+      agentHookEvent({ agent: "pi", event: "Stop", pid: 1001 })
+    );
+    agg.ingestAgentEvent(
+      agentHookEvent({ agent: "pi", event: "SessionEnd", pid: 1001 })
+    );
+    a = agg.snapshot().activities[0] as AgentActivity;
+    expect(a.agentId).toBe("pi");
+    expect(a.status).toBe("processing");
+
+    agg.ingestAgentEvent(
+      agentHookEvent({ agent: "pi", event: "Stop", pid: 1002 })
+    );
+    a = agg.snapshot().activities[0] as AgentActivity;
+    expect(a.status).toBe("ready");
+    agg.ingestAgentEvent(
+      agentHookEvent({ agent: "pi", event: "SessionEnd", pid: 1002 })
+    );
+    expect(agg.snapshot().activities).toHaveLength(0);
+    agg.dispose();
+  });
+
+  it("sessionId 优先于 pid: 结束一个 session 不清掉同 panel 另一个 session", () => {
+    const agg = createForegroundActivityAggregator({ now });
+    agg.ingestAgentEvent(
+      agentHookEvent({ event: "PromptSubmit", pid: 1001, sessionId: "s1" })
+    );
+    agg.ingestAgentEvent(
+      agentHookEvent({ event: "ToolStart", pid: 1002, sessionId: "s2" })
+    );
+    let a = agg.snapshot().activities[0] as AgentActivity;
+    expect(a.status).toBe("tool");
+
+    agg.ingestAgentEvent(
+      agentHookEvent({ event: "SessionEnd", pid: 1001, sessionId: "s1" })
+    );
+    a = agg.snapshot().activities[0] as AgentActivity;
+    expect(a.status).toBe("tool");
+
+    agg.ingestAgentEvent(
+      agentHookEvent({ event: "SessionEnd", pid: 1002, sessionId: "s2" })
+    );
+    expect(agg.snapshot().activities).toHaveLength(0);
+    agg.dispose();
+  });
+
+  it("Codex/Claude shell hook pid 不作为会话身份", () => {
+    const agg = createForegroundActivityAggregator({ now });
+    agg.ingestAgentEvent(
+      agentHookEvent({ agent: "codex", event: "PromptSubmit", pid: 2001 })
+    );
+    agg.ingestAgentEvent(
+      agentHookEvent({ agent: "codex", event: "Stop", pid: 2002 })
+    );
+    let a = agg.snapshot().activities[0] as AgentActivity;
+    expect(a.status).toBe("ready");
+
+    agg.ingestAgentEvent(
+      agentHookEvent({ agent: "codex", event: "ToolStart", pid: 2003 })
+    );
+    a = agg.snapshot().activities[0] as AgentActivity;
+    expect(a.status).toBe("tool");
+    agg.ingestAgentEvent(
+      agentHookEvent({ agent: "codex", event: "SessionEnd", pid: 2004 })
+    );
+    expect(agg.snapshot().activities).toHaveLength(0);
+    agg.dispose();
+  });
+
+  it("扩展运行时事件缺 pid 且无 sessionId 时回退到 panel 级收尾", () => {
+    const agg = createForegroundActivityAggregator({ now });
+    agg.ingestAgentEvent(
+      agentHookEvent({ agent: "pi", event: "PromptSubmit" })
+    );
+    expect(agg.snapshot().activities).toHaveLength(1);
+    agg.ingestAgentEvent(agentHookEvent({ agent: "pi", event: "SessionEnd" }));
+    expect(agg.snapshot().activities).toHaveLength(0);
     agg.dispose();
   });
 


### PR DESCRIPTION
## Summary
- Add scoped hook session aggregation so one child process/session ending does not clear active agent state for the whole panel.
- Prefer sessionId, use process pid only for runtime-extension integrations, and keep shell hook agents like Codex/Claude panel-scoped.
- Add regression coverage for Pi multi-pid, sessionId isolation, Codex pid handling, and fallback behavior.

## Test Plan
- pnpm typecheck
- pnpm depcruise
- pnpm check:file-size
- pnpm exec ultracite check src/main/services/foreground-activity/aggregator-hook-scopes.ts src/main/services/foreground-activity/entry.ts src/main/services/foreground-activity/aggregator.ts src/main/services/foreground-activity/aggregator-tracing.ts tests/unit/main/foreground-activity-aggregator.test.ts
- pnpm exec vitest run tests/unit/main/foreground-activity-aggregator.test.ts tests/unit/main/agent-hooks-install.test.ts
- pnpm test:unit