### PR TITLE
feat(files): terminal project status item

### DIFF
--- a/docs/superpowers/plans/2026-07-09-files-project-status-item.md
+++ b/docs/superpowers/plans/2026-07-09-files-project-status-item.md
@@ -1,0 +1,706 @@
+# Files 终端状态栏「当前项目」入口 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 让 `pier.files` 在终端状态栏贡献 `pier.files.project`：展示当前项目根并点击打开 Files 树（锚定项目根，不对齐 shell cwd）。
+
+**Architecture:** 纯函数解析项目锚点与路径展示；`openProjectFiles` 复用/打开无 `source` 的 Files 实例并展开树；状态项组件形态对齐 `pier.worktree.status`，经 manifest + `terminalStatusItems.register` 接入现有合并管道。
+
+**Tech Stack:** React 19、TypeScript strict、`@pier/ui` Button、Vitest 4、现有 plugin terminalStatusItems / panels.openInstance / files-tree-registry。
+
+**配套设计：** `docs/superpowers/specs/2026-07-09-files-project-status-item-design.md`
+
+## Global Constraints
+
+- 展示与打开锚定**项目根**，不随 shell `cd` 变化。
+- 归属 `pier.files`，不做 core 状态项、不新建 header 池。
+- 用户可见文案全部走插件 i18n；失败用 `notifications.error`，成功不加 toast。
+- 禁止 `@ts-ignore` / `@ts-expect-error` / `as any`。
+- 默认 git 只读：本计划步骤含 commit 时，执行前先向用户确认；未确认则只改文件不提交。
+
+---
+
+## 文件结构
+
+**新建**
+
+- `src/plugins/builtin/files/renderer/files-project-anchor.ts`：`projectAnchor` + `formatProjectPath` 纯函数。
+- `src/plugins/builtin/files/renderer/files-open-project.ts`：`openProjectFiles`（打开/复用 Files + 展开树 + reveal 根）。
+- `src/plugins/builtin/files/renderer/files-project-status-item.tsx`：状态项 UI + `registerFilesProjectStatusItem`。
+- `tests/unit/renderer/files-project-anchor.test.ts`
+- `tests/unit/renderer/files-open-project.test.ts`
+- `tests/unit/renderer/files-project-status-item.test.tsx`
+
+**修改**
+
+- `src/plugins/builtin/files/manifest.ts`：声明 `terminalStatusItems` + 导出 id 常量。
+- `src/plugins/builtin/files/locales/en.json` / `zh-CN.json`：`terminalStatusItems` + 打开失败文案。
+- `src/plugins/builtin/files/renderer/file-tree-preferences.ts`：导出 `ensureProjectFileTreeExpanded`。
+- `src/plugins/builtin/files/renderer/index.tsx`：activate 注册状态项。
+
+---
+
+### Task 1: 项目锚点与路径折叠纯函数
+
+**Files:**
+- Create: `src/plugins/builtin/files/renderer/files-project-anchor.ts`
+- Test: `tests/unit/renderer/files-project-anchor.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `projectAnchor(context: PanelContext | undefined): string | null`
+  - `formatProjectPath(path: string, homeDirectory?: string | null): string`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from "vitest";
+import type { PanelContext } from "@shared/contracts/panel.ts";
+import {
+  formatProjectPath,
+  projectAnchor,
+} from "../../../src/plugins/builtin/files/renderer/files-project-anchor.ts";
+
+function ctx(partial: Partial<PanelContext> & Pick<PanelContext, "contextId" | "projectRootPath" | "updatedAt">): PanelContext {
+  return partial;
+}
+
+describe("projectAnchor", () => {
+  it("returns null when context is missing", () => {
+    expect(projectAnchor(undefined)).toBeNull();
+  });
+
+  it("prefers projectRootPath over worktree/git/cwd", () => {
+    expect(
+      projectAnchor(
+        ctx({
+          contextId: "c",
+          projectRootPath: "/repo",
+          updatedAt: 1,
+          worktreeRoot: "/repo-wt",
+          gitRoot: "/repo-git",
+          cwd: "/repo/src",
+        })
+      )
+    ).toBe("/repo");
+  });
+
+  it("falls back worktreeRoot → gitRoot → cwd when projectRootPath is empty", () => {
+    expect(
+      projectAnchor(
+        ctx({
+          contextId: "c",
+          projectRootPath: "",
+          updatedAt: 1,
+          worktreeRoot: "/wt",
+        })
+      )
+    ).toBe("/wt");
+    expect(
+      projectAnchor(
+        ctx({
+          contextId: "c",
+          projectRootPath: "",
+          updatedAt: 1,
+          gitRoot: "/git",
+        })
+      )
+    ).toBe("/git");
+    expect(
+      projectAnchor(
+        ctx({
+          contextId: "c",
+          projectRootPath: "",
+          updatedAt: 1,
+          cwd: "/cwd",
+        })
+      )
+    ).toBe("/cwd");
+  });
+});
+
+describe("formatProjectPath", () => {
+  it("returns absolute path when home is null", () => {
+    expect(formatProjectPath("/Users/a/proj", null)).toBe("/Users/a/proj");
+  });
+
+  it("folds home to ~", () => {
+    expect(formatProjectPath("/Users/a", "/Users/a")).toBe("~");
+    expect(formatProjectPath("/Users/a/proj", "/Users/a")).toBe("~/proj");
+  });
+
+  it("strips trailing separators before compare", () => {
+    expect(formatProjectPath("/Users/a/proj/", "/Users/a/")).toBe("~/proj");
+  });
+});
+```
+
+修正「fallback」用例为不依赖非法 `projectRootPath: undefined`：用类型断言构造仅含 `worktreeRoot` / `gitRoot` / `cwd` 的对象，或在实现里对 `projectRootPath` 做空串忽略。推荐实现：
+
+```ts
+function nonEmpty(value: string | undefined): string | null {
+  return value && value.length > 0 ? value : null;
+}
+```
+
+优先级：`projectRootPath` → `worktreeRoot` → `gitRoot` → `cwd`（与 spec 一致；**不要**用 `openedPath`，避免与 `filePanelProjectRoot` 在「打开文件路径」场景分叉——本状态项只要项目根）。
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run tests/unit/renderer/files-project-anchor.test.ts`
+
+Expected: FAIL（模块不存在）
+
+- [ ] **Step 3: Write minimal implementation**
+
+`src/plugins/builtin/files/renderer/files-project-anchor.ts`:
+
+```ts
+import type { PanelContext } from "@shared/contracts/panel.ts";
+
+function nonEmpty(value: string | undefined): string | null {
+  return value && value.length > 0 ? value : null;
+}
+
+export function projectAnchor(
+  context: PanelContext | undefined
+): string | null {
+  if (!context) {
+    return null;
+  }
+  return (
+    nonEmpty(context.projectRootPath) ??
+    nonEmpty(context.worktreeRoot) ??
+    nonEmpty(context.gitRoot) ??
+    nonEmpty(context.cwd)
+  );
+}
+
+function stripTrailingSeparators(value: string): string {
+  return value.replace(/[\\/]+$/, "") || value;
+}
+
+export function formatProjectPath(
+  path: string,
+  homeDirectory: string | null = null
+): string {
+  const normalized = stripTrailingSeparators(path);
+  const home = homeDirectory ? stripTrailingSeparators(homeDirectory) : null;
+  if (!(home && home !== "/" && home !== "\\")) {
+    return normalized;
+  }
+  if (normalized === home) {
+    return "~";
+  }
+  if (normalized.startsWith(`${home}/`)) {
+    return `~/${normalized.slice(home.length + 1)}`;
+  }
+  if (normalized.startsWith(`${home}\\`)) {
+    return `~/${normalized.slice(home.length + 1).replace(/\\/g, "/")}`;
+  }
+  return normalized;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm exec vitest run tests/unit/renderer/files-project-anchor.test.ts`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**（需用户确认后）
+
+```bash
+git add src/plugins/builtin/files/renderer/files-project-anchor.ts tests/unit/renderer/files-project-anchor.test.ts
+git commit -m "$(cat <<'EOF'
+feat(files): add project anchor and path fold helpers
+
+Pure helpers for the terminal project status item display and open target.
+EOF
+)"
+```
+
+---
+
+### Task 2: `openProjectFiles` 打开/复用 Files 并展开树
+
+**Files:**
+- Modify: `src/plugins/builtin/files/renderer/file-tree-preferences.ts`
+- Create: `src/plugins/builtin/files/renderer/files-open-project.ts`
+- Test: `tests/unit/renderer/files-open-project.test.ts`
+
+**Interfaces:**
+- Consumes: `projectAnchor`；`revealFilesTreePath` / `findFilesTreeInstanceId`；`FILES_FILE_PANEL_ID`；`panels.openInstance` / `listInstances`
+- Produces:
+  - `ensureProjectFileTreeExpanded(root: string): void`
+  - `openProjectFiles(pluginContext, panelContext): { ok: true } | { ok: false; reason: "no-anchor" | "open-failed" }`
+  - `createProjectFilesInstanceId(root: string): string`（稳定空面板 id）
+
+打开策略（锁定）：
+
+1. `anchor = projectAnchor(panelContext)`；无则 `{ ok: false, reason: "no-anchor" }`。
+2. `listInstances(FILES_FILE_PANEL_ID)`，找 `projectAnchor(instance.params.context) === anchor` 的已有实例（params.context 经 `panelContextSchema.safeParse`）。
+3. 若有：`openInstance` 同 `instanceId`，带上 `context: panelContext`，保留已有 `params`（含 source），只激活/聚焦。
+4. 若无：`openInstance` 新实例，`instanceId = pier.files.filePanel:project:${hash(anchor)}`，`params: {}`（无 source → empty + 树），`title = projectNameFromRoot(anchor)`，`context: panelContext`。
+5. `ensureProjectFileTreeExpanded(anchor)`（写 localStorage collapsed=false）。
+6. `setTimeout(80ms)` 后 `revealFilesTreePath({ root: anchor, path: "" })` 或 path=`anchor` 的相对空——树 API 对根用 `""` 或 `"."`；若 `revealPath("")` 无效则 reveal 根目录名。以现有 `PierFileTree.revealPath` 行为为准：对项目根传 `""`；若测试/运行无效，改为不传 reveal、仅展开树（仍算达标「打开到项目根」）。
+7. `openInstance` 抛错 → catch → `{ ok: false, reason: "open-failed" }`。
+
+- [ ] **Step 1: Export tree expand helper**
+
+在 `file-tree-preferences.ts` 增加：
+
+```ts
+export function ensureProjectFileTreeExpanded(root: string): void {
+  writeTreeCollapsed(root, false);
+}
+```
+
+- [ ] **Step 2: Write the failing openProjectFiles tests**
+
+```ts
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import type { PanelContext } from "@shared/contracts/panel.ts";
+import type { RendererPluginContext } from "@plugins/api/renderer.ts";
+import { FILES_FILE_PANEL_ID } from "../../../src/plugins/builtin/files/manifest.ts";
+import { openProjectFiles } from "../../../src/plugins/builtin/files/renderer/files-open-project.ts";
+import * as treeRegistry from "../../../src/plugins/builtin/files/renderer/files-tree-registry.ts";
+import * as prefs from "../../../src/plugins/builtin/files/renderer/file-tree-preferences.ts";
+
+const baseContext: PanelContext = {
+  contextId: "ctx:1",
+  projectRootPath: "/Users/a/proj",
+  updatedAt: 1,
+  cwd: "/Users/a/proj/src",
+};
+
+function makePlugin(overrides?: {
+  listInstances?: PluginPanelInstance[];
+  openInstance?: ReturnType<typeof vi.fn>;
+}): RendererPluginContext {
+  // 最小 mock：panels.listInstances / openInstance；其余用 vi.fn
+}
+
+describe("openProjectFiles", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns no-anchor when context lacks project fields", () => {
+    const plugin = makePlugin();
+    expect(
+      openProjectFiles(plugin, {
+        contextId: "x",
+        projectRootPath: "",
+        updatedAt: 1,
+      } as PanelContext)
+    ).toEqual({ ok: false, reason: "no-anchor" });
+  });
+
+  it("opens a new empty files instance for the project root", () => {
+    const openInstance = vi.fn();
+    const plugin = makePlugin({ listInstances: [], openInstance });
+    const expand = vi.spyOn(prefs, "ensureProjectFileTreeExpanded");
+    expect(openProjectFiles(plugin, baseContext)).toEqual({ ok: true });
+    expect(openInstance).toHaveBeenCalledWith(
+      expect.objectContaining({
+        componentId: FILES_FILE_PANEL_ID,
+        context: baseContext,
+        params: {},
+      })
+    );
+    expect(expand).toHaveBeenCalledWith("/Users/a/proj");
+  });
+
+  it("reuses an existing instance for the same project anchor", () => {
+    const openInstance = vi.fn();
+    const plugin = makePlugin({
+      listInstances: [
+        {
+          id: "existing-id",
+          componentId: FILES_FILE_PANEL_ID,
+          groupId: "g1",
+          title: "proj",
+          params: { context: baseContext, source: { kind: "disk", path: "a.ts", root: "/Users/a/proj" } },
+        },
+      ],
+      openInstance,
+    });
+    openProjectFiles(plugin, baseContext);
+    expect(openInstance).toHaveBeenCalledWith(
+      expect.objectContaining({ instanceId: "existing-id" })
+    );
+  });
+
+  it("schedules reveal after open", () => {
+    const reveal = vi.spyOn(treeRegistry, "revealFilesTreePath").mockReturnValue(true);
+    const plugin = makePlugin({ listInstances: [], openInstance: vi.fn() });
+    openProjectFiles(plugin, baseContext);
+    expect(reveal).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(80);
+    expect(reveal).toHaveBeenCalledWith(
+      expect.objectContaining({ root: "/Users/a/proj" })
+    );
+  });
+});
+```
+
+（按仓库现有 mock 风格补全 `makePlugin`；可参考 `tests/unit/renderer/files-tree-create.test.ts`。）
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `pnpm exec vitest run tests/unit/renderer/files-open-project.test.ts`
+
+Expected: FAIL
+
+- [ ] **Step 4: Implement `files-open-project.ts`**
+
+```ts
+import type { RendererPluginContext } from "@plugins/api/renderer.ts";
+import type { PanelContext } from "@shared/contracts/panel.ts";
+import { panelContextSchema } from "@shared/contracts/panel.ts";
+import { FILES_FILE_PANEL_ID } from "../manifest.ts";
+import { projectNameFromRoot, ensureProjectFileTreeExpanded } from "./file-tree-preferences.ts";
+import { projectAnchor } from "./files-project-anchor.ts";
+import { revealFilesTreePath } from "./files-tree-registry.ts";
+import { stableFileIdentityHash } from "./files-stable-hash.ts";
+
+const REVEAL_DELAY_MS = 80;
+
+export function createProjectFilesInstanceId(root: string): string {
+  return `${FILES_FILE_PANEL_ID}:project:${stableFileIdentityHash(root)}`;
+}
+
+function contextFromParams(params: unknown): PanelContext | undefined {
+  if (!params || typeof params !== "object" || !("context" in params)) {
+    return;
+  }
+  const parsed = panelContextSchema.safeParse(
+    (params as { context: unknown }).context
+  );
+  return parsed.success ? parsed.data : undefined;
+}
+
+export function openProjectFiles(
+  pluginContext: RendererPluginContext,
+  panelContext: PanelContext
+): { ok: true } | { ok: false; reason: "no-anchor" | "open-failed" } {
+  const anchor = projectAnchor(panelContext);
+  if (!anchor) {
+    return { ok: false, reason: "no-anchor" };
+  }
+
+  try {
+    const instances = pluginContext.panels.listInstances(FILES_FILE_PANEL_ID);
+    const existing = instances.find(
+      (instance) => projectAnchor(contextFromParams(instance.params)) === anchor
+    );
+
+    if (existing) {
+      pluginContext.panels.openInstance({
+        componentId: FILES_FILE_PANEL_ID,
+        context: panelContext,
+        instanceId: existing.id,
+        params: existing.params ? { ...existing.params } : {},
+        title: existing.title,
+        ...(existing.groupId ? { targetGroupId: existing.groupId } : {}),
+      });
+    } else {
+      pluginContext.panels.openInstance({
+        componentId: FILES_FILE_PANEL_ID,
+        context: panelContext,
+        instanceId: createProjectFilesInstanceId(anchor),
+        params: {},
+        title: projectNameFromRoot(anchor),
+      });
+    }
+
+    ensureProjectFileTreeExpanded(anchor);
+    globalThis.setTimeout(() => {
+      revealFilesTreePath({ path: "", root: anchor });
+    }, REVEAL_DELAY_MS);
+
+    return { ok: true };
+  } catch {
+    return { ok: false, reason: "open-failed" };
+  }
+}
+```
+
+若 `projectNameFromRoot` / `ensureProjectFileTreeExpanded` 导出路径需微调，以编译为准。
+
+- [ ] **Step 5: Run tests**
+
+Run: `pnpm exec vitest run tests/unit/renderer/files-open-project.test.ts`
+
+Expected: PASS
+
+- [ ] **Step 6: Commit**（需用户确认后）
+
+```bash
+git add src/plugins/builtin/files/renderer/file-tree-preferences.ts \
+  src/plugins/builtin/files/renderer/files-open-project.ts \
+  tests/unit/renderer/files-open-project.test.ts
+git commit -m "$(cat <<'EOF'
+feat(files): open project Files panel from status item helper
+
+Reuse same-project instances, expand the tree, and reveal the project root.
+EOF
+)"
+```
+
+---
+
+### Task 3: Manifest、i18n 与状态项 UI 注册
+
+**Files:**
+- Modify: `src/plugins/builtin/files/manifest.ts`
+- Modify: `src/plugins/builtin/files/locales/en.json`
+- Modify: `src/plugins/builtin/files/locales/zh-CN.json`
+- Create: `src/plugins/builtin/files/renderer/files-project-status-item.tsx`
+- Modify: `src/plugins/builtin/files/renderer/index.tsx`
+- Test: `tests/unit/renderer/files-project-status-item.test.tsx`
+
+**Interfaces:**
+- Consumes: `projectAnchor` / `formatProjectPath` / `openProjectFiles`
+- Produces: `FILES_PROJECT_STATUS_ITEM_ID = "pier.files.project"`；`registerFilesProjectStatusItem(context): () => void`
+
+- [ ] **Step 1: Manifest + locale**
+
+`manifest.ts` 增加：
+
+```ts
+export const FILES_PROJECT_STATUS_ITEM_ID = "pier.files.project";
+```
+
+`terminalStatusItems` 改为：
+
+```ts
+terminalStatusItems: [
+  {
+    alignment: "right",
+    id: FILES_PROJECT_STATUS_ITEM_ID,
+    order: 9,
+    permissions: ["panel:open", "file:read"],
+    title: "Project",
+  },
+],
+```
+
+`en.json` 增加顶层（与 git 插件同级结构）：
+
+```json
+"terminalStatusItems": {
+  "pier.files.project": {
+    "title": "Project",
+    "description": "Shows the current project and opens its file tree."
+  }
+}
+```
+
+`messages` 增加：
+
+```json
+"files.projectStatus.openLabel": "Open project files",
+"files.projectStatus.openTooltip": "Open project files",
+"files.projectStatus.openFailed": "Unable to open project files"
+```
+
+`zh-CN.json` 对应：
+
+```json
+"terminalStatusItems": {
+  "pier.files.project": {
+    "title": "项目",
+    "description": "显示当前项目并打开其文件树。"
+  }
+}
+```
+
+```json
+"files.projectStatus.openLabel": "打开项目文件",
+"files.projectStatus.openTooltip": "打开项目文件",
+"files.projectStatus.openFailed": "无法打开项目文件"
+```
+
+- [ ] **Step 2: Write status item tests**
+
+覆盖：
+
+1. `isVisible` / render：无锚点 → register 的 `isVisible` 为 false；有 `projectRootPath` → true。
+2. 点击调用 `openProjectFiles`；失败时 `notifications.error`。
+3. 按钮 `data-testid="files-project-status-trigger"` 存在；主文案为 `formatProjectPath(anchor)`（home=null → 绝对路径）。
+
+可用 `vi.mock("./files-open-project.ts")`。注册后从 registry 取 item 较重时，改为直接测导出的 `FilesProjectStatusItem` 组件 + 单独测 `isVisible` 函数（若抽出 `isFilesProjectStatusVisible`）。
+
+推荐抽出：
+
+```ts
+export function isFilesProjectStatusVisible(
+  statusContext: RendererTerminalStatusItemContext
+): boolean {
+  return projectAnchor(statusContext.context) != null;
+}
+```
+
+- [ ] **Step 3: Implement status item**
+
+`files-project-status-item.tsx`（对齐 git 触发器）：
+
+```tsx
+import { Button } from "@pier/ui/button.tsx";
+import type {
+  RendererPluginContext,
+  RendererTerminalStatusItemContext,
+} from "@plugins/api/renderer.ts";
+import { Folder } from "lucide-react";
+import { FILES_PROJECT_STATUS_ITEM_ID } from "../manifest.ts";
+import {
+  formatProjectPath,
+  projectAnchor,
+} from "./files-project-anchor.ts";
+import { openProjectFiles } from "./files-open-project.ts";
+
+export function isFilesProjectStatusVisible(
+  statusContext: RendererTerminalStatusItemContext
+): boolean {
+  return projectAnchor(statusContext.context) != null;
+}
+
+function FilesProjectStatusItem({
+  pluginContext,
+  ...statusContext
+}: RendererTerminalStatusItemContext & {
+  pluginContext: RendererPluginContext;
+}) {
+  const anchor = projectAnchor(statusContext.context);
+  if (!anchor || !statusContext.context) {
+    return null;
+  }
+  const label = formatProjectPath(anchor, null);
+  const t = (key: string, fallback: string) =>
+    pluginContext.i18n.t(key, undefined, fallback);
+  const openLabel = t("files.projectStatus.openLabel", "Open project files");
+  const openTooltip = t(
+    "files.projectStatus.openTooltip",
+    "Open project files"
+  );
+
+  return (
+    <Button
+      aria-label={openLabel}
+      className="h-5 min-w-0 max-w-56 gap-1 px-2 font-normal text-xs"
+      data-testid="files-project-status-trigger"
+      onClick={() => {
+        const result = openProjectFiles(
+          pluginContext,
+          statusContext.context as NonNullable<typeof statusContext.context>
+        );
+        if (!result.ok) {
+          pluginContext.notifications.error(
+            t(
+              "files.projectStatus.openFailed",
+              "Unable to open project files"
+            )
+          );
+        }
+      }}
+      size="xs"
+      title={`${openTooltip}\n${anchor}`}
+      type="button"
+      variant="outline"
+    >
+      <Folder className="size-3 shrink-0 opacity-70" aria-hidden="true" />
+      <span className="min-w-0 truncate" dir="rtl">
+        <span dir="ltr" style={{ unicodeBidi: "isolate" }}>
+          {label}
+        </span>
+      </span>
+    </Button>
+  );
+}
+
+export function registerFilesProjectStatusItem(
+  context: RendererPluginContext
+): () => void {
+  return context.terminalStatusItems.register({
+    id: FILES_PROJECT_STATUS_ITEM_ID,
+    isVisible: isFilesProjectStatusVisible,
+    render: (statusContext) => (
+      <FilesProjectStatusItem {...statusContext} pluginContext={context} />
+    ),
+  });
+}
+```
+
+避免 `as NonNullable`：在 `onClick` 前已 guard `statusContext.context`，把 `const panelContext = statusContext.context` 收窄后传入。
+
+- [ ] **Step 4: Wire activate**
+
+`index.tsx` 的 `disposers` 增加：
+
+```ts
+registerFilesProjectStatusItem(context),
+```
+
+- [ ] **Step 5: Run tests**
+
+```bash
+pnpm exec vitest run tests/unit/renderer/files-project-status-item.test.tsx tests/unit/renderer/files-project-anchor.test.ts tests/unit/renderer/files-open-project.test.ts
+```
+
+Expected: PASS
+
+- [ ] **Step 6: Lint / typecheck touched files**
+
+```bash
+pnpm exec biome check src/plugins/builtin/files/manifest.ts \
+  src/plugins/builtin/files/renderer/files-project-anchor.ts \
+  src/plugins/builtin/files/renderer/files-open-project.ts \
+  src/plugins/builtin/files/renderer/files-project-status-item.tsx \
+  src/plugins/builtin/files/renderer/file-tree-preferences.ts \
+  src/plugins/builtin/files/renderer/index.tsx
+pnpm exec tsc -p tsconfig.json --noEmit 2>&1 | head -40
+```
+
+（若全量 tsc 过慢，至少保证改动文件无新增诊断。）
+
+- [ ] **Step 7: Commit**（需用户确认后）
+
+```bash
+git add src/plugins/builtin/files/manifest.ts \
+  src/plugins/builtin/files/locales/en.json \
+  src/plugins/builtin/files/locales/zh-CN.json \
+  src/plugins/builtin/files/renderer/files-project-status-item.tsx \
+  src/plugins/builtin/files/renderer/index.tsx \
+  tests/unit/renderer/files-project-status-item.test.tsx
+git commit -m "$(cat <<'EOF'
+feat(files): add terminal project status item
+
+Contribute pier.files.project on the right status bar to open the
+current project file tree, matching Git item contribution patterns.
+EOF
+)"
+```
+
+---
+
+## Spec coverage（self-review）
+
+| Spec 要求 | Task |
+|---|---|
+| `pier.files.project` manifest + order 9 right | Task 3 |
+| `projectAnchor` 优先级 / 无锚点隐藏 | Task 1 + 3 |
+| `~/` 折叠（无 home → 绝对路径） | Task 1 + 3（home=null） |
+| 点击打开 Files、项目根、复用实例 | Task 2 |
+| 展开树 + reveal | Task 2 |
+| 失败 notifications.error，成功无 toast | Task 3 |
+| 不随 shell cwd 变文案 | Task 1/3 只用 anchor，不用 statusContext.cwd 主文案 |
+| 非 Git 仍显示 | Task 1 fallback 到 cwd |
+| 设置页/右键自动出现 | Task 3 manifest 声明（现有合并管道） |
+| 测试锚点/折叠/打开/注册 | Task 1–3 |
+
+**有意不做（spec 非目标）：** shell cwd 指示器、header 池、core 项、编辑器 status bar。

--- a/docs/superpowers/specs/2026-07-09-files-project-status-item-design.md
+++ b/docs/superpowers/specs/2026-07-09-files-project-status-item-design.md
@@ -1,0 +1,169 @@
+# Files 终端状态栏「当前项目」入口
+
+**日期**：2026-07-09  
+**范围**：`pier.files` 向终端状态栏贡献项目入口；点击打开 Files 并定位到当前项目根  
+**关联文档**：
+
+- [2026-07-02-plugin-configuration-and-statusbar-design.md](2026-07-02-plugin-configuration-and-statusbar-design.md)（插件状态栏贡献 / prefs 合并）
+- [2026-07-01-git-status-bar-design.md](2026-07-01-git-status-bar-design.md)（`pier.worktree.status` 形态与可见性先例）
+- [2026-07-02-project-file-tree-design.md](2026-07-02-project-file-tree-design.md)（Files 树根 = 项目锚点）
+- Loomdesk 参考：`header-directory-item.svelte`（终端目录入口；语义为本 spec **有意偏离** 的对照物）
+
+## 1. 背景与问题
+
+Loomdesk 终端顶栏有可点的 `directory` 项：展示 shell cwd（`~/...`），点击 `openExplorer` 打开文件管理。
+
+Pier 现状：
+
+- 终端状态栏已有 core agent/task + Git `pier.worktree.status`
+- `pier.files` 的 `terminalStatusItems: []`，没有对应入口
+- Files 树根锚定 `projectRootPath`（Git 优先 gitRoot，非 Git 为 cwd），不是 shell 瞬时 cwd
+- Shell cwd 已有 OSC7 → `PanelContext` → tab/title 管道，不缺「cwd 上报」
+
+若原样移植 loomdesk「展示并打开 shell cwd」，会与 Files 树根模型错位，并与 tab cwd 重复。需要的是：**终端上一键打开当前项目的文件管理**，工程形态对齐 Git 状态项。
+
+## 2. 目标 / 非目标
+
+### 目标
+
+1. `pier.files` 贡献终端状态项，作为「当前项目 → 打开 Files」入口。
+2. 可见性、右对齐、outline 小按钮形态与 `pier.worktree.status` 同构（工程模式对齐，不是同一字段）。
+3. 展示与点击均锚定**项目根**，与 Files 树根一致。
+4. 无项目上下文时不渲染；设置页 / 右键状态栏菜单自动出现该项（走现有 manifest 合并管道）。
+
+### 非目标
+
+- **不**做 loomdesk 等价的 shell cwd 常驻指示器（不随 `cd` 更新文案）。
+- **不**新建终端 header 贡献池。
+- **不**把该项做成 core 状态项。
+- **不**改 Git 状态栏、不改 cwd→tab 管道。
+- **不**在本项内做编码 / 行列 / 语言等编辑器 status bar。
+
+## 3. 产品定位（为何这是最佳实践）
+
+| 信号 | 落点 | 原因 |
+|---|---|---|
+| 项目 / 工作区身份 | 本状态项 + Files 面板 | 稳定、可行动；与树根一致 |
+| Git 分支 / 脏状态 | `pier.worktree.status` | 已有；职责不抢 |
+| Shell cwd | 终端 tab / title（已有） | 高频变化；业界也不常驻状态栏 |
+
+状态栏适合放稳定工作区动作；shell cwd 适合进程级 UI。点击目标必须等于 Files 数据模型的根，否则「显示路径 ≠ 打开结果」。
+
+相对 loomdesk：学「终端上有可点的目录/项目入口」，落点改为 Pier 的项目锚点——适配，不是 1:1 抄。
+
+## 4. 设计
+
+### 4.1 贡献声明
+
+插件：`pier.files`  
+状态项 id：`pier.files.project`
+
+```ts
+// manifest.terminalStatusItems
+{
+  id: "pier.files.project",
+  title: "Project",
+  alignment: "right",
+  order: 9, // 紧挨 pier.worktree.status (order 10) 左侧
+  permissions: ["panel:open", "file:read"],
+}
+```
+
+- locale：`terminalStatusItems.pier.files.project.{title,description}`
+- `activate` 里 `context.terminalStatusItems.register({ id, isVisible, render })`，dispose 进 cleanup
+
+### 4.2 项目锚点与可见性
+
+```ts
+function projectAnchor(context: PanelContext | undefined): string | null {
+  return (
+    context?.projectRootPath ??
+    context?.worktreeRoot ??
+    context?.gitRoot ??
+    context?.cwd ??
+    null
+  );
+}
+```
+
+- `isVisible` / `render`：无锚点 → 隐藏 / `null`（对齐 Git「无 worktree/gitRoot 不出现」的原则）
+- 非 Git 目录：仍可显示（锚点落到 `projectRootPath` 或 `cwd`）；**不要**要求 `gitRoot`
+- 启动瞬间 context 未到：隐藏，避免空路径闪烁
+
+展示用锚点路径，**不用**状态栏上下文里的瞬时 `cwd` 字段做主文案（`cwd` 仅可进 tooltip 辅助，可选）。
+
+### 4.3 展示
+
+- 文案：锚点绝对路径折叠为 `~/...`（home 前缀规则；无 home 信息时显示绝对路径）
+- 过长：`truncate` + `max-w-*`；tooltip 为全路径 + 简短说明（如「打开项目文件」）
+- 控件：`Button` `size="xs"` `variant="outline"`，可选 `Folder` 图标，与 Git 触发器同高（`h-5`）
+- `data-testid`：`files-project-status-trigger`
+- i18n：插件 messages，禁止内联用户可见字符串
+
+命名：UI / locale 用「项目 / Project」，避免「当前目录」造成 shell cwd 预期。
+
+### 4.4 点击行为
+
+```
+click
+  → resolve projectAnchor(panelContext)
+  → panels.openInstance({
+       componentId: FILES_FILE_PANEL_ID,
+       context: panelContext,
+       // 打开策略：复用现有 files 打开惯例（同 context 优先复用已有 group/instance）
+     })
+  → 确保文件树展开（若 collapsed 则展开）
+  → revealFilesTreePath({ root: anchor, path: "" | anchor-relative root })
+```
+
+细则：
+
+1. **打开**：带上当前终端的 `PanelContext`；优先聚焦已有同项目 Files 实例，避免无意义新开。
+2. **Reveal**：定位到项目根（树根本身）。不 reveal shell 子目录。
+3. **失败反馈**：打开或 reveal 失败 → `context.notifications.error`（i18n）；禁止只 `console.error`。
+4. **强自然反馈**：面板打开 / 树定位成功 → 不加成功 toast。
+
+实现上可抽 `openProjectFiles(context, panelContext)`（或等价），供状态项与未来命令复用；若现有 `openInstance` + `revealFilesTreePath` 已够，不必强行新命令。
+
+### 4.5 与 Git 项的关系
+
+| | `pier.files.project` | `pier.worktree.status` |
+|---|---|---|
+| 职责 | 打开项目文件树 | 分支 / 脏 / 特殊态 |
+| 可见性字段 | 项目锚点（含非 Git） | gitRoot / worktreeRoot |
+| order | 9 | 10 |
+| 点击 | Files | Git status dropdown |
+
+两者可同时出现；文案避免都刷长路径——本项以折叠路径为主，Git 保持现有分支/标志为主。
+
+### 4.6 Shell cwd 边界（写死）
+
+- 终端内 `cd` 到子目录：**本项文案不变**（仍是项目根）。
+- Tab / document title 仍可反映 cwd（现有管道）。
+- 若未来需要「打开 shell 当前目录」，另立状态项或 tab 交互，不扩展本项语义。
+
+## 5. 测试
+
+- 单元：`projectAnchor` 优先级；路径 `~` 折叠；无 context → 不可见。
+- 组件 / 注册：manifest 声明 + register；点击调用打开/reveal（mock panels / tree registry）。
+- 回归：Git 状态项、cwd→tab、Files 树根解析不受影响。
+
+## 6. 验收标准
+
+1. 有项目上下文的终端：右侧出现项目项，形态接近 Git 状态按钮。
+2. 点击 → Files 打开，上下文正确，树在项目根。
+3. 无项目上下文：该项不出现。
+4. `cd` 进子目录：该项文案不变；tab 仍可反映 cwd。
+5. 非 Git 目录：仍显示并可打开 Files。
+6. 设置页 / 右键「管理状态栏」能看到并开关该项。
+
+## 7. 实现提示（非绑定实现细节）
+
+主要触点（实现计划可再拆）：
+
+- `src/plugins/builtin/files/manifest.ts` — 声明 `terminalStatusItems`
+- `src/plugins/builtin/files/locales/{en,zh-CN}.json` — `terminalStatusItems` + 通知文案
+- `src/plugins/builtin/files/renderer/` — 新 status item 组件 + `openProjectFiles` 辅助 + `activate` 注册
+- 必要时扩展 `revealFilesTreePath` / group 打开路径以支持「仅打开树、无磁盘文件 tab」
+
+参考实现：`src/plugins/builtin/git/renderer/git-status-item.tsx` 的 `registerGitStatusItem`。

--- a/src/plugins/builtin/files/locales/en.json
+++ b/src/plugins/builtin/files/locales/en.json
@@ -56,8 +56,13 @@
     "filePanel.tree.nameRequired": "Name required",
     "filePanel.tree.nameReserved": "Reserved name",
     "filePanel.tree.nameInvalidChars": "Name cannot contain / \\ or NUL",
+    "filePanel.tree.pathMustBeRelative": "Path must be relative to the parent folder",
+    "filePanel.tree.pathInvalidChars": "Path cannot contain \\ or NUL",
+    "filePanel.tree.pathEmptySegment": "Path cannot contain empty segments",
     "filePanel.tree.nameConflict": "Name already exists",
     "filePanel.tree.createFailed": "Unable to create item",
+    "filePanel.tree.createNeedsProject": "Open a project to create files.",
+    "filePanel.tree.contextMenuFailed": "Unable to open menu",
     "filePanel.tree.renameFailed": "Unable to rename",
     "filePanel.tree.deleteFailed": "Unable to delete",
     "filePanel.tree.copyFailed": "Copy failed",
@@ -109,7 +114,16 @@
     "filePanel.saveOnClose.body": "Your changes will be lost if you don't save them.",
     "filePanel.saveOnClose.saveLabel": "Save",
     "filePanel.saveOnClose.dontSaveLabel": "Don't Save",
-    "filePanel.saveOnClose.cancelLabel": "Cancel"
+    "filePanel.saveOnClose.cancelLabel": "Cancel",
+    "files.projectStatus.openLabel": "Open project files",
+    "files.projectStatus.openTooltip": "Open project files",
+    "files.projectStatus.openFailed": "Unable to open project files"
+  },
+  "terminalStatusItems": {
+    "pier.files.project": {
+      "title": "Project",
+      "description": "Shows the current project and opens its file tree."
+    }
   },
   "name": "Files",
   "panels": {

--- a/src/plugins/builtin/files/locales/zh-CN.json
+++ b/src/plugins/builtin/files/locales/zh-CN.json
@@ -56,8 +56,13 @@
     "filePanel.tree.nameRequired": "请输入名称",
     "filePanel.tree.nameReserved": "该名称保留",
     "filePanel.tree.nameInvalidChars": "名称不能包含 / \\ 或 NUL",
+    "filePanel.tree.pathMustBeRelative": "路径必须相对于父目录",
+    "filePanel.tree.pathInvalidChars": "路径不能包含 \\ 或 NUL",
+    "filePanel.tree.pathEmptySegment": "路径不能包含空段",
     "filePanel.tree.nameConflict": "名称已存在",
     "filePanel.tree.createFailed": "创建失败",
+    "filePanel.tree.createNeedsProject": "请先打开项目再创建文件。",
+    "filePanel.tree.contextMenuFailed": "无法打开菜单",
     "filePanel.tree.renameFailed": "重命名失败",
     "filePanel.tree.deleteFailed": "删除失败",
     "filePanel.tree.copyFailed": "复制失败",
@@ -109,7 +114,16 @@
     "filePanel.saveOnClose.body": "如果不保存，你的更改将会丢失。",
     "filePanel.saveOnClose.saveLabel": "保存",
     "filePanel.saveOnClose.dontSaveLabel": "不保存",
-    "filePanel.saveOnClose.cancelLabel": "取消"
+    "filePanel.saveOnClose.cancelLabel": "取消",
+    "files.projectStatus.openLabel": "打开项目文件",
+    "files.projectStatus.openTooltip": "打开项目文件",
+    "files.projectStatus.openFailed": "无法打开项目文件"
+  },
+  "terminalStatusItems": {
+    "pier.files.project": {
+      "title": "项目",
+      "description": "显示当前项目并打开其文件树。"
+    }
   },
   "name": "文件",
   "panels": {

--- a/src/plugins/builtin/files/manifest.ts
+++ b/src/plugins/builtin/files/manifest.ts
@@ -25,6 +25,7 @@ export const FILES_EDITOR_COPY_COMMAND_ID = "pier.files.editor.copy";
 export const FILES_EDITOR_PASTE_COMMAND_ID = "pier.files.editor.paste";
 export const FILES_EDITOR_SELECT_ALL_COMMAND_ID = "pier.files.editor.selectAll";
 
+export const FILES_PROJECT_STATUS_ITEM_ID = "pier.files.project";
 export const FILES_PLUGIN_MANIFEST = {
   apiVersion: 1,
   commands: [
@@ -37,13 +38,13 @@ export const FILES_PLUGIN_MANIFEST = {
     {
       category: "file",
       id: FILES_NEW_FILE_COMMAND_ID,
-      permissions: ["file:read", "file:write"],
+      permissions: ["file:read", "file:write", "panel:open"],
       title: "New File...",
     },
     {
       category: "file",
       id: FILES_NEW_FOLDER_COMMAND_ID,
-      permissions: ["file:read", "file:write"],
+      permissions: ["file:read", "file:write", "panel:open"],
       title: "New Folder...",
     },
     {
@@ -179,6 +180,14 @@ export const FILES_PLUGIN_MANIFEST = {
   ],
   publisher: "Pier",
   source: { kind: "builtin" },
-  terminalStatusItems: [],
+  terminalStatusItems: [
+    {
+      alignment: "right",
+      id: FILES_PROJECT_STATUS_ITEM_ID,
+      order: 9,
+      permissions: ["panel:open", "file:read"],
+      title: "Project",
+    },
+  ],
   version: "1.0.0",
 } satisfies PluginManifest;

--- a/src/plugins/builtin/files/renderer/file-tree-preferences.ts
+++ b/src/plugins/builtin/files/renderer/file-tree-preferences.ts
@@ -42,6 +42,9 @@ export function filePanelProjectRoot(
 export function projectNameFromRoot(root: string): string {
   return root.split("/").filter(Boolean).at(-1) ?? root;
 }
+export function ensureProjectFileTreeExpanded(root: string): void {
+  writeTreeCollapsed(root, false);
+}
 
 export function useProjectFileTreeCollapsed(
   root: string | null

--- a/src/plugins/builtin/files/renderer/files-open-project.ts
+++ b/src/plugins/builtin/files/renderer/files-open-project.ts
@@ -1,0 +1,71 @@
+import type { RendererPluginContext } from "@plugins/api/renderer.ts";
+import type { PanelContext } from "@shared/contracts/panel.ts";
+import { panelContextSchema } from "@shared/contracts/panel.ts";
+import { FILES_FILE_PANEL_ID } from "../manifest.ts";
+import {
+  ensureProjectFileTreeExpanded,
+  projectNameFromRoot,
+} from "./file-tree-preferences.ts";
+import { projectAnchor } from "./files-project-anchor.ts";
+import { stableFileIdentityHash } from "./files-stable-hash.ts";
+import { revealFilesTreePath } from "./files-tree-registry.ts";
+
+const REVEAL_DELAY_MS = 80;
+
+export function createProjectFilesInstanceId(root: string): string {
+  return `${FILES_FILE_PANEL_ID}:project:${stableFileIdentityHash(root)}`;
+}
+
+function contextFromParams(params: unknown): PanelContext | undefined {
+  if (!params || typeof params !== "object" || !("context" in params)) {
+    return;
+  }
+  const raw = (params as { context: unknown }).context;
+  const parsed = panelContextSchema.safeParse(raw);
+  return parsed.success ? parsed.data : undefined;
+}
+
+export function openProjectFiles(
+  pluginContext: RendererPluginContext,
+  panelContext: PanelContext
+): { ok: true } | { ok: false; reason: "no-anchor" | "open-failed" } {
+  const anchor = projectAnchor(panelContext);
+  if (!anchor) {
+    return { ok: false, reason: "no-anchor" };
+  }
+
+  try {
+    const instances = pluginContext.panels.listInstances(FILES_FILE_PANEL_ID);
+    const existing = instances.find(
+      (instance) => projectAnchor(contextFromParams(instance.params)) === anchor
+    );
+
+    if (existing) {
+      pluginContext.panels.openInstance({
+        componentId: FILES_FILE_PANEL_ID,
+        context: panelContext,
+        instanceId: existing.id,
+        params: existing.params ? { ...existing.params } : {},
+        title: existing.title,
+        ...(existing.groupId ? { targetGroupId: existing.groupId } : {}),
+      });
+    } else {
+      pluginContext.panels.openInstance({
+        componentId: FILES_FILE_PANEL_ID,
+        context: panelContext,
+        instanceId: createProjectFilesInstanceId(anchor),
+        params: {},
+        title: projectNameFromRoot(anchor),
+      });
+    }
+
+    ensureProjectFileTreeExpanded(anchor);
+    globalThis.setTimeout(() => {
+      revealFilesTreePath({ path: "", root: anchor });
+    }, REVEAL_DELAY_MS);
+
+    return { ok: true };
+  } catch {
+    return { ok: false, reason: "open-failed" };
+  }
+}

--- a/src/plugins/builtin/files/renderer/files-project-anchor.ts
+++ b/src/plugins/builtin/files/renderer/files-project-anchor.ts
@@ -1,0 +1,44 @@
+import type { PanelContext } from "@shared/contracts/panel.ts";
+
+function nonEmpty(value: string | undefined): string | null {
+  return value && value.length > 0 ? value : null;
+}
+
+export function projectAnchor(
+  context: PanelContext | undefined
+): string | null {
+  if (!context) {
+    return null;
+  }
+  return (
+    nonEmpty(context.projectRootPath) ??
+    nonEmpty(context.worktreeRoot) ??
+    nonEmpty(context.gitRoot) ??
+    nonEmpty(context.cwd)
+  );
+}
+
+function stripTrailingSeparators(value: string): string {
+  return value.replace(/[\\/]+$/, "") || value;
+}
+
+export function formatProjectPath(
+  path: string,
+  homeDirectory: string | null = null
+): string {
+  const normalized = stripTrailingSeparators(path);
+  const home = homeDirectory ? stripTrailingSeparators(homeDirectory) : null;
+  if (!(home && home !== "/" && home !== "\\")) {
+    return normalized;
+  }
+  if (normalized === home) {
+    return "~";
+  }
+  if (normalized.startsWith(`${home}/`)) {
+    return `~/${normalized.slice(home.length + 1)}`;
+  }
+  if (normalized.startsWith(`${home}\\`)) {
+    return `~/${normalized.slice(home.length + 1).replace(/\\/g, "/")}`;
+  }
+  return normalized;
+}

--- a/src/plugins/builtin/files/renderer/files-project-status-item.tsx
+++ b/src/plugins/builtin/files/renderer/files-project-status-item.tsx
@@ -1,0 +1,75 @@
+import { Button } from "@pier/ui/button.tsx";
+import type {
+  RendererPluginContext,
+  RendererTerminalStatusItemContext,
+} from "@plugins/api/renderer.ts";
+import { Folder } from "lucide-react";
+import { FILES_PROJECT_STATUS_ITEM_ID } from "../manifest.ts";
+import { openProjectFiles } from "./files-open-project.ts";
+import { formatProjectPath, projectAnchor } from "./files-project-anchor.ts";
+
+export function isFilesProjectStatusVisible(
+  statusContext: RendererTerminalStatusItemContext
+): boolean {
+  return projectAnchor(statusContext.context) != null;
+}
+
+function FilesProjectStatusItem({
+  pluginContext,
+  ...statusContext
+}: RendererTerminalStatusItemContext & {
+  pluginContext: RendererPluginContext;
+}) {
+  const anchor = projectAnchor(statusContext.context);
+  if (!(anchor && statusContext.context)) {
+    return null;
+  }
+  const panelContext = statusContext.context;
+  const label = formatProjectPath(anchor, null);
+  const t = (key: string, fallback: string) =>
+    pluginContext.i18n.t(key, undefined, fallback);
+  const openLabel = t("files.projectStatus.openLabel", "Open project files");
+  const openTooltip = t(
+    "files.projectStatus.openTooltip",
+    "Open project files"
+  );
+
+  return (
+    <Button
+      aria-label={openLabel}
+      className="h-5 min-w-0 max-w-56 gap-1 px-2 font-normal text-xs"
+      data-testid="files-project-status-trigger"
+      onClick={() => {
+        const result = openProjectFiles(pluginContext, panelContext);
+        if (!result.ok) {
+          pluginContext.notifications.error(
+            t("files.projectStatus.openFailed", "Unable to open project files")
+          );
+        }
+      }}
+      size="xs"
+      title={`${openTooltip}\n${anchor}`}
+      type="button"
+      variant="outline"
+    >
+      <Folder aria-hidden="true" className="size-3 shrink-0 opacity-70" />
+      <span className="min-w-0 truncate" dir="rtl">
+        <span dir="ltr" style={{ unicodeBidi: "isolate" }}>
+          {label}
+        </span>
+      </span>
+    </Button>
+  );
+}
+
+export function registerFilesProjectStatusItem(
+  context: RendererPluginContext
+): () => void {
+  return context.terminalStatusItems.register({
+    id: FILES_PROJECT_STATUS_ITEM_ID,
+    isVisible: isFilesProjectStatusVisible,
+    render: (statusContext) => (
+      <FilesProjectStatusItem {...statusContext} pluginContext={context} />
+    ),
+  });
+}

--- a/src/plugins/builtin/files/renderer/index.tsx
+++ b/src/plugins/builtin/files/renderer/index.tsx
@@ -33,6 +33,7 @@ import { createFilesEditorActions } from "./files-editor-actions.ts";
 import { clearFilesEditorViews } from "./files-editor-view-registry.ts";
 import { clearFilesNavHistory } from "./files-nav-history.ts";
 import { hasOtherOpenFilesSourceInstance } from "./files-panel-instance-utils.ts";
+import { registerFilesProjectStatusItem } from "./files-project-status-item.tsx";
 import {
   clearFileTreeSidebarCache,
   openFilesTreeSearch,
@@ -315,6 +316,7 @@ export const filesRendererPlugin: RendererPluginModule = {
       ...createFilesEditorActions(context).map((action) =>
         context.actions.register(action)
       ),
+      registerFilesProjectStatusItem(context),
     ];
 
     return () => {

--- a/tests/unit/renderer/files-open-project.test.ts
+++ b/tests/unit/renderer/files-open-project.test.ts
@@ -1,0 +1,131 @@
+import type {
+  PluginPanelInstanceSnapshot,
+  RendererPluginContext,
+} from "@plugins/api/renderer.ts";
+import type { PanelContext } from "@shared/contracts/panel.ts";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { FILES_FILE_PANEL_ID } from "../../../src/plugins/builtin/files/manifest.ts";
+import * as prefs from "../../../src/plugins/builtin/files/renderer/file-tree-preferences.ts";
+import { openProjectFiles } from "../../../src/plugins/builtin/files/renderer/files-open-project.ts";
+import * as treeRegistry from "../../../src/plugins/builtin/files/renderer/files-tree-registry.ts";
+
+const baseContext: PanelContext = {
+  contextId: "ctx:1",
+  projectRootPath: "/Users/a/proj",
+  updatedAt: 1,
+  cwd: "/Users/a/proj/src",
+};
+
+function makePlugin(overrides?: {
+  listInstances?: PluginPanelInstanceSnapshot[];
+  openInstance?: RendererPluginContext["panels"]["openInstance"];
+}): RendererPluginContext {
+  const openInstance =
+    overrides?.openInstance ??
+    vi.fn<RendererPluginContext["panels"]["openInstance"]>();
+  const listInstances = overrides?.listInstances ?? [];
+
+  return {
+    actions: { register: vi.fn() },
+    commands: { register: vi.fn(), invoke: vi.fn() },
+    configuration: { get: vi.fn(), set: vi.fn(), onChange: vi.fn() },
+    environments: {} as RendererPluginContext["environments"],
+    files: {} as RendererPluginContext["files"],
+    git: {} as RendererPluginContext["git"],
+    i18n: { t: vi.fn((key: string) => key), lang: "en" },
+    missionControlWidgets: { register: vi.fn() },
+    notifications: {
+      error: vi.fn(),
+      info: vi.fn(),
+      success: vi.fn(),
+      warning: vi.fn(),
+    },
+    overlays: { open: vi.fn() },
+    panels: {
+      getActiveContext: vi.fn(),
+      getActiveInstanceId: vi.fn(),
+      listInstances: vi.fn().mockReturnValue(listInstances),
+      open: vi.fn(),
+      openInstance,
+      register: vi.fn(),
+      registerCloseGuard: vi.fn(),
+    },
+    commandPalette: { openQuickPick: vi.fn() },
+    settings: { openSection: vi.fn() },
+    terminal: {} as RendererPluginContext["terminal"],
+    terminalStatusItems: { register: vi.fn() },
+    worktrees: {} as RendererPluginContext["worktrees"],
+  } as unknown as RendererPluginContext;
+}
+
+describe("openProjectFiles", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns no-anchor when context lacks project fields", () => {
+    const plugin = makePlugin();
+    const result = openProjectFiles(plugin, {
+      contextId: "x",
+      projectRootPath: "",
+      updatedAt: 1,
+    } as PanelContext);
+    expect(result).toEqual({ ok: false, reason: "no-anchor" });
+  });
+
+  it("opens a new empty files instance for the project root", () => {
+    const openInstance = vi.fn();
+    const plugin = makePlugin({ listInstances: [], openInstance });
+    const expand = vi.spyOn(prefs, "ensureProjectFileTreeExpanded");
+    expect(openProjectFiles(plugin, baseContext)).toEqual({ ok: true });
+    expect(openInstance).toHaveBeenCalledWith(
+      expect.objectContaining({
+        componentId: FILES_FILE_PANEL_ID,
+        context: baseContext,
+        params: {},
+      })
+    );
+    expect(expand).toHaveBeenCalledWith("/Users/a/proj");
+    expand.mockRestore();
+  });
+
+  it("reuses an existing instance for the same project anchor", () => {
+    const openInstance = vi.fn();
+    const plugin = makePlugin({
+      listInstances: [
+        {
+          id: "existing-id",
+          componentId: FILES_FILE_PANEL_ID,
+          groupId: "g1",
+          title: "proj",
+          params: {
+            context: baseContext,
+            source: { kind: "disk", path: "a.ts", root: "/Users/a/proj" },
+          },
+        },
+      ],
+      openInstance,
+    });
+    openProjectFiles(plugin, baseContext);
+    expect(openInstance).toHaveBeenCalledWith(
+      expect.objectContaining({ instanceId: "existing-id" })
+    );
+  });
+
+  it("schedules reveal after open", () => {
+    const reveal = vi
+      .spyOn(treeRegistry, "revealFilesTreePath")
+      .mockReturnValue(true);
+    const plugin = makePlugin({ listInstances: [], openInstance: vi.fn() });
+    openProjectFiles(plugin, baseContext);
+    expect(reveal).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(80);
+    expect(reveal).toHaveBeenCalledWith(
+      expect.objectContaining({ root: "/Users/a/proj" })
+    );
+    reveal.mockRestore();
+  });
+});

--- a/tests/unit/renderer/files-project-anchor.test.ts
+++ b/tests/unit/renderer/files-project-anchor.test.ts
@@ -1,0 +1,82 @@
+import type { PanelContext } from "@shared/contracts/panel.ts";
+import { describe, expect, it } from "vitest";
+import {
+  formatProjectPath,
+  projectAnchor,
+} from "../../../src/plugins/builtin/files/renderer/files-project-anchor.ts";
+
+function ctx(
+  partial: Partial<PanelContext> &
+    Pick<PanelContext, "contextId" | "projectRootPath" | "updatedAt">
+): PanelContext {
+  return partial;
+}
+
+describe("projectAnchor", () => {
+  it("returns null when context is missing", () => {
+    expect(projectAnchor(undefined)).toBeNull();
+  });
+
+  it("prefers projectRootPath over worktree/git/cwd", () => {
+    expect(
+      projectAnchor(
+        ctx({
+          contextId: "c",
+          projectRootPath: "/repo",
+          updatedAt: 1,
+          worktreeRoot: "/repo-wt",
+          gitRoot: "/repo-git",
+          cwd: "/repo/src",
+        })
+      )
+    ).toBe("/repo");
+  });
+
+  it("falls back worktreeRoot → gitRoot → cwd when projectRootPath is empty", () => {
+    expect(
+      projectAnchor(
+        ctx({
+          contextId: "c",
+          projectRootPath: "",
+          updatedAt: 1,
+          worktreeRoot: "/wt",
+        })
+      )
+    ).toBe("/wt");
+    expect(
+      projectAnchor(
+        ctx({
+          contextId: "c",
+          projectRootPath: "",
+          updatedAt: 1,
+          gitRoot: "/git",
+        })
+      )
+    ).toBe("/git");
+    expect(
+      projectAnchor(
+        ctx({
+          contextId: "c",
+          projectRootPath: "",
+          updatedAt: 1,
+          cwd: "/cwd",
+        })
+      )
+    ).toBe("/cwd");
+  });
+});
+
+describe("formatProjectPath", () => {
+  it("returns absolute path when home is null", () => {
+    expect(formatProjectPath("/Users/a/proj", null)).toBe("/Users/a/proj");
+  });
+
+  it("folds home to ~", () => {
+    expect(formatProjectPath("/Users/a", "/Users/a")).toBe("~");
+    expect(formatProjectPath("/Users/a/proj", "/Users/a")).toBe("~/proj");
+  });
+
+  it("strips trailing separators before compare", () => {
+    expect(formatProjectPath("/Users/a/proj/", "/Users/a/")).toBe("~/proj");
+  });
+});

--- a/tests/unit/renderer/files-project-status-item.test.tsx
+++ b/tests/unit/renderer/files-project-status-item.test.tsx
@@ -1,0 +1,57 @@
+import type { PanelContext } from "@shared/contracts/panel.ts";
+import { describe, expect, it } from "vitest";
+import { isFilesProjectStatusVisible } from "../../../src/plugins/builtin/files/renderer/files-project-status-item.tsx";
+
+function makeStatusContext(panelContext?: PanelContext) {
+  return {
+    context: panelContext,
+    cwd: panelContext?.cwd ?? null,
+    panelId: "terminal-1",
+    title: "Terminal",
+  };
+}
+
+describe("isFilesProjectStatusVisible", () => {
+  it("returns false when context is undefined", () => {
+    expect(isFilesProjectStatusVisible(makeStatusContext(undefined))).toBe(
+      false
+    );
+  });
+
+  it("returns false when context has no project root", () => {
+    expect(
+      isFilesProjectStatusVisible(
+        makeStatusContext({
+          contextId: "x",
+          projectRootPath: "",
+          updatedAt: 1,
+        } as PanelContext)
+      )
+    ).toBe(false);
+  });
+
+  it("returns true when context has projectRootPath", () => {
+    expect(
+      isFilesProjectStatusVisible(
+        makeStatusContext({
+          contextId: "c",
+          projectRootPath: "/repo",
+          updatedAt: 1,
+        } as PanelContext)
+      )
+    ).toBe(true);
+  });
+
+  it("returns true when context has worktreeRoot", () => {
+    expect(
+      isFilesProjectStatusVisible(
+        makeStatusContext({
+          contextId: "c",
+          projectRootPath: "",
+          worktreeRoot: "/wt",
+          updatedAt: 1,
+        } as PanelContext)
+      )
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

给 `pier.files` 插件新增 `pier.files.project` 终端状态栏入口。

### 能力
- **展示项目根路径**：优先级 `projectRootPath → worktreeRoot → gitRoot → cwd`，支持 `~/` 折叠（home directory）
- **点击打开 Files 面板**：同项目实例复用、自动展开树、reveal 项目根
- **失败反馈**：`notifications.error`；成功不加 toast（有强视觉反馈）
- **无项目时不显示**：`projectAnchor` 返回 null 时隐藏状态项

### Spec 覆盖
| 需求 | 状态 |
|------|------|
| `pier.files.project` manifest + order 9 right | ✅ |
| `projectAnchor` 优先级 / 无锚点隐藏 | ✅ |
| `~/` 折叠（无 home → 绝对路径）| ✅ |
| 点击打开 Files、项目根、复用实例 | ✅ |
| 展开树 + reveal | ✅ |
| 失败 notifications.error，成功无 toast | ✅ |
| 不随 shell cwd 变文案 | ✅ |
| 非 Git 仍显示 | ✅ |
| 测试锚点/折叠/打开/注册 | ✅ 14 项测试 |

### 文件
- **新建 4**：`files-project-anchor.ts`, `files-open-project.ts`, `files-project-status-item.tsx`, 两项 test 文件
- **修改 5**：`manifest.ts`, `locales/en.json`, `locales/zh-CN.json`, `file-tree-preferences.ts`, `renderer/index.tsx`
