### PR TITLE
fix: AI one-shot agent fallback and tooltip dismiss

### DIFF
--- a/packages/ui/src/tooltip.tsx
+++ b/packages/ui/src/tooltip.tsx
@@ -1,15 +1,113 @@
 import { Tooltip as TooltipPrimitive } from "radix-ui";
 import { useComposedRefs } from "radix-ui/internal";
-import type * as React from "react";
+import * as React from "react";
 
 import { useTerminalOverlay } from "./use-terminal-overlay.tsx";
 import { cn } from "./utils.ts";
+
+type DismissListener = () => void;
+
+const dismissListeners = new Set<DismissListener>();
+let hardSuppressCount = 0;
+let softSuppressed = false;
+let pointerMoveReleaseArmed = false;
+let globalListenersInstalled = false;
+
+function isTooltipSuppressed(): boolean {
+  return hardSuppressCount > 0 || softSuppressed;
+}
+
+function notifyDismissListeners(): void {
+  for (const listener of dismissListeners) {
+    listener();
+  }
+}
+
+function armPointerMoveRelease(): void {
+  if (pointerMoveReleaseArmed || typeof document === "undefined") {
+    return;
+  }
+  pointerMoveReleaseArmed = true;
+  const release = () => {
+    pointerMoveReleaseArmed = false;
+    softSuppressed = false;
+  };
+  document.addEventListener("pointermove", release, {
+    capture: true,
+    once: true,
+  });
+}
+
+/**
+ * 关闭所有已打开的 tooltip, 并 soft-suppress 到下一次 pointermove.
+ * soft-suppress 用来吞掉 Radix delay timer 在 dismiss 之后迟到的 open.
+ */
+function dismissAllTooltips(): void {
+  softSuppressed = true;
+  notifyDismissListeners();
+  armPointerMoveRelease();
+}
+
+/**
+ * 硬抑制窗口 (可重入): 用于原生菜单等会夺走 pointer 事件流的场景.
+ * 配对调用 releaseTooltipSuppression.
+ */
+function suppressTooltips(): void {
+  hardSuppressCount += 1;
+  softSuppressed = true;
+  notifyDismissListeners();
+}
+
+function releaseTooltipSuppression(): void {
+  hardSuppressCount = Math.max(0, hardSuppressCount - 1);
+  if (hardSuppressCount === 0 && !pointerMoveReleaseArmed) {
+    // 菜单关闭后若指针仍停在 trigger 上, 保持 soft suppress 直到 pointermove,
+    // 避免菜单关闭瞬间立刻被残留 hover 重新打开.
+    softSuppressed = true;
+    armPointerMoveRelease();
+  }
+}
+
+function subscribeTooltipDismiss(listener: DismissListener): () => void {
+  dismissListeners.add(listener);
+  return () => {
+    dismissListeners.delete(listener);
+  };
+}
+
+function ensureGlobalDismissListeners(): void {
+  if (globalListenersInstalled || typeof document === "undefined") {
+    return;
+  }
+  globalListenersInstalled = true;
+
+  const onDismissSignal = () => {
+    dismissAllTooltips();
+  };
+
+  document.addEventListener("pointerdown", onDismissSignal, true);
+  document.addEventListener("keydown", onDismissSignal, true);
+  document.addEventListener("dragstart", onDismissSignal, true);
+  window.addEventListener("blur", onDismissSignal);
+}
+
+/** 测试用: 清掉 suppress / listener 状态, 不卸载 document 监听 (jsdom 生命周期内复用). */
+function resetTooltipDismissStateForTests(): void {
+  hardSuppressCount = 0;
+  softSuppressed = false;
+  pointerMoveReleaseArmed = false;
+  dismissListeners.clear();
+}
 
 function TooltipProvider({
   delayDuration = 0,
   disableHoverableContent = true,
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+  React.useEffect(() => {
+    ensureGlobalDismissListeners();
+  }, []);
+
   return (
     <TooltipPrimitive.Provider
       data-slot="tooltip-provider"
@@ -21,9 +119,47 @@ function TooltipProvider({
 }
 
 function Tooltip({
+  defaultOpen = false,
+  onOpenChange,
+  open: openProp,
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Root>) {
-  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />;
+  const [uncontrolledOpen, setUncontrolledOpen] = React.useState(defaultOpen);
+  const isControlled = openProp !== undefined;
+  const open = isControlled ? openProp : uncontrolledOpen;
+
+  React.useEffect(
+    () =>
+      subscribeTooltipDismiss(() => {
+        if (!isControlled) {
+          setUncontrolledOpen(false);
+        }
+        onOpenChange?.(false);
+      }),
+    [isControlled, onOpenChange]
+  );
+
+  const handleOpenChange = React.useCallback(
+    (next: boolean) => {
+      if (next && isTooltipSuppressed()) {
+        return;
+      }
+      if (!isControlled) {
+        setUncontrolledOpen(next);
+      }
+      onOpenChange?.(next);
+    },
+    [isControlled, onOpenChange]
+  );
+
+  return (
+    <TooltipPrimitive.Root
+      data-slot="tooltip"
+      {...props}
+      onOpenChange={handleOpenChange}
+      open={open}
+    />
+  );
 }
 
 function TooltipTrigger({
@@ -70,4 +206,13 @@ function TooltipContent({
   );
 }
 
-export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger };
+export {
+  dismissAllTooltips,
+  releaseTooltipSuppression,
+  resetTooltipDismissStateForTests,
+  suppressTooltips,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+};

--- a/src/main/services/ai/ai-service.ts
+++ b/src/main/services/ai/ai-service.ts
@@ -1,7 +1,7 @@
 import { execFile } from "node:child_process";
 import { tmpdir } from "node:os";
 import { getAgentCatalogEntry } from "@shared/agent-catalog.ts";
-import { pickAgent } from "@shared/agent-selection.ts";
+import { AGENT_AUTO_PICK_ORDER, pickAgent } from "@shared/agent-selection.ts";
 import type { AgentKind } from "@shared/contracts/agent.ts";
 import type {
   AiGenerateTextRequest,
@@ -49,6 +49,8 @@ export interface RunOneShotOptions {
 
 const DEFAULT_TIMEOUT_MS = 45_000;
 const MAX_STDOUT_BYTES = 4 * 1024 * 1024;
+/** one-shot 失败后最多再试几个 agent（含首选，合计上限）。 */
+const MAX_ONE_SHOT_ATTEMPTS = 3;
 
 function oneShotCwd(projectRootPath: string | undefined): string {
   return projectRootPath?.trim() || tmpdir();
@@ -91,17 +93,66 @@ export function defaultRunOneShot(
   });
 }
 
+function oneShotEligible(
+  preferences: ProjectPreferences,
+  detected: readonly AgentKind[]
+): AgentKind[] {
+  const det = new Set(detected.filter((id) => supportsOneShot(id)));
+  const dis = new Set(preferences.disabledAgentIds);
+  return AGENT_AUTO_PICK_ORDER.filter((id) => det.has(id) && !dis.has(id));
+}
+
 /** 与 New Agent 一致:优先 defaultAgentId,否则按 AGENT_AUTO_PICK_ORDER 兜底;仅保留支持 one-shot 的。 */
 function resolveOneShotAgent(
   preferences: ProjectPreferences,
   detected: readonly AgentKind[]
 ): AgentKind | null {
-  const oneShotDetected = detected.filter((id) => supportsOneShot(id));
   return pickAgent(
     preferences.defaultAgentId,
-    oneShotDetected,
+    detected.filter((id) => supportsOneShot(id)),
     preferences.disabledAgentIds
   );
+}
+
+/**
+ * 生成候选链：默认 agent（若可用）置首，其余按 auto-pick 顺序补足，去重后截断到上限。
+ */
+function resolveOneShotFallbackChain(
+  preferences: ProjectPreferences,
+  detected: readonly AgentKind[]
+): AgentKind[] {
+  const eligible = oneShotEligible(preferences, detected);
+  if (eligible.length === 0) {
+    return [];
+  }
+  const preferred = preferences.defaultAgentId;
+  const ordered: AgentKind[] = [];
+  if (preferred && preferred !== "blank" && eligible.includes(preferred)) {
+    ordered.push(preferred);
+  }
+  for (const id of eligible) {
+    if (!ordered.includes(id)) {
+      ordered.push(id);
+    }
+  }
+  return ordered.slice(0, MAX_ONE_SHOT_ATTEMPTS);
+}
+
+function failureResult(
+  err: unknown
+): Extract<AiGenerateTextResult, { status: "unavailable" }> {
+  if (err instanceof AgentRunError) {
+    return {
+      message: err.message,
+      reason: err.kind === "timeout" ? "timeout" : "request_failed",
+      status: "unavailable",
+    };
+  }
+  return {
+    message: err instanceof Error ? err.message : String(err),
+    reason: "request_failed",
+    status: "unavailable",
+  };
 }
 
 export function createAiService({
@@ -110,21 +161,24 @@ export function createAiService({
   runOneShot = defaultRunOneShot,
   timeoutMs = DEFAULT_TIMEOUT_MS,
 }: CreateAiServiceOptions): AiService {
-  async function resolveAgent(): Promise<{
-    agent: AgentKind | null;
+  async function resolveContext(): Promise<{
+    agents: AgentKind[];
     preferences: ProjectPreferences;
   }> {
     const [preferences, detected] = await Promise.all([
       readPreferences(),
       detectAgents(),
     ]);
-    return { agent: resolveOneShotAgent(preferences, detected), preferences };
+    return {
+      agents: resolveOneShotFallbackChain(preferences, detected),
+      preferences,
+    };
   }
 
   return {
     async generateText(request) {
-      const { agent, preferences } = await resolveAgent();
-      if (!agent) {
+      const { agents, preferences } = await resolveContext();
+      if (agents.length === 0) {
         return {
           message: "no detected agent supports one-shot generation",
           reason: "not_configured",
@@ -132,44 +186,53 @@ export function createAiService({
         };
       }
       const cwd = oneShotCwd(request.projectRootPath);
-      const invocation = resolveOneShotInvocation({
-        agentId: agent,
-        cwd,
-        override: preferences.agentCommandOverrides[agent],
-        agentDefaultArgs: preferences.agentDefaultArgs,
-        agentPermissionMode: preferences.agentPermissionMode,
-        prompt: request.prompt,
-      });
-      if (!invocation) {
-        return {
-          message: `agent ${agent} has no one-shot command`,
-          reason: "not_configured",
-          status: "unavailable",
-        };
-      }
-      try {
-        const text = await runOneShot(invocation.binary, invocation.args, {
+      let lastFailure: Extract<
+        AiGenerateTextResult,
+        { status: "unavailable" }
+      > | null = null;
+
+      for (const agent of agents) {
+        const invocation = resolveOneShotInvocation({
+          agentId: agent,
           cwd,
-          timeoutMs,
+          override: preferences.agentCommandOverrides[agent],
+          agentDefaultArgs: preferences.agentDefaultArgs,
+          agentPermissionMode: preferences.agentPermissionMode,
+          prompt: request.prompt,
         });
-        return { status: "ok", text };
-      } catch (err) {
-        if (err instanceof AgentRunError) {
-          return {
-            message: err.message,
-            reason: err.kind === "timeout" ? "timeout" : "request_failed",
+        if (!invocation) {
+          lastFailure = {
+            message: `agent ${agent} has no one-shot command`,
+            reason: "not_configured",
             status: "unavailable",
           };
+          continue;
         }
-        return {
-          message: err instanceof Error ? err.message : String(err),
-          reason: "request_failed",
-          status: "unavailable",
-        };
+        try {
+          const text = await runOneShot(invocation.binary, invocation.args, {
+            cwd,
+            timeoutMs,
+          });
+          return { status: "ok", text };
+        } catch (err) {
+          lastFailure = failureResult(err);
+        }
       }
+
+      return (
+        lastFailure ?? {
+          message: "no detected agent supports one-shot generation",
+          reason: "not_configured",
+          status: "unavailable",
+        }
+      );
     },
     async status() {
-      const { agent } = await resolveAgent();
+      const [preferences, detected] = await Promise.all([
+        readPreferences(),
+        detectAgents(),
+      ]);
+      const agent = resolveOneShotAgent(preferences, detected);
       return {
         agent,
         configured: agent !== null,

--- a/src/renderer/components/workspace/workspace-host.tsx
+++ b/src/renderer/components/workspace/workspace-host.tsx
@@ -9,7 +9,7 @@ import {
   useSyncExternalStore,
 } from "react";
 import "dockview-react/dist/styles/dockview.css";
-import { TooltipProvider } from "@pier/ui/tooltip.tsx";
+import { dismissAllTooltips, TooltipProvider } from "@pier/ui/tooltip.tsx";
 import {
   getPluginPanelRevision,
   setPluginPanelCloser,
@@ -359,6 +359,9 @@ export function WorkspaceHost() {
           });
         }
         descriptorStore.setActive(panel?.id ?? null);
+
+        // 程序化切 tab / 关闭面板等路径指针未必移动, 主动收掉残留 tooltip.
+        dismissAllTooltips();
 
         syncActivePanelScope(panel);
         syncTerminalPresentation(event.api, "dockview-active-panel");

--- a/src/renderer/lib/context-menu/use-context-menu.ts
+++ b/src/renderer/lib/context-menu/use-context-menu.ts
@@ -8,6 +8,10 @@
  *
  * Phase 1 的 actions 都用 store.getState() 读 active panel 决策, 不需传 args.
  */
+import {
+  releaseTooltipSuppression,
+  suppressTooltips,
+} from "@pier/ui/tooltip.tsx";
 import { type MouseEvent, useCallback } from "react";
 import { actionRegistry } from "@/lib/actions/registry.ts";
 import type { ActionInvocation } from "@/lib/actions/types.ts";
@@ -78,35 +82,43 @@ async function popupAndDispatch(
     return;
   }
 
-  const result = await window.pier.menu
-    .popup(template, coords)
-    .catch((err: unknown) => {
-      console.error(`[menu] popup ${surface} failed:`, err);
-      return null;
-    });
-  if (!result?.actionId) {
-    return;
-  }
-
-  const action = actionRegistry.get(result.actionId);
-  if (!action) {
-    console.warn(
-      `[menu] action ${result.actionId} not found (registered after menu open?)`
-    );
-    return;
-  }
+  // 原生 Menu.popup 会夺走 pointer 事件流; Radix tooltip 的 delay timer 仍可能
+  // 在菜单打开后 fire. 硬抑制覆盖整个 popup 生命周期, 关闭后 soft-suppress
+  // 到下一次 pointermove (见 @pier/ui/tooltip).
+  suppressTooltips();
   try {
-    if (action.enabled?.() === false) {
+    const result = await window.pier.menu
+      .popup(template, coords)
+      .catch((err: unknown) => {
+        console.error(`[menu] popup ${surface} failed:`, err);
+        return null;
+      });
+    if (!result?.actionId) {
       return;
     }
-  } catch (err) {
-    console.error(`[menu] action ${result.actionId} enabled() threw:`, err);
-    return;
-  }
 
-  await Promise.resolve(action.handler({ ...invocation, surface })).catch(
-    (err: unknown) => {
-      console.error(`[menu] action ${result.actionId} threw:`, err);
+    const action = actionRegistry.get(result.actionId);
+    if (!action) {
+      console.warn(
+        `[menu] action ${result.actionId} not found (registered after menu open?)`
+      );
+      return;
     }
-  );
+    try {
+      if (action.enabled?.() === false) {
+        return;
+      }
+    } catch (err) {
+      console.error(`[menu] action ${result.actionId} enabled() threw:`, err);
+      return;
+    }
+
+    await Promise.resolve(action.handler({ ...invocation, surface })).catch(
+      (err: unknown) => {
+        console.error(`[menu] action ${result.actionId} threw:`, err);
+      }
+    );
+  } finally {
+    releaseTooltipSuppression();
+  }
 }

--- a/src/shared/contracts/ai.ts
+++ b/src/shared/contracts/ai.ts
@@ -1,7 +1,8 @@
 /**
  * AI 服务契约:main 进程复用本机已安装的 CLI agent(claude/codex/gemini 等)
  * 做一次性文本生成,renderer/插件只发任务级命令。
- * 结果统一用 status 区分成功/不可用,失败不抛异常 —— 调用方可静默降级。
+ * generateText 失败时按 auto-pick 顺序 fallback 下一个 agent,最多尝试 3 个;
+ * 全部失败或无可试 agent 才返回 unavailable。失败不抛异常 —— 调用方可静默降级。
  */
 import { z } from "zod";
 import { agentKindSchema } from "./agent.ts";

--- a/tests/component/tooltip.test.tsx
+++ b/tests/component/tooltip.test.tsx
@@ -1,10 +1,14 @@
 import {
+  dismissAllTooltips,
+  releaseTooltipSuppression,
+  resetTooltipDismissStateForTests,
+  suppressTooltips,
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
 } from "@pier/ui/tooltip.tsx";
-import { render, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 function findTooltipContent(): Promise<HTMLElement> {
@@ -12,6 +16,12 @@ function findTooltipContent(): Promise<HTMLElement> {
     const content = document.querySelector('[data-slot="tooltip-content"]');
     expect(content).not.toBeNull();
     return content as HTMLElement;
+  });
+}
+
+async function expectTooltipClosed(): Promise<void> {
+  await waitFor(() => {
+    expect(document.querySelector('[data-slot="tooltip-content"]')).toBeNull();
   });
 }
 
@@ -39,9 +49,11 @@ describe("Tooltip primitive", () => {
       }
     }
     vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+    resetTooltipDismissStateForTests();
   });
 
   afterEach(() => {
+    resetTooltipDismissStateForTests();
     vi.unstubAllGlobals();
   });
 
@@ -117,5 +129,106 @@ describe("Tooltip primitive", () => {
     expect(tooltip).toHaveTextContent("Right-side help");
     expect(tooltip.querySelector('[data-slot="tooltip-arrow"]')).toBeNull();
     expectNoManualHorizontalArrowClasses(tooltip);
+  });
+
+  it("dismissAllTooltips closes an open tooltip", async () => {
+    render(
+      <TooltipProvider>
+        <Tooltip defaultOpen>
+          <TooltipTrigger asChild>
+            <button type="button">Trigger</button>
+          </TooltipTrigger>
+          <TooltipContent>Help</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    );
+
+    await findTooltipContent();
+    act(() => {
+      dismissAllTooltips();
+    });
+    await expectTooltipClosed();
+  });
+
+  it("suppresses open attempts until release and a fresh hover", async () => {
+    const { getByRole } = render(
+      <TooltipProvider delayDuration={0}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button type="button">Trigger</button>
+          </TooltipTrigger>
+          <TooltipContent>Help</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    );
+
+    const trigger = getByRole("button");
+    act(() => {
+      suppressTooltips();
+    });
+
+    fireEvent.pointerMove(trigger);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(document.querySelector('[data-slot="tooltip-content"]')).toBeNull();
+
+    act(() => {
+      releaseTooltipSuppression();
+    });
+    // Soft-suppress holds until a pointermove that is not itself a reopen.
+    fireEvent.pointerMove(document.body);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(document.querySelector('[data-slot="tooltip-content"]')).toBeNull();
+
+    // Radix only re-enters after leave clears hasPointerMoveOpenedRef.
+    fireEvent.pointerLeave(trigger);
+    fireEvent.pointerMove(trigger);
+    await findTooltipContent();
+  });
+
+  it("closes on document pointerdown / keydown / window blur", async () => {
+    render(
+      <TooltipProvider>
+        <Tooltip defaultOpen>
+          <TooltipTrigger asChild>
+            <button type="button">Trigger</button>
+          </TooltipTrigger>
+          <TooltipContent>Help</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    );
+
+    await findTooltipContent();
+    fireEvent.pointerDown(document.body);
+    await expectTooltipClosed();
+
+    // Re-open via controlled path for the next signal.
+    const view = render(
+      <TooltipProvider>
+        <Tooltip defaultOpen>
+          <TooltipTrigger asChild>
+            <button type="button">Trigger 2</button>
+          </TooltipTrigger>
+          <TooltipContent>Help 2</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    );
+    await findTooltipContent();
+    fireEvent.keyDown(document.body, { key: "Escape" });
+    await expectTooltipClosed();
+    view.unmount();
+
+    render(
+      <TooltipProvider>
+        <Tooltip defaultOpen>
+          <TooltipTrigger asChild>
+            <button type="button">Trigger 3</button>
+          </TooltipTrigger>
+          <TooltipContent>Help 3</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    );
+    await findTooltipContent();
+    fireEvent.blur(window);
+    await expectTooltipClosed();
   });
 });

--- a/tests/unit/main/ai-service.test.ts
+++ b/tests/unit/main/ai-service.test.ts
@@ -145,6 +145,95 @@ describe("createAiService(agent one-shot)", () => {
       status: "unavailable",
     });
   });
+
+  it("generateText:首个 agent 失败后按 auto-pick 顺序 fallback 到下一个", async () => {
+    const runOneShot = vi
+      .fn<RunOneShot>()
+      .mockRejectedValueOnce(
+        new AgentRunError("run_failed", "claude not logged in")
+      )
+      .mockResolvedValueOnce("feature/file-plugin\n");
+    const service = makeService({
+      detected: ["claude", "codex", "gemini"],
+      runOneShot,
+    });
+
+    const result = await service.generateText({ prompt: "file 插件完善" });
+
+    expect(result).toEqual({ status: "ok", text: "feature/file-plugin\n" });
+    expect(runOneShot).toHaveBeenCalledTimes(2);
+    expect(runOneShot.mock.calls[0]?.[0]).toBe("claude");
+    expect(runOneShot.mock.calls[1]?.[0]).toBe("codex");
+  });
+
+  it("generateText:最多尝试 3 个 agent，第 3 个成功则返回", async () => {
+    const runOneShot = vi
+      .fn<RunOneShot>()
+      .mockRejectedValueOnce(new AgentRunError("run_failed", "claude fail"))
+      .mockRejectedValueOnce(new AgentRunError("timeout", "codex timeout"))
+      .mockResolvedValueOnce("ok-branch\n");
+    const service = makeService({
+      // auto-pick: claude → codex → grok → … → gemini
+      detected: ["claude", "codex", "gemini", "grok"],
+      runOneShot,
+    });
+
+    const result = await service.generateText({ prompt: "x" });
+
+    expect(result).toEqual({ status: "ok", text: "ok-branch\n" });
+    expect(runOneShot).toHaveBeenCalledTimes(3);
+    expect(runOneShot.mock.calls.map((call) => call[0])).toEqual([
+      "claude",
+      "codex",
+      "grok",
+    ]);
+  });
+
+  it("generateText:3 个都失败时返回最后一次错误，且不尝试第 4 个", async () => {
+    const runOneShot = vi
+      .fn<RunOneShot>()
+      .mockRejectedValueOnce(new AgentRunError("run_failed", "claude fail"))
+      .mockRejectedValueOnce(new AgentRunError("run_failed", "codex fail"))
+      .mockRejectedValueOnce(new AgentRunError("timeout", "grok timeout"));
+    const service = makeService({
+      detected: ["claude", "codex", "gemini", "grok"],
+      runOneShot,
+    });
+
+    const result = await service.generateText({ prompt: "x" });
+
+    expect(result).toMatchObject({
+      message: "grok timeout",
+      reason: "timeout",
+      status: "unavailable",
+    });
+    expect(runOneShot).toHaveBeenCalledTimes(3);
+    expect(runOneShot.mock.calls.map((call) => call[0])).toEqual([
+      "claude",
+      "codex",
+      "grok",
+    ]);
+  });
+
+  it("generateText:默认 agent 优先，失败后再按 auto-pick 顺序补足", async () => {
+    const runOneShot = vi
+      .fn<RunOneShot>()
+      .mockRejectedValueOnce(new AgentRunError("run_failed", "gemini fail"))
+      .mockResolvedValueOnce("from-claude\n");
+    const service = makeService({
+      detected: ["claude", "codex", "gemini"],
+      preferences: { defaultAgentId: "gemini" },
+      runOneShot,
+    });
+
+    const result = await service.generateText({ prompt: "x" });
+
+    expect(result).toEqual({ status: "ok", text: "from-claude\n" });
+    expect(runOneShot.mock.calls.map((call) => call[0])).toEqual([
+      "gemini",
+      "claude",
+    ]);
+  });
 });
 
 describe("defaultRunOneShot", () => {

--- a/tests/unit/renderer/lib/context-menu/use-context-menu.test.tsx
+++ b/tests/unit/renderer/lib/context-menu/use-context-menu.test.tsx
@@ -6,9 +6,16 @@ import { useZoomStore } from "@/stores/zoom.store.ts";
 const buildMenuEntriesMock = vi.hoisted(() =>
   vi.fn(() => [{ id: "panel.close", label: "Close", type: "action" }])
 );
+const suppressTooltipsMock = vi.hoisted(() => vi.fn());
+const releaseTooltipSuppressionMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/context-menu/build-entries.ts", () => ({
   buildMenuEntries: buildMenuEntriesMock,
+}));
+
+vi.mock("@pier/ui/tooltip.tsx", () => ({
+  suppressTooltips: suppressTooltipsMock,
+  releaseTooltipSuppression: releaseTooltipSuppressionMock,
 }));
 
 vi.mock("@/lib/actions/registry.ts", () => ({
@@ -29,6 +36,8 @@ function ContextMenuTarget() {
 describe("useContextMenu", () => {
   beforeEach(() => {
     buildMenuEntriesMock.mockClear();
+    suppressTooltipsMock.mockClear();
+    releaseTooltipSuppressionMock.mockClear();
     useZoomStore.setState({ windowZoomLevel: 0 });
     Object.defineProperty(window, "pier", {
       configurable: true,
@@ -55,5 +64,29 @@ describe("useContextMenu", () => {
         { x: 14.4, y: 28.8 }
       );
     });
+  });
+
+  it("suppresses tooltips for the native menu popup lifetime", async () => {
+    const { getByRole } = render(<ContextMenuTarget />);
+
+    fireEvent.contextMenu(getByRole("button"), {
+      clientX: 10,
+      clientY: 20,
+    });
+
+    await waitFor(() => {
+      expect(window.pier.menu.popup).toHaveBeenCalled();
+    });
+    expect(suppressTooltipsMock).toHaveBeenCalledTimes(1);
+    expect(releaseTooltipSuppressionMock).toHaveBeenCalledTimes(1);
+    const suppressOrder = suppressTooltipsMock.mock.invocationCallOrder[0];
+    const releaseOrder =
+      releaseTooltipSuppressionMock.mock.invocationCallOrder[0];
+    expect(typeof suppressOrder).toBe("number");
+    expect(typeof releaseOrder).toBe("number");
+    if (typeof suppressOrder !== "number" || typeof releaseOrder !== "number") {
+      throw new Error("expected invocation call order");
+    }
+    expect(suppressOrder).toBeLessThan(releaseOrder);
   });
 });


### PR DESCRIPTION
## Summary
- Retry `ai.generateText` across up to 3 detected one-shot agents (default first, then auto-pick order) so a single CLI auth/timeout failure does not abort worktree smart naming.
- Dismiss open tooltips on pointer/key/drag/blur, and suppress reopen while native context menus own the pointer.

## Test plan
- [ ] Worktree smart naming: with Claude logged out but another one-shot agent available, generation succeeds via fallback
- [ ] Worktree smart naming: with 3+ agents all failing, error surfaces after 3 attempts (no 4th try)
- [ ] Hover a tab/button tooltip, then click elsewhere / press a key / start drag / blur window — tooltip closes and does not immediately reopen
- [ ] Open a native context menu over a tooltip trigger — tooltip stays suppressed until menu closes and pointer moves
- [ ] `pnpm exec vitest run tests/unit/main/ai-service.test.ts tests/component/tooltip.test.tsx tests/unit/renderer/lib/context-menu/use-context-menu.test.tsx`


Made with [Cursor](https://cursor.com)