### PR TITLE
feat(terminal-debug): record EventRouterView routing decisions in a ring buffer

### DIFF
--- a/native/Sources/GhosttyBridge/GhosttyBridge.swift
+++ b/native/Sources/GhosttyBridge/GhosttyBridge.swift
@@ -52,6 +52,25 @@ final class EventRouterView: NSView {
     var targets: [String: Target] = [:]
     var webOverlayRects: [NSRect] = []
 
+    /// 路由决策 ring buffer — hitTest / routeKeyDown / routeRightMouseDown 的最近
+    /// N 次判定, 供 debug snapshot 事后诊断 "看得见但点不到 / 按键不响应" 类问题.
+    /// hitTest 在无 acceptsMouseMoved 场景下频率不高 (mouseDown / scrollWheel /
+    /// dragged), 上限 64 足以覆盖用户复现 bug 的最近数秒操作.
+    ///
+    /// `seq` 单调递增 (不复用), 供 renderer 做稳定 React key; 一段时间无事件时
+    /// UInt64 也够用几百年。绝不把用户按键的 raw chars 放进 payload —— 密码/凭据
+    /// 会随 debug snapshot 落 UI; 需要"按了什么"信息时只写 charsLen + mods。
+    private struct RouterDecisionRecord {
+        let capturedAt: TimeInterval
+        let kind: String
+        let payload: [String: Any]
+        let seq: UInt64
+    }
+    private var recentDecisions: [RouterDecisionRecord] = []
+    private let recentDecisionsLock = NSLock()
+    private var nextDecisionSeq: UInt64 = 0
+    private static let maxRecentDecisions = 64
+
     private weak var ownerWindow: NSWindow?
     private var keyMonitor: Any?
     private var mouseMonitor: Any?
@@ -134,12 +153,15 @@ final class EventRouterView: NSView {
         guard let sv = superview else { return nil }
         let local = convert(point, from: sv)
         if containsWebOverlay(local) {
+            recordHitTest(local: local, decision: "web-overlay", matchedPanelId: NSNull())
             return nil
         }
-        if let (_, target) = terminalTarget(at: local) {
+        if let (matchedPanelId, target) = terminalTarget(at: local) {
+            recordHitTest(local: local, decision: "terminal", matchedPanelId: matchedPanelId)
             let p = target.view.superview?.convert(point, from: sv) ?? point
             return target.view.hitTest(p)
         }
+        recordHitTest(local: local, decision: "miss", matchedPanelId: NSNull())
         return nil
     }
 
@@ -154,6 +176,70 @@ final class EventRouterView: NSView {
             }
         }
         return nil
+    }
+
+    private func recordDecision(kind: String, payload: [String: Any]) {
+        recentDecisionsLock.lock()
+        defer { recentDecisionsLock.unlock() }
+        let seq = nextDecisionSeq
+        nextDecisionSeq &+= 1
+        let record = RouterDecisionRecord(
+            capturedAt: Date().timeIntervalSince1970,
+            kind: kind,
+            payload: payload,
+            seq: seq
+        )
+        recentDecisions.append(record)
+        if recentDecisions.count > Self.maxRecentDecisions {
+            recentDecisions.removeFirst(recentDecisions.count - Self.maxRecentDecisions)
+        }
+    }
+
+    /// NaN / Infinity CGFloat 从 broken superview convert 溢出到 payload 会让
+    /// JSONSerialization.isValidJSONObject 全盘拒绝, jsonString 返回 "{}", 整个
+    /// debug snapshot 塌成空对象 —— 用一个 sanitize 保证坐标非有限时用 -1 兜底,
+    /// UI 上会看到明显异常值而不是无声消失。
+    private static func sanitizedCoordinate(_ value: CGFloat) -> Double {
+        let d = Double(value)
+        return d.isFinite ? d : -1
+    }
+
+    private func recordHitTest(local: NSPoint, decision: String, matchedPanelId: Any) {
+        recordDecision(kind: "hit-test", payload: [
+            "x": Self.sanitizedCoordinate(local.x),
+            "y": Self.sanitizedCoordinate(local.y),
+            "decision": decision,
+            "matchedPanelId": matchedPanelId,
+            "targetsCount": targets.count,
+            "webOverlayCount": webOverlayRects.count,
+        ])
+    }
+
+    private func recordRightMouse(local: NSPoint, decision: String, matchedPanelId: Any) {
+        recordDecision(kind: "right-mouse", payload: [
+            "x": Self.sanitizedCoordinate(local.x),
+            "y": Self.sanitizedCoordinate(local.y),
+            "decision": decision,
+            "matchedPanelId": matchedPanelId,
+        ])
+    }
+
+    /// Debug snapshot 出口: 导出最近路由决策序列, 供 renderer 侧 debug window 展示.
+    /// 顺序为 append 序 (旧 → 新); renderer 侧倒序即最新在顶.
+    ///
+    /// `seq` 用 Double 表达 (JSON 只有 number, UInt64 高位可能落 53 位精度外, 但一次
+    /// pier 会话内递增速度不会突破 2^53). renderer 用 seq 做 React key 保持行 identity.
+    func snapshotRecentDecisions() -> [[String: Any]] {
+        recentDecisionsLock.lock()
+        defer { recentDecisionsLock.unlock() }
+        return recentDecisions.map { record in
+            [
+                "at": record.capturedAt,
+                "kind": record.kind,
+                "payload": record.payload,
+                "seq": Double(record.seq),
+            ]
+        }
     }
 
     /// 在 setupWindow 后调用一次, 绑定 window 并安装 keyboard + mouse 监听.
@@ -282,15 +368,35 @@ final class EventRouterView: NSView {
     private func routeKeyDown(_ event: NSEvent) -> NSEvent? {
         guard let window = ownerWindow, event.window === window else { return event }
 
+        let state = GhosttyBridgeImpl.shared.stateFor(window: window)
+        let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        let chars = event.charactersIgnoringModifiers ?? ""
+        let activeTerminalPanelIdValue: Any =
+            state.activeTerminalPanelId.map { $0 as Any } ?? NSNull()
+
+        // 只写 charsLen 数字, 绝不写 raw chars: terminal-passthrough 分支覆盖 sudo
+        // 密码输入, ring buffer 落到 debug snapshot 会随 UI 明文暴露给任何打开
+        // pier.terminal.openDebugWindow 的人。mods + charsLen 已够诊断 "有键但去哪了"。
+        func record(_ decision: String) {
+            recordDecision(kind: "key-down", payload: [
+                "charsLen": chars.count,
+                "mods": Int(mods.rawValue),
+                "acceptsTerminalKeyboard": state.acceptsTerminalKeyboard,
+                "activeTerminalPanelId": activeTerminalPanelIdValue,
+                "decision": decision,
+            ])
+        }
+
         // Web keyboard target: 全 pass through. Web DOM 自然接所有 key
         // (含 ↑/↓/Enter/Cmd+A/Cmd+T 等). 不在此处拦截 Cmd+key — let web's
         // useKeyboardShortcuts 路径 1 (DOM keydown capture) 处理.
-        let state = GhosttyBridgeImpl.shared.stateFor(window: window)
-        guard state.acceptsTerminalKeyboard else { return event }
+        guard state.acceptsTerminalKeyboard else {
+            record("web-passthrough")
+            return event
+        }
 
         // Terminal mode: 只把运行时 allowlist 内的 Pier app 快捷键 forward 给 web
         // (路径 2 IPC), 其他组合全部 pass through 给 Ghostty.
-        let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
         let isCmd = mods.contains(.command)
 
         // macOS menu reserved keys (Cmd+Q/Cmd+H/Cmd+M/Cmd+Comma 等 role-bound items)
@@ -299,17 +405,21 @@ final class EventRouterView: NSView {
         // 永远 swallow 在 web forward 链 (web 没注册 → 静默 drop, 用户感受"Cmd+Q 失效").
         // 仅 Cmd 路径走 menu — menu items 全部都是 Cmd+... 修饰, Ctrl+Shift 不参与.
         if isCmd, NSApp.mainMenu?.performKeyEquivalent(with: event) == true {
+            record("menu-consumed")
             return nil
         }
 
-        guard let chars = event.charactersIgnoringModifiers, !chars.isEmpty else {
+        guard !chars.isEmpty else {
+            record("terminal-passthrough-no-chars")
             return passThroughToTerminal(window: window, event: event)
         }
         guard let shortcutKey = Self.terminalAppShortcutKey(modifierFlags: mods, chars: chars),
               Self.terminalAppShortcutKeys.contains(shortcutKey) else {
+            record("terminal-passthrough")
             return passThroughToTerminal(window: window, event: event)
         }
 
+        record("shortcut-forward")
         EventRouterView.forwardCmdKeyCallback?(browserWindowId, mods.rawValue, chars)
         return nil
     }
@@ -326,15 +436,18 @@ final class EventRouterView: NSView {
         // BrowserWindow contentView 一致, 可直接给 main 做 Menu.popup({x,y}).
         let local = self.convert(event.locationInWindow, from: nil)
         if containsWebOverlay(local) {
+            recordRightMouse(local: local, decision: "web-overlay", matchedPanelId: NSNull())
             return event
         }
         if let (panelId, _) = terminalTarget(at: local) {
+            recordRightMouse(local: local, decision: "terminal", matchedPanelId: panelId)
             TerminalContainerView.forwardFocusRequestCallback?(browserWindowId, panelId)
             EventRouterView.forwardRightMouseCallback?(
                 browserWindowId, panelId, Double(local.x), Double(local.y)
             )
             return nil  // 消费, 不让 terminal NSView 收到右键
         }
+        recordRightMouse(local: local, decision: "miss", matchedPanelId: NSNull())
         return event
     }
 
@@ -1526,11 +1639,13 @@ final class GhosttyBridgeImpl {
         )
     }
 
+    /// 失败时返回明确带 error 的对象 (而不是 "{}"), 让 main 侧 normalize 能识别
+    /// "整个 snapshot 序列化失败" 而不是把它当成 healthy-empty snapshot 静默展示。
     private static func jsonString(_ value: Any) -> String {
         guard JSONSerialization.isValidJSONObject(value),
               let data = try? JSONSerialization.data(withJSONObject: value, options: [.sortedKeys]),
               let json = String(data: data, encoding: .utf8) else {
-            return "{}"
+            return "{\"error\":\"native snapshot json serialization failed\"}"
         }
         return json
     }
@@ -1583,6 +1698,7 @@ final class GhosttyBridgeImpl {
             "lastAppliedNativeApplySequence": applyState?.lastAppliedNativeApplySequence ?? 0,
             "lastAppliedRendererSequence": applyState?.lastAppliedRendererSequence ?? 0,
             "lastPresentationReason": applyState?.lastPresentationReason ?? "",
+            "recentRouterDecisions": router?.snapshotRecentDecisions() ?? [],
             "staleDiscardCount": applyState?.staleDiscardCount ?? 0,
             "terminalTargetCount": router?.targets.count ?? 0,
             "webOverlayRectCount": router?.webOverlayRects.count ?? 0,

--- a/src/main/ipc/terminal-debug-snapshot.ts
+++ b/src/main/ipc/terminal-debug-snapshot.ts
@@ -1,4 +1,4 @@
-import type { TerminalDebugSnapshotArgs } from "@shared/contracts/terminal.ts";
+import type { TerminalDebugSnapshotArgs } from "@shared/contracts/terminal-debug.ts";
 import type { IpcMain } from "electron";
 import {
   findAppWindowByElectronId,

--- a/src/main/ipc/terminal-debug-window.ts
+++ b/src/main/ipc/terminal-debug-window.ts
@@ -1,5 +1,5 @@
 import { join } from "node:path";
-import type { TerminalDebugWindowOpenResult } from "@shared/contracts/terminal.ts";
+import type { TerminalDebugWindowOpenResult } from "@shared/contracts/terminal-debug.ts";
 import { BrowserWindow, type IpcMain } from "electron";
 import { isDevRuntime } from "../runtime-mode.ts";
 import { windowFromWebContents } from "./terminal.ts";

--- a/src/main/ipc/terminal-debug.ts
+++ b/src/main/ipc/terminal-debug.ts
@@ -1,13 +1,18 @@
 import type {
+  TerminalFrame,
+  TerminalKeyboardFocusTarget,
+} from "@shared/contracts/terminal.ts";
+import type {
   TerminalDebugEvent,
   TerminalDebugNativeSnapshot,
   TerminalDebugRendererSnapshot,
   TerminalDebugRendererSnapshotResult,
   TerminalDebugRoute,
+  TerminalDebugRouterDecision,
+  TerminalDebugRouterDecisionKind,
+  TerminalDebugRouterDecisionPayload,
   TerminalDebugSnapshot,
-  TerminalFrame,
-  TerminalKeyboardFocusTarget,
-} from "@shared/contracts/terminal.ts";
+} from "@shared/contracts/terminal-debug.ts";
 import { buildTerminalDebugIssues } from "@shared/terminal-debug-diagnostics.ts";
 import type { IpcMain, WebContents } from "electron";
 import type { AppWindow } from "../windows/app-window.ts";
@@ -89,6 +94,86 @@ function keyboardFocusTargetValue(value: unknown): TerminalKeyboardFocusTarget {
   return { kind: "web" };
 }
 
+const ROUTER_DECISION_KINDS: readonly TerminalDebugRouterDecisionKind[] = [
+  "hit-test",
+  "key-down",
+  "right-mouse",
+];
+
+function routerDecisionKind(
+  value: unknown
+): TerminalDebugRouterDecisionKind | null {
+  return typeof value === "string" &&
+    (ROUTER_DECISION_KINDS as readonly string[]).includes(value)
+    ? (value as TerminalDebugRouterDecisionKind)
+    : null;
+}
+
+/**
+ * Native ring buffer 把 panel id 存成 scoped key (`<browserWindowId>::<panelId>`),
+ * 但 debug window 的其他字段全走 fromNativePanelKey 展示为原始 id — 同一 panel 在
+ * 一个 UI 里以两种格式并排出现会让排错者误判为不同 panel. 这里把 payload 里已知
+ * 会承载 native panel key 的字段单独 demangle, 保持展示一致.
+ */
+const NATIVE_PANEL_KEY_PAYLOAD_FIELDS = new Set([
+  "matchedPanelId",
+  "activeTerminalPanelId",
+]);
+
+function routerDecisionPayload(
+  value: unknown
+): TerminalDebugRouterDecisionPayload {
+  const record = objectRecord(value);
+  if (!record) {
+    return {};
+  }
+  const payload: TerminalDebugRouterDecisionPayload = {};
+  for (const [key, raw] of Object.entries(record)) {
+    if (raw === null) {
+      payload[key] = null;
+    } else if (typeof raw === "boolean" || typeof raw === "number") {
+      payload[key] = raw;
+    } else if (typeof raw === "string") {
+      payload[key] = NATIVE_PANEL_KEY_PAYLOAD_FIELDS.has(key)
+        ? fromNativePanelKey(raw)
+        : raw;
+    }
+  }
+  return payload;
+}
+
+interface RouterDecisionsNormalizeResult {
+  decisions: TerminalDebugRouterDecision[];
+  droppedCount: number;
+}
+
+function routerDecisions(value: unknown): RouterDecisionsNormalizeResult {
+  if (!Array.isArray(value)) {
+    return { decisions: [], droppedCount: 0 };
+  }
+  const decisions: TerminalDebugRouterDecision[] = [];
+  let droppedCount = 0;
+  for (const entry of value) {
+    const record = objectRecord(entry);
+    if (!record) {
+      droppedCount += 1;
+      continue;
+    }
+    const kind = routerDecisionKind(record.kind);
+    if (!kind) {
+      droppedCount += 1;
+      continue;
+    }
+    decisions.push({
+      at: numberValue(record.at),
+      kind,
+      payload: routerDecisionPayload(record.payload),
+      seq: numberValue(record.seq),
+    });
+  }
+  return { decisions, droppedCount };
+}
+
 function frameValue(value: unknown): TerminalFrame {
   const record = objectRecord(value);
   return {
@@ -111,12 +196,28 @@ function normalizeNativeSnapshot(rawJson: string): TerminalDebugNativeSnapshot {
   if (!raw) {
     return emptyNativeSnapshot("native debug snapshot was not an object");
   }
+  // Swift jsonString 在 JSONSerialization 拒绝 payload 时会写 `{"error": "..."}`,
+  // 老实现返回 "{}" 会让 objectRecord({}) 通过, 后续所有字段落到默认值 0, error
+  // 保持 undefined, renderer 展示成一个 "0 targets / 0 web / no decisions" 的假
+  // healthy 状态。检测 error 字段以及 window/surfaces 缺失, 把它标成 error 并让
+  // banner 显式提示。
+  if (typeof raw.error === "string" && raw.error.length > 0) {
+    return emptyNativeSnapshot(raw.error);
+  }
+  if (!("window" in raw || "surfaces" in raw)) {
+    return emptyNativeSnapshot(
+      "native debug snapshot payload missing window/surfaces"
+    );
+  }
 
   const rawWindow = objectRecord(raw.window);
   const nativeActiveTerminalPanelId = stringValue(
     rawWindow?.activeTerminalPanelId
   );
   const rawSurfaces = Array.isArray(raw.surfaces) ? raw.surfaces : [];
+  const routerDecisionsResult = routerDecisions(
+    rawWindow?.recentRouterDecisions
+  );
   return {
     surfaces: rawSurfaces.flatMap((entry) => {
       const surface = objectRecord(entry);
@@ -172,6 +273,11 @@ function normalizeNativeSnapshot(rawJson: string): TerminalDebugNativeSnapshot {
           ? rawWindow.lastPresentationReason
           : undefined,
       nativeActiveTerminalPanelId,
+      recentRouterDecisions: routerDecisionsResult.decisions,
+      routerDecisionsDroppedCount:
+        routerDecisionsResult.droppedCount > 0
+          ? routerDecisionsResult.droppedCount
+          : undefined,
       staleDiscardCount:
         typeof rawWindow?.staleDiscardCount === "number"
           ? rawWindow.staleDiscardCount

--- a/src/main/ipc/terminal-presentation.ts
+++ b/src/main/ipc/terminal-presentation.ts
@@ -1,6 +1,4 @@
 import type {
-  TerminalDebugInputRoutingSnapshot,
-  TerminalDebugPresentationSnapshot,
   TerminalInputRoutingSnapshot,
   TerminalKeyboardFocusTarget,
   TerminalNativeInputRoutingSnapshot,
@@ -8,6 +6,10 @@ import type {
   TerminalPresentationReason,
   TerminalPresentationSnapshot,
 } from "@shared/contracts/terminal.ts";
+import type {
+  TerminalDebugInputRoutingSnapshot,
+  TerminalDebugPresentationSnapshot,
+} from "@shared/contracts/terminal-debug.ts";
 import { computeEffectiveKeyboardTarget } from "@shared/terminal-keyboard-target.ts";
 import type { AppWindow } from "../windows/app-window.ts";
 import type { NativeAddon } from "./terminal-native-addon.ts";

--- a/src/preload/terminal-api.ts
+++ b/src/preload/terminal-api.ts
@@ -1,8 +1,8 @@
+import type { TerminalAPI } from "@shared/contracts/terminal.ts";
 import type {
-  TerminalAPI,
   TerminalDebugRendererSnapshotRequest,
   TerminalDebugRendererSnapshotResult,
-} from "@shared/contracts/terminal.ts";
+} from "@shared/contracts/terminal-debug.ts";
 import { PIER_BROADCAST } from "@shared/ipc-channels.ts";
 import { ipcRenderer } from "electron";
 import { subscribeIpc } from "./ipc-envelope.ts";

--- a/src/renderer/components/common/terminal-debug-layout-view.tsx
+++ b/src/renderer/components/common/terminal-debug-layout-view.tsx
@@ -1,11 +1,13 @@
 import type {
+  TerminalFrame,
+  TerminalWebOverlayRect,
+} from "@shared/contracts/terminal.ts";
+import type {
   TerminalDebugIssue,
   TerminalDebugNativeSurfaceSnapshot,
   TerminalDebugRendererPanelSnapshot,
   TerminalDebugSnapshot,
-  TerminalFrame,
-  TerminalWebOverlayRect,
-} from "@shared/contracts/terminal.ts";
+} from "@shared/contracts/terminal-debug.ts";
 
 type LayoutState = "creating" | "hidden" | "missing" | "rendered";
 

--- a/src/renderer/components/common/terminal-debug-window.tsx
+++ b/src/renderer/components/common/terminal-debug-window.tsx
@@ -1,12 +1,15 @@
 import type {
   TerminalDebugEvent,
+  TerminalDebugRouterDecision,
+  TerminalDebugRouterDecisionPayload,
   TerminalDebugSnapshot,
-} from "@shared/contracts/terminal.ts";
+} from "@shared/contracts/terminal-debug.ts";
 import {
   Activity,
   Columns3,
   Crosshair,
   GitBranch,
+  ListTree,
   MonitorDot,
   MousePointer2,
   RefreshCw,
@@ -186,6 +189,145 @@ function HealthChip({ item }: { item: RouteHealth }) {
   );
 }
 
+function formatDecisionAge(at: number, nowSeconds: number): string {
+  // at=0 是 normalize 对缺失/非法字段的 fallback: 直接算差会得到 55 年级别的
+  // "N千万分钟前" 胡言, 视为未知即可; 超过一天视同 stale 也用 dash.
+  if (!Number.isFinite(at) || at <= 0) {
+    return "—";
+  }
+  const deltaSeconds = Math.max(0, nowSeconds - at);
+  if (deltaSeconds < 1) {
+    return `${Math.round(deltaSeconds * 1000)}ms ago`;
+  }
+  if (deltaSeconds < 60) {
+    return `${deltaSeconds.toFixed(1)}s ago`;
+  }
+  if (deltaSeconds < 3600) {
+    return `${Math.floor(deltaSeconds / 60)}m ago`;
+  }
+  if (deltaSeconds < 86_400) {
+    return `${Math.floor(deltaSeconds / 3600)}h ago`;
+  }
+  return "—";
+}
+
+function formatDecisionPayload(
+  payload: TerminalDebugRouterDecisionPayload
+): string {
+  return Object.entries(payload)
+    .map(([key, raw]) => {
+      if (raw === null) {
+        return `${key}=null`;
+      }
+      if (typeof raw === "number") {
+        // 坐标数值裁到 1 位小数, 长 float 字符串会挤爆行.
+        return `${key}=${Number.isInteger(raw) ? raw : raw.toFixed(1)}`;
+      }
+      // 字符串值走 JSON.stringify 加引号 + 转义: 未来若 payload 里出现空格/tab/
+      // 私区 unicode 的字符串, 空格 join 会把 `chars=" "` 变成两个模糊 token; 引号
+      // 让每个 pair 边界依旧可读。
+      return `${key}=${JSON.stringify(raw)}`;
+    })
+    .join(" ");
+}
+
+/**
+ * 决策是否指向 "看得见但点不到 / 按键不到 terminal" 的可疑路径, 用琥珀色高亮:
+ * - hit-test/right-mouse miss 或 web-overlay: 只有当此窗口存在 terminal target 时
+ *   才算可疑; 纯 web 页面点击也会命中 web-overlay, 那时应视为常态。
+ * - key-down web-passthrough: 仅当 activeTerminalPanelId != null (即 basePanel
+ *   已指向 terminal 但 key 却被路由到 web) 才算可疑; 否则是普通 web 输入。
+ * - key-down menu-consumed: 仅当 acceptsTerminalKeyboard === true (terminal 期待
+ *   接收 key 却被系统菜单吃掉) 才算可疑 —— 正好是 "按 Cmd+K 期望到 terminal 但
+ *   被 macOS menu 拦截" 的经典场景。
+ */
+function isSuspiciousDecision(decision: TerminalDebugRouterDecision): boolean {
+  const rawDecision = decision.payload.decision;
+  if (typeof rawDecision !== "string") {
+    return false;
+  }
+  if (decision.kind === "hit-test") {
+    if (rawDecision !== "miss" && rawDecision !== "web-overlay") {
+      return false;
+    }
+    const targetsCount = decision.payload.targetsCount;
+    return typeof targetsCount === "number" ? targetsCount > 0 : true;
+  }
+  if (decision.kind === "right-mouse") {
+    return rawDecision === "miss" || rawDecision === "web-overlay";
+  }
+  if (decision.kind === "key-down") {
+    if (rawDecision === "web-passthrough") {
+      return decision.payload.activeTerminalPanelId !== null;
+    }
+    if (rawDecision === "menu-consumed") {
+      return decision.payload.acceptsTerminalKeyboard === true;
+    }
+  }
+  return false;
+}
+
+function RouterDecisionsPanel({
+  decisions,
+  droppedCount,
+}: {
+  decisions: TerminalDebugRouterDecision[];
+  droppedCount: number;
+}) {
+  // debug window 每 750ms 拉一次 snapshot 触发 re-render, nowSeconds 顺带刷新;
+  // age 显示误差不超过一次 refresh interval, 对复盘足够。
+  const nowSeconds = Date.now() / 1000;
+  const orderedRecent = useMemo(() => decisions.slice().reverse(), [decisions]);
+  return (
+    <section className="flex min-h-0 shrink-0 flex-col border border-[#d0d0d0] bg-white">
+      <div className="flex h-9 shrink-0 items-center gap-2 border-[#d0d0d0] border-b bg-[#f3f3f3] px-3">
+        <ListTree className="size-4 text-[#6f6f6f]" />
+        <div className="font-semibold text-sm">Recent Router Decisions</div>
+        <div className="ml-auto text-[#6f6f6f] text-xs">
+          {decisions.length} / 64
+          {droppedCount > 0 ? (
+            <span className="ml-2 text-amber-700">
+              ({droppedCount} dropped)
+            </span>
+          ) : null}
+        </div>
+      </div>
+      <div className="max-h-64 min-h-0 overflow-auto">
+        {orderedRecent.length === 0 ? (
+          <div className="p-3 text-[#6f6f6f] text-xs">
+            No decisions yet — reproduce the issue (click, press a key, right
+            click) to populate.
+          </div>
+        ) : (
+          <ul className="divide-y divide-[#eaeaea]">
+            {orderedRecent.map((decision) => {
+              const suspicious = isSuspiciousDecision(decision);
+              return (
+                <li
+                  className={`flex flex-wrap gap-2 px-3 py-1.5 font-mono text-xs ${
+                    suspicious ? "bg-amber-50 text-amber-900" : "text-[#202124]"
+                  }`}
+                  key={decision.seq}
+                >
+                  <span className="shrink-0 text-[#6f6f6f]">
+                    {formatDecisionAge(decision.at, nowSeconds)}
+                  </span>
+                  <span className="shrink-0 font-semibold">
+                    {decision.kind}
+                  </span>
+                  <span className="min-w-0 flex-1 break-all">
+                    {formatDecisionPayload(decision.payload)}
+                  </span>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </section>
+  );
+}
+
 function RoutingStateView({
   snapshot,
 }: {
@@ -266,6 +408,10 @@ function RoutingStateView({
           ))}
         </div>
       </aside>
+      <RouterDecisionsPanel
+        decisions={snapshot?.native.window.recentRouterDecisions ?? []}
+        droppedCount={snapshot?.native.window.routerDecisionsDroppedCount ?? 0}
+      />
     </div>
   );
 }

--- a/src/renderer/lib/terminal-debug/renderer-snapshot.ts
+++ b/src/renderer/lib/terminal-debug/renderer-snapshot.ts
@@ -1,4 +1,4 @@
-import type { TerminalDebugRendererSnapshot } from "@shared/contracts/terminal.ts";
+import type { TerminalDebugRendererSnapshot } from "@shared/contracts/terminal-debug.ts";
 import {
   hasRegisteredTerminalAnchor,
   readRegisteredTerminalAnchorFrame,

--- a/src/renderer/panel-kits/terminal/terminal-lifecycle-debug.ts
+++ b/src/renderer/panel-kits/terminal/terminal-lifecycle-debug.ts
@@ -1,7 +1,7 @@
 import type {
   TerminalDebugRendererTerminalLifecycleSnapshot,
   TerminalDebugRendererTerminalPhase,
-} from "@shared/contracts/terminal.ts";
+} from "@shared/contracts/terminal-debug.ts";
 
 export type TerminalLifecycleDebugPatch = Partial<
   Omit<TerminalDebugRendererTerminalLifecycleSnapshot, "updatedAt">

--- a/src/shared/contracts/terminal-debug.ts
+++ b/src/shared/contracts/terminal-debug.ts
@@ -1,0 +1,212 @@
+import type {
+  TerminalFrame,
+  TerminalInputRoutingSnapshot,
+  TerminalKeyboardFocusTarget,
+  TerminalNativeInputRoutingSnapshot,
+  TerminalNativePresentationSnapshot,
+  TerminalPresentationSnapshot,
+} from "./terminal.ts";
+
+export interface TerminalDebugPresentationSnapshot {
+  desired?: TerminalPresentationSnapshot | undefined;
+  effective?: TerminalNativePresentationSnapshot | undefined;
+}
+
+export interface TerminalDebugInputRoutingSnapshot {
+  desired?: TerminalInputRoutingSnapshot | undefined;
+  effective?: TerminalNativeInputRoutingSnapshot | undefined;
+}
+
+export type TerminalDebugRoute =
+  | "renderer->main->native"
+  | "renderer->main->webContents"
+  | "native->main->renderer";
+
+export interface TerminalDebugEvent {
+  action: string;
+  at: string;
+  browserWindowId: number;
+  detail?: Record<string, boolean | number | string | null> | undefined;
+  id: number;
+  nativePanelId?: string | undefined;
+  panelId?: string | undefined;
+  route: TerminalDebugRoute;
+  windowId?: string | undefined;
+}
+
+export type TerminalDebugRouterDecisionKind =
+  | "hit-test"
+  | "key-down"
+  | "right-mouse";
+
+export type TerminalDebugRouterDecisionPayload = Record<
+  string,
+  boolean | number | string | null
+>;
+
+/**
+ * EventRouterView 每次 hitTest / keyDown / rightMouseDown 的一条判定记录, 由 native
+ * 侧 ring buffer 维护 (上限 64 条). 供 debug window 复盘 "看得见但点不到 / 按键不
+ * 到 terminal" 类问题 — 光看瞬时状态看不出事件流向哪里, 决策序列能定位是 hitTest
+ * miss 还是 basePanel 指错.
+ *
+ * `seq` 是 EventRouterView 实例内单调递增, 供 renderer 稳定 React key; ring buffer
+ * 逐出旧条时 seq 不复用, 保证跨 refresh 的行 identity 稳定.
+ */
+export interface TerminalDebugRouterDecision {
+  at: number;
+  kind: TerminalDebugRouterDecisionKind;
+  payload: TerminalDebugRouterDecisionPayload;
+  seq: number;
+}
+
+export interface TerminalDebugNativeWindowSnapshot {
+  activeTerminalPanelId: string | null;
+  inputRoutingStaleDiscardCount?: number | undefined;
+  keyboardFocusTarget: TerminalKeyboardFocusTarget;
+  lastAppliedInputRoutingSequence?: number | undefined;
+  lastAppliedNativeApplySequence?: number | undefined;
+  lastAppliedRendererSequence?: number | undefined;
+  lastPresentationReason?: string | undefined;
+  nativeActiveTerminalPanelId: string | null;
+  recentRouterDecisions?: TerminalDebugRouterDecision[] | undefined;
+  /**
+   * 未知 kind / 非 primitive payload 值被 normalize 静默丢弃的条数. UI 展示成 "N/64
+   * (M dropped)" 提醒 native 或 schema 已经跑偏; 否则用户会以为 ring buffer 就是空的.
+   */
+  routerDecisionsDroppedCount?: number | undefined;
+  staleDiscardCount?: number | undefined;
+  terminalTargetCount: number;
+  webOverlayRectCount: number;
+}
+
+export interface TerminalDebugNativeSurfaceSnapshot {
+  alpha: number;
+  browserWindowId: number;
+  cursorSuppressed?: boolean | undefined;
+  frame: TerminalFrame;
+  hasRouterTarget: boolean;
+  hostKeyboardActive?: boolean | undefined;
+  isFirstResponder: boolean;
+  isHidden: boolean;
+  isOffscreen: boolean;
+  isSurfaceFocused?: boolean | undefined;
+  nativePanelId: string;
+  panelId: string;
+  surfaceVisible?: boolean | undefined;
+  targetRect?: TerminalFrame | null | undefined;
+  viewportFrame?: TerminalFrame | null | undefined;
+}
+
+export interface TerminalDebugNativeSnapshot {
+  error?: string | undefined;
+  surfaces: TerminalDebugNativeSurfaceSnapshot[];
+  window: TerminalDebugNativeWindowSnapshot;
+}
+
+export type TerminalDebugIssueSeverity = "error" | "warning";
+
+export interface TerminalDebugIssue {
+  code:
+    | "duplicate_renderer_panel"
+    | "desired_frame_native_mismatch"
+    | "desired_hidden_native_visible"
+    | "desired_visible_native_hidden"
+    | "frame_mismatch"
+    | "input_routing_keyboard_first_responder_mismatch"
+    | "input_routing_keyboard_target_mismatch"
+    | "input_routing_overlay_rect_count_mismatch"
+    | "input_routing_stale"
+    | "input_routing_terminal_cursor_policy_mismatch"
+    | "input_routing_terminal_target_missing"
+    | "input_routing_terminal_surface_focus_mismatch"
+    | "native_hidden_while_anchor_visible"
+    | "native_missing"
+    | "orphan_native_surface"
+    | "presentation_stale"
+    | "renderer_terminal_create_pending"
+    | "renderer_terminal_lifecycle_missing"
+    | "renderer_terminal_placeholder_visible";
+  message: string;
+  panelId?: string | undefined;
+  severity: TerminalDebugIssueSeverity;
+}
+
+export type TerminalDebugRendererTerminalPhase =
+  | "creating"
+  | "disposed"
+  | "error"
+  | "mounted"
+  | "ready"
+  | "waiting_for_session"
+  | "waiting_for_anchor";
+
+export interface TerminalDebugRendererTerminalLifecycleSnapshot {
+  createAttemptCount: number;
+  createPending: boolean;
+  didCreateNativeTerminal: boolean;
+  error: string | null;
+  hasRenderableAnchor: boolean;
+  nativeTerminalReady: boolean;
+  phase: TerminalDebugRendererTerminalPhase;
+  placeholderVisible: boolean;
+  updatedAt: number;
+}
+
+export interface TerminalDebugRendererPanelSnapshot {
+  anchorFrame: TerminalFrame | null;
+  component: string;
+  dockviewActive: boolean;
+  dockviewVisible: boolean;
+  hasAnchor: boolean;
+  isActivePanel: boolean;
+  panelId: string;
+  resourceMode?:
+    | "coldSuspendedCandidate"
+    | "visible"
+    | "warmHidden"
+    | undefined;
+  terminalLifecycle?:
+    | TerminalDebugRendererTerminalLifecycleSnapshot
+    | undefined;
+}
+
+export interface TerminalDebugRendererSnapshot {
+  activePanelId: string | null;
+  desiredInputRouting?: TerminalInputRoutingSnapshot | undefined;
+  desiredPresentation?: TerminalPresentationSnapshot | undefined;
+  hasMaximizedGroup: boolean;
+  panelCount: number;
+  panels: TerminalDebugRendererPanelSnapshot[];
+  viewportFrame?: TerminalFrame | undefined;
+}
+
+export interface TerminalDebugRendererSnapshotRequest {
+  requestId: string;
+}
+
+export interface TerminalDebugRendererSnapshotResult {
+  error?: string | undefined;
+  ok: boolean;
+  renderer?: TerminalDebugRendererSnapshot | undefined;
+  requestId: string;
+}
+
+export interface TerminalDebugSnapshotArgs {
+  targetBrowserWindowId?: number | undefined;
+}
+
+export interface TerminalDebugSnapshot {
+  events: TerminalDebugEvent[];
+  inputRouting?: TerminalDebugInputRoutingSnapshot | undefined;
+  issues?: TerminalDebugIssue[] | undefined;
+  native: TerminalDebugNativeSnapshot;
+  presentation?: TerminalDebugPresentationSnapshot | undefined;
+  renderer?: TerminalDebugRendererSnapshot | undefined;
+}
+
+export interface TerminalDebugWindowOpenResult {
+  error?: string | undefined;
+  ok: boolean;
+  targetBrowserWindowId?: number | undefined;
+}

--- a/src/shared/contracts/terminal.ts
+++ b/src/shared/contracts/terminal.ts
@@ -1,6 +1,15 @@
 import type { AgentKind } from "./agent.ts";
 import type { PanelContext, PanelTabChrome } from "./panel.ts";
 import type { TaskPanelMetadata } from "./tasks.ts";
+// TerminalAPI 是终端 IPC 契约, 里面 debugSnapshot / openDebugWindow 等 debug 相关
+// 方法需要引用 debug schema. 仅 type-only 循环 import (tsc 会 erase), 不构成运行时环。
+import type {
+  TerminalDebugRendererSnapshot,
+  TerminalDebugRendererSnapshotRequest,
+  TerminalDebugSnapshot,
+  TerminalDebugSnapshotArgs,
+  TerminalDebugWindowOpenResult,
+} from "./terminal-debug.ts";
 import type { TerminalAgentRestoreLaunchOptions } from "./terminal-launch.ts";
 
 export interface TerminalFrame {
@@ -73,178 +82,6 @@ export interface TerminalNativePresentationSnapshot
   extends TerminalPresentationSnapshot {
   nativeApplySequence: number;
   windowFocused: boolean;
-}
-
-export interface TerminalDebugPresentationSnapshot {
-  desired?: TerminalPresentationSnapshot | undefined;
-  effective?: TerminalNativePresentationSnapshot | undefined;
-}
-
-export interface TerminalDebugInputRoutingSnapshot {
-  desired?: TerminalInputRoutingSnapshot | undefined;
-  effective?: TerminalNativeInputRoutingSnapshot | undefined;
-}
-
-export type TerminalDebugRoute =
-  | "renderer->main->native"
-  | "renderer->main->webContents"
-  | "native->main->renderer";
-
-export interface TerminalDebugEvent {
-  action: string;
-  at: string;
-  browserWindowId: number;
-  detail?: Record<string, boolean | number | string | null> | undefined;
-  id: number;
-  nativePanelId?: string | undefined;
-  panelId?: string | undefined;
-  route: TerminalDebugRoute;
-  windowId?: string | undefined;
-}
-
-export interface TerminalDebugNativeWindowSnapshot {
-  activeTerminalPanelId: string | null;
-  inputRoutingStaleDiscardCount?: number | undefined;
-  keyboardFocusTarget: TerminalKeyboardFocusTarget;
-  lastAppliedInputRoutingSequence?: number | undefined;
-  lastAppliedNativeApplySequence?: number | undefined;
-  lastAppliedRendererSequence?: number | undefined;
-  lastPresentationReason?: string | undefined;
-  nativeActiveTerminalPanelId: string | null;
-  staleDiscardCount?: number | undefined;
-  terminalTargetCount: number;
-  webOverlayRectCount: number;
-}
-
-export interface TerminalDebugNativeSurfaceSnapshot {
-  alpha: number;
-  browserWindowId: number;
-  cursorSuppressed?: boolean | undefined;
-  frame: TerminalFrame;
-  hasRouterTarget: boolean;
-  hostKeyboardActive?: boolean | undefined;
-  isFirstResponder: boolean;
-  isHidden: boolean;
-  isOffscreen: boolean;
-  isSurfaceFocused?: boolean | undefined;
-  nativePanelId: string;
-  panelId: string;
-  surfaceVisible?: boolean | undefined;
-  targetRect?: TerminalFrame | null | undefined;
-  viewportFrame?: TerminalFrame | null | undefined;
-}
-
-export interface TerminalDebugNativeSnapshot {
-  error?: string | undefined;
-  surfaces: TerminalDebugNativeSurfaceSnapshot[];
-  window: TerminalDebugNativeWindowSnapshot;
-}
-
-export type TerminalDebugIssueSeverity = "error" | "warning";
-
-export interface TerminalDebugIssue {
-  code:
-    | "duplicate_renderer_panel"
-    | "desired_frame_native_mismatch"
-    | "desired_hidden_native_visible"
-    | "desired_visible_native_hidden"
-    | "frame_mismatch"
-    | "input_routing_keyboard_first_responder_mismatch"
-    | "input_routing_keyboard_target_mismatch"
-    | "input_routing_overlay_rect_count_mismatch"
-    | "input_routing_stale"
-    | "input_routing_terminal_cursor_policy_mismatch"
-    | "input_routing_terminal_target_missing"
-    | "input_routing_terminal_surface_focus_mismatch"
-    | "native_hidden_while_anchor_visible"
-    | "native_missing"
-    | "orphan_native_surface"
-    | "presentation_stale"
-    | "renderer_terminal_create_pending"
-    | "renderer_terminal_lifecycle_missing"
-    | "renderer_terminal_placeholder_visible";
-  message: string;
-  panelId?: string | undefined;
-  severity: TerminalDebugIssueSeverity;
-}
-
-export type TerminalDebugRendererTerminalPhase =
-  | "creating"
-  | "disposed"
-  | "error"
-  | "mounted"
-  | "ready"
-  | "waiting_for_session"
-  | "waiting_for_anchor";
-
-export interface TerminalDebugRendererTerminalLifecycleSnapshot {
-  createAttemptCount: number;
-  createPending: boolean;
-  didCreateNativeTerminal: boolean;
-  error: string | null;
-  hasRenderableAnchor: boolean;
-  nativeTerminalReady: boolean;
-  phase: TerminalDebugRendererTerminalPhase;
-  placeholderVisible: boolean;
-  updatedAt: number;
-}
-
-export interface TerminalDebugRendererPanelSnapshot {
-  anchorFrame: TerminalFrame | null;
-  component: string;
-  dockviewActive: boolean;
-  dockviewVisible: boolean;
-  hasAnchor: boolean;
-  isActivePanel: boolean;
-  panelId: string;
-  resourceMode?:
-    | "coldSuspendedCandidate"
-    | "visible"
-    | "warmHidden"
-    | undefined;
-  terminalLifecycle?:
-    | TerminalDebugRendererTerminalLifecycleSnapshot
-    | undefined;
-}
-
-export interface TerminalDebugRendererSnapshot {
-  activePanelId: string | null;
-  desiredInputRouting?: TerminalInputRoutingSnapshot | undefined;
-  desiredPresentation?: TerminalPresentationSnapshot | undefined;
-  hasMaximizedGroup: boolean;
-  panelCount: number;
-  panels: TerminalDebugRendererPanelSnapshot[];
-  viewportFrame?: TerminalFrame | undefined;
-}
-
-export interface TerminalDebugRendererSnapshotRequest {
-  requestId: string;
-}
-
-export interface TerminalDebugRendererSnapshotResult {
-  error?: string | undefined;
-  ok: boolean;
-  renderer?: TerminalDebugRendererSnapshot | undefined;
-  requestId: string;
-}
-
-export interface TerminalDebugSnapshotArgs {
-  targetBrowserWindowId?: number | undefined;
-}
-
-export interface TerminalDebugSnapshot {
-  events: TerminalDebugEvent[];
-  inputRouting?: TerminalDebugInputRoutingSnapshot | undefined;
-  issues?: TerminalDebugIssue[] | undefined;
-  native: TerminalDebugNativeSnapshot;
-  presentation?: TerminalDebugPresentationSnapshot | undefined;
-  renderer?: TerminalDebugRendererSnapshot | undefined;
-}
-
-export interface TerminalDebugWindowOpenResult {
-  error?: string | undefined;
-  ok: boolean;
-  targetBrowserWindowId?: number | undefined;
 }
 
 /**

--- a/src/shared/terminal-debug-diagnostics.ts
+++ b/src/shared/terminal-debug-diagnostics.ts
@@ -1,14 +1,16 @@
 import type {
-  TerminalDebugInputRoutingSnapshot,
-  TerminalDebugIssue,
-  TerminalDebugNativeSnapshot,
-  TerminalDebugPresentationSnapshot,
-  TerminalDebugRendererSnapshot,
   TerminalFrame,
   TerminalInputRoutingSnapshot,
   TerminalPresentationEntry,
   TerminalPresentationSnapshot,
 } from "./contracts/terminal.ts";
+import type {
+  TerminalDebugInputRoutingSnapshot,
+  TerminalDebugIssue,
+  TerminalDebugNativeSnapshot,
+  TerminalDebugPresentationSnapshot,
+  TerminalDebugRendererSnapshot,
+} from "./contracts/terminal-debug.ts";
 import {
   computeEffectiveKeyboardTarget,
   sameKeyboardFocusTarget,

--- a/tests/unit/main/terminal-debug.test.ts
+++ b/tests/unit/main/terminal-debug.test.ts
@@ -186,4 +186,136 @@ describe("terminal native debug IPC", () => {
       ])
     );
   });
+
+  it("normalizes native recentRouterDecisions: demangles panel-id fields, preserves seq, tallies drops for unknown-kind / non-object entries", async () => {
+    const { fakeAddon, invokeHandlers, win } = await setupHarness();
+
+    fakeAddon.debugSnapshot.mockReturnValue(
+      JSON.stringify({
+        surfaces: [],
+        window: {
+          activeTerminalPanelId: null,
+          keyboardFocusTarget: { kind: "web" },
+          recentRouterDecisions: [
+            {
+              at: 1_700_000_000.5,
+              kind: "hit-test",
+              payload: {
+                decision: "terminal",
+                matchedPanelId: "7::terminal-1",
+                targetsCount: 2,
+                webOverlayCount: 1,
+                x: 123.5,
+                y: 456,
+              },
+              seq: 10,
+            },
+            {
+              at: 1_700_000_001,
+              kind: "key-down",
+              payload: {
+                acceptsTerminalKeyboard: true,
+                activeTerminalPanelId: "7::terminal-1",
+                charsLen: 1,
+                decision: "terminal-passthrough",
+                mods: 0,
+              },
+              seq: 11,
+            },
+            {
+              at: 1_700_000_002,
+              kind: "unknown-kind",
+              payload: {},
+              seq: 12,
+            },
+            "not-an-object",
+          ],
+          routerDecisionsDroppedCount: 0,
+          terminalTargetCount: 2,
+          webOverlayRectCount: 1,
+        },
+      })
+    );
+
+    const snapshot = (await invokeHandlers.get(
+      "pier:terminal:debug-snapshot"
+    )?.({ sender: win.webContents })) as {
+      native: {
+        window: {
+          recentRouterDecisions?: Array<{
+            at: number;
+            kind: string;
+            payload: Record<string, unknown>;
+            seq: number;
+          }>;
+          routerDecisionsDroppedCount?: number;
+        };
+      };
+    };
+
+    expect(snapshot.native.window.recentRouterDecisions).toEqual([
+      {
+        at: 1_700_000_000.5,
+        kind: "hit-test",
+        payload: {
+          decision: "terminal",
+          matchedPanelId: "terminal-1",
+          targetsCount: 2,
+          webOverlayCount: 1,
+          x: 123.5,
+          y: 456,
+        },
+        seq: 10,
+      },
+      {
+        at: 1_700_000_001,
+        kind: "key-down",
+        payload: {
+          acceptsTerminalKeyboard: true,
+          activeTerminalPanelId: "terminal-1",
+          charsLen: 1,
+          decision: "terminal-passthrough",
+          mods: 0,
+        },
+        seq: 11,
+      },
+    ]);
+    expect(snapshot.native.window.routerDecisionsDroppedCount).toBe(2);
+  });
+
+  it("surfaces the native error banner when the swift snapshot is a serialization-failure fallback", async () => {
+    const { fakeAddon, invokeHandlers, win } = await setupHarness();
+
+    fakeAddon.debugSnapshot.mockReturnValue(
+      JSON.stringify({
+        error: "native snapshot json serialization failed",
+      })
+    );
+
+    const snapshot = (await invokeHandlers.get(
+      "pier:terminal:debug-snapshot"
+    )?.({ sender: win.webContents })) as {
+      native: { error?: string };
+    };
+
+    expect(snapshot.native.error).toBe(
+      "native snapshot json serialization failed"
+    );
+  });
+
+  it("surfaces an error rather than a silent healthy snapshot when the native payload lacks window/surfaces", async () => {
+    const { fakeAddon, invokeHandlers, win } = await setupHarness();
+
+    fakeAddon.debugSnapshot.mockReturnValue("{}");
+
+    const snapshot = (await invokeHandlers.get(
+      "pier:terminal:debug-snapshot"
+    )?.({ sender: win.webContents })) as {
+      native: { error?: string };
+    };
+
+    expect(snapshot.native.error).toBe(
+      "native debug snapshot payload missing window/surfaces"
+    );
+  });
 });

--- a/tests/unit/native-terminal-debug-source.test.ts
+++ b/tests/unit/native-terminal-debug-source.test.ts
@@ -7,6 +7,7 @@ const GHOSTTY_BRIDGE_PATH = join(
   "native/Sources/GhosttyBridge/GhosttyBridge.swift"
 );
 const ADDON_PATH = join(process.cwd(), "native/src/addon.mm");
+const RAW_CHARS_PAYLOAD_RE = /"chars":\s*chars/;
 
 describe("native terminal debug bridge source", () => {
   it("exports a native debug snapshot through Swift and N-API", () => {
@@ -41,5 +42,45 @@ describe("native terminal debug bridge source", () => {
 
     expect(swift).toContain('"surfaceVisible"');
     expect(swift).toContain("term.surfaceVisible");
+  });
+
+  it("records EventRouterView routing decisions in a ring buffer surfaced via debug snapshot", () => {
+    const swift = readFileSync(GHOSTTY_BRIDGE_PATH, "utf8");
+
+    expect(swift).toContain('recordDecision(kind: "hit-test"');
+    expect(swift).toContain('recordDecision(kind: "key-down"');
+    expect(swift).toContain('recordDecision(kind: "right-mouse"');
+    // Ring buffer 出口到 debug snapshot: recordHitTest / recordRightMouse 覆盖三种
+    // 路由决策 (web-overlay / terminal / miss), snapshotRecentDecisions 由
+    // debugSnapshot 装进 recentRouterDecisions 字段.
+    expect(swift).toContain("recordHitTest(");
+    expect(swift).toContain("recordRightMouse(");
+    expect(swift).toContain("snapshotRecentDecisions()");
+    expect(swift).toContain('"recentRouterDecisions"');
+  });
+
+  it("redacts raw keystrokes and stamps decision records with a monotonic seq", () => {
+    const swift = readFileSync(GHOSTTY_BRIDGE_PATH, "utf8");
+
+    // Raw `chars` 绝不能进 payload — sudo 密码等敏感输入会随 debug snapshot 泄漏。
+    expect(swift).toContain('"charsLen": chars.count');
+    expect(swift).not.toMatch(RAW_CHARS_PAYLOAD_RE);
+    // seq 单调递增, snapshot 出口暴露给 renderer 做稳定 React key。
+    expect(swift).toContain("nextDecisionSeq");
+    expect(swift).toContain("nextDecisionSeq &+= 1");
+    expect(swift).toContain('"seq": Double(record.seq)');
+  });
+
+  it("guards non-finite coordinates and returns an error-tagged json string instead of empty '{}' when serialization fails", () => {
+    const swift = readFileSync(GHOSTTY_BRIDGE_PATH, "utf8");
+
+    // NaN / Infinity CGFloat 会让 JSONSerialization 拒绝整个 payload; 用有限性
+    // sanitizer 拦一次, 让坏坐标以 -1 明显出现在 UI 而不是塌成 "{}".
+    expect(swift).toContain("sanitizedCoordinate(");
+    expect(swift).toContain("d.isFinite ? d : -1");
+    // jsonString 失败时输出的兜底串必须带 error 字段, 供 normalize 识别。
+    expect(swift).toContain(
+      '{\\"error\\":\\"native snapshot json serialization failed\\"}'
+    );
   });
 });

--- a/tests/unit/native-terminal-state-invariants.test.ts
+++ b/tests/unit/native-terminal-state-invariants.test.ts
@@ -49,10 +49,12 @@ const CLOSE_CLEARS_STALE_STATE_RE =
 const TARGETS_DICT_RE = /var targets: \[String: Target\]/;
 const HIT_ITERATES_TARGETS_RE =
   /for \(panelId, target\) in targets \{[\s\S]*?target\.rect\.contains/;
+// 窗口容纳一行 recordHitTest / recordRightMouse 日志调用; 关键不变量 ——
+// containsWebOverlay 检查必须在 terminalTarget 之前 —— 仍被这个非贪婪匹配序列锁死.
 const HIT_TEST_WEB_OVERLAY_FIRST_RE =
-  /if containsWebOverlay\(local\) \{[\s\S]{0,80}?return nil[\s\S]{0,160}?terminalTarget\(at: local\)/;
+  /if containsWebOverlay\(local\) \{[\s\S]{0,160}?return nil[\s\S]{0,240}?terminalTarget\(at: local\)/;
 const RIGHT_MOUSE_WEB_OVERLAY_FIRST_RE =
-  /if containsWebOverlay\(local\) \{[\s\S]{0,80}?return event[\s\S]{0,160}?terminalTarget\(at: local\)/;
+  /if containsWebOverlay\(local\) \{[\s\S]{0,160}?return event[\s\S]{0,240}?terminalTarget\(at: local\)/;
 const FORBIDDEN_HIDE_GUARD_RE =
   /guard panelId != activePanelId else \{ return \}/;
 const FORBIDDEN_GLOBAL_ACTIVE_PANEL_ID_RE =


### PR DESCRIPTION
## 背景

排查「看得见但点不到 / 按键不到 terminal」类问题时, 现有 debug snapshot 只给到瞬时状态(哪些 target rect、当前 basePanel 等), 看不出鼠标 / 按键事件到底路由到了哪个决策分支。本 PR 加一份 per-EventRouterView 的最近 64 条决策 ring buffer, 把 hitTest / routeKeyDown / routeRightMouseDown 的判定过程留下, 通过 debug snapshot 传到 renderer 的 Routing view 展示, 复现现场时能事后回放。

## 主要改动

**Native (`GhosttyBridge.swift`)**
- `EventRouterView` 新增 `recentDecisions` 环形缓冲(上限 64), 三条 helper (`recordHitTest` / `recordRightMouse` / 内联 `record` closure)
- keyDown 只写 `charsLen` (数字长度) 不写 raw `chars` — 防 sudo 密码等敏感输入随 debug snapshot 落 UI
- 坐标经 `sanitizedCoordinate` 过滤 `NaN` / `Infinity`, 避免整包被 `JSONSerialization.isValidJSONObject` 拒绝而塌成 `\"{}\"`
- `jsonString` 失败时返回 `{\"error\":\"...\"}` 而不是 `\"{}\"`, 让 UI 能识别序列化失败
- 单调递增 `seq: UInt64` 供 renderer 做稳定 React key

**Main normalize (`terminal-debug.ts`)**
- `routerDecisionPayload` 对 `matchedPanelId` / `activeTerminalPanelId` 走 `fromNativePanelKey`, 与 snapshot 其他 panel-id 字段保持同一格式
- `routerDecisions` 累计 `droppedCount` (未知 kind / non-primitive payload), 通过 `routerDecisionsDroppedCount` 上报, UI 展示 `(N dropped)` 徽章
- `normalizeNativeSnapshot` 检测 `raw.error` 与缺失 `window`/`surfaces` 的空 snapshot, 转成 error banner 而不是假 healthy 视图

**Renderer UI (`terminal-debug-window.tsx`)**
- Routing view 加 `Recent Router Decisions` 面板(最新在顶, kind + payload + 相对时间)
- `isSuspiciousDecision` 按 kind + payload 精细判定: hit-test miss / web-overlay 仅在 targetsCount>0 时琥珀高亮; key-down web-passthrough 仅在 activeTerminalPanelId != null 时琥珀; key-down menu-consumed 仅在 acceptsTerminalKeyboard=true 时琥珀
- string payload 走 `JSON.stringify` 加引号避免空格 / 控制字符破坏 key=value 边界
- age 加 h 档 + 对 at=0 / 非有限值显示 `—` 避免「28833333m ago」类胡言
- React key 换成 native 侧 `seq`

**Shared schema**
- `TerminalDebug*` 类型整体拆到独立 `src/shared/contracts/terminal-debug.ts`, `terminal.ts` 回到 500 行硬 cap 之下
- 20 处 import 站点同步更新

**Tests**
- `tests/unit/main/terminal-debug.test.ts`: 新增 payload panel-id demangle / droppedCount / 空 snapshot / error 兜底覆盖
- `tests/unit/native-terminal-debug-source.test.ts`: 断言 chars redact / NaN guard / seq / jsonString error 兜底
- `tests/unit/native-terminal-state-invariants.test.ts`: hit-test 正则窗口放宽容纳 recordHitTest helper 一行

## 使用方式

Bug 现场:
1. 保持 pier 不关
2. 命令面板运行 `Open Terminal Debug Window`
3. 切到 `Routing` tab, 看底部 `Recent Router Decisions`
4. 点 / 按键 / 滚动卡住的 panel
5. 观察决策序列 — 一句话可以定位根因:
   - \`hit-test decision=miss\` → 点击落空, targetRect 陈旧
   - \`hit-test decision=web-overlay\` → web overlay 覆盖了 terminal 区
   - \`key-down decision=web-passthrough activeTerminalPanelId=...\` → basePanel 没同步过来
   - \`key-down decision=menu-consumed\` → 被 macOS 菜单拦截

## 测试

- \`pnpm check\` 全绿(typecheck + lint + depcruise + file-size + 2564 unit tests + 242 component tests)
- 未在真实 pier binary 里跑 — 该分支需要重新打包才在实际 UI 生效

## 已知非目标

- 这次仅加日志能力, **不修**原始「看得见但点不到」bug 本身(用户跑的 pier binary 不含改动, 用户会在下次复现时用新 debug window 采集根因)

🤖 Generated with [Claude Code](https://claude.com/claude-code)