### PR TITLE
feat(files): inline file/folder creation in file tree

### DIFF
--- a/docs/superpowers/plans/2026-07-09-files-project-status-item.md
+++ b/docs/superpowers/plans/2026-07-09-files-project-status-item.md
@@ -1,0 +1,706 @@
+# Files 终端状态栏「当前项目」入口 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 让 `pier.files` 在终端状态栏贡献 `pier.files.project`：展示当前项目根并点击打开 Files 树（锚定项目根，不对齐 shell cwd）。
+
+**Architecture:** 纯函数解析项目锚点与路径展示；`openProjectFiles` 复用/打开无 `source` 的 Files 实例并展开树；状态项组件形态对齐 `pier.worktree.status`，经 manifest + `terminalStatusItems.register` 接入现有合并管道。
+
+**Tech Stack:** React 19、TypeScript strict、`@pier/ui` Button、Vitest 4、现有 plugin terminalStatusItems / panels.openInstance / files-tree-registry。
+
+**配套设计：** `docs/superpowers/specs/2026-07-09-files-project-status-item-design.md`
+
+## Global Constraints
+
+- 展示与打开锚定**项目根**，不随 shell `cd` 变化。
+- 归属 `pier.files`，不做 core 状态项、不新建 header 池。
+- 用户可见文案全部走插件 i18n；失败用 `notifications.error`，成功不加 toast。
+- 禁止 `@ts-ignore` / `@ts-expect-error` / `as any`。
+- 默认 git 只读：本计划步骤含 commit 时，执行前先向用户确认；未确认则只改文件不提交。
+
+---
+
+## 文件结构
+
+**新建**
+
+- `src/plugins/builtin/files/renderer/files-project-anchor.ts`：`projectAnchor` + `formatProjectPath` 纯函数。
+- `src/plugins/builtin/files/renderer/files-open-project.ts`：`openProjectFiles`（打开/复用 Files + 展开树 + reveal 根）。
+- `src/plugins/builtin/files/renderer/files-project-status-item.tsx`：状态项 UI + `registerFilesProjectStatusItem`。
+- `tests/unit/renderer/files-project-anchor.test.ts`
+- `tests/unit/renderer/files-open-project.test.ts`
+- `tests/unit/renderer/files-project-status-item.test.tsx`
+
+**修改**
+
+- `src/plugins/builtin/files/manifest.ts`：声明 `terminalStatusItems` + 导出 id 常量。
+- `src/plugins/builtin/files/locales/en.json` / `zh-CN.json`：`terminalStatusItems` + 打开失败文案。
+- `src/plugins/builtin/files/renderer/file-tree-preferences.ts`：导出 `ensureProjectFileTreeExpanded`。
+- `src/plugins/builtin/files/renderer/index.tsx`：activate 注册状态项。
+
+---
+
+### Task 1: 项目锚点与路径折叠纯函数
+
+**Files:**
+- Create: `src/plugins/builtin/files/renderer/files-project-anchor.ts`
+- Test: `tests/unit/renderer/files-project-anchor.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `projectAnchor(context: PanelContext | undefined): string | null`
+  - `formatProjectPath(path: string, homeDirectory?: string | null): string`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from "vitest";
+import type { PanelContext } from "@shared/contracts/panel.ts";
+import {
+  formatProjectPath,
+  projectAnchor,
+} from "../../../src/plugins/builtin/files/renderer/files-project-anchor.ts";
+
+function ctx(partial: Partial<PanelContext> & Pick<PanelContext, "contextId" | "projectRootPath" | "updatedAt">): PanelContext {
+  return partial;
+}
+
+describe("projectAnchor", () => {
+  it("returns null when context is missing", () => {
+    expect(projectAnchor(undefined)).toBeNull();
+  });
+
+  it("prefers projectRootPath over worktree/git/cwd", () => {
+    expect(
+      projectAnchor(
+        ctx({
+          contextId: "c",
+          projectRootPath: "/repo",
+          updatedAt: 1,
+          worktreeRoot: "/repo-wt",
+          gitRoot: "/repo-git",
+          cwd: "/repo/src",
+        })
+      )
+    ).toBe("/repo");
+  });
+
+  it("falls back worktreeRoot → gitRoot → cwd when projectRootPath is empty", () => {
+    expect(
+      projectAnchor(
+        ctx({
+          contextId: "c",
+          projectRootPath: "",
+          updatedAt: 1,
+          worktreeRoot: "/wt",
+        })
+      )
+    ).toBe("/wt");
+    expect(
+      projectAnchor(
+        ctx({
+          contextId: "c",
+          projectRootPath: "",
+          updatedAt: 1,
+          gitRoot: "/git",
+        })
+      )
+    ).toBe("/git");
+    expect(
+      projectAnchor(
+        ctx({
+          contextId: "c",
+          projectRootPath: "",
+          updatedAt: 1,
+          cwd: "/cwd",
+        })
+      )
+    ).toBe("/cwd");
+  });
+});
+
+describe("formatProjectPath", () => {
+  it("returns absolute path when home is null", () => {
+    expect(formatProjectPath("/Users/a/proj", null)).toBe("/Users/a/proj");
+  });
+
+  it("folds home to ~", () => {
+    expect(formatProjectPath("/Users/a", "/Users/a")).toBe("~");
+    expect(formatProjectPath("/Users/a/proj", "/Users/a")).toBe("~/proj");
+  });
+
+  it("strips trailing separators before compare", () => {
+    expect(formatProjectPath("/Users/a/proj/", "/Users/a/")).toBe("~/proj");
+  });
+});
+```
+
+修正「fallback」用例为不依赖非法 `projectRootPath: undefined`：用类型断言构造仅含 `worktreeRoot` / `gitRoot` / `cwd` 的对象，或在实现里对 `projectRootPath` 做空串忽略。推荐实现：
+
+```ts
+function nonEmpty(value: string | undefined): string | null {
+  return value && value.length > 0 ? value : null;
+}
+```
+
+优先级：`projectRootPath` → `worktreeRoot` → `gitRoot` → `cwd`（与 spec 一致；**不要**用 `openedPath`，避免与 `filePanelProjectRoot` 在「打开文件路径」场景分叉——本状态项只要项目根）。
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run tests/unit/renderer/files-project-anchor.test.ts`
+
+Expected: FAIL（模块不存在）
+
+- [ ] **Step 3: Write minimal implementation**
+
+`src/plugins/builtin/files/renderer/files-project-anchor.ts`:
+
+```ts
+import type { PanelContext } from "@shared/contracts/panel.ts";
+
+function nonEmpty(value: string | undefined): string | null {
+  return value && value.length > 0 ? value : null;
+}
+
+export function projectAnchor(
+  context: PanelContext | undefined
+): string | null {
+  if (!context) {
+    return null;
+  }
+  return (
+    nonEmpty(context.projectRootPath) ??
+    nonEmpty(context.worktreeRoot) ??
+    nonEmpty(context.gitRoot) ??
+    nonEmpty(context.cwd)
+  );
+}
+
+function stripTrailingSeparators(value: string): string {
+  return value.replace(/[\\/]+$/, "") || value;
+}
+
+export function formatProjectPath(
+  path: string,
+  homeDirectory: string | null = null
+): string {
+  const normalized = stripTrailingSeparators(path);
+  const home = homeDirectory ? stripTrailingSeparators(homeDirectory) : null;
+  if (!(home && home !== "/" && home !== "\\")) {
+    return normalized;
+  }
+  if (normalized === home) {
+    return "~";
+  }
+  if (normalized.startsWith(`${home}/`)) {
+    return `~/${normalized.slice(home.length + 1)}`;
+  }
+  if (normalized.startsWith(`${home}\\`)) {
+    return `~/${normalized.slice(home.length + 1).replace(/\\/g, "/")}`;
+  }
+  return normalized;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm exec vitest run tests/unit/renderer/files-project-anchor.test.ts`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**（需用户确认后）
+
+```bash
+git add src/plugins/builtin/files/renderer/files-project-anchor.ts tests/unit/renderer/files-project-anchor.test.ts
+git commit -m "$(cat <<'EOF'
+feat(files): add project anchor and path fold helpers
+
+Pure helpers for the terminal project status item display and open target.
+EOF
+)"
+```
+
+---
+
+### Task 2: `openProjectFiles` 打开/复用 Files 并展开树
+
+**Files:**
+- Modify: `src/plugins/builtin/files/renderer/file-tree-preferences.ts`
+- Create: `src/plugins/builtin/files/renderer/files-open-project.ts`
+- Test: `tests/unit/renderer/files-open-project.test.ts`
+
+**Interfaces:**
+- Consumes: `projectAnchor`；`revealFilesTreePath` / `findFilesTreeInstanceId`；`FILES_FILE_PANEL_ID`；`panels.openInstance` / `listInstances`
+- Produces:
+  - `ensureProjectFileTreeExpanded(root: string): void`
+  - `openProjectFiles(pluginContext, panelContext): { ok: true } | { ok: false; reason: "no-anchor" | "open-failed" }`
+  - `createProjectFilesInstanceId(root: string): string`（稳定空面板 id）
+
+打开策略（锁定）：
+
+1. `anchor = projectAnchor(panelContext)`；无则 `{ ok: false, reason: "no-anchor" }`。
+2. `listInstances(FILES_FILE_PANEL_ID)`，找 `projectAnchor(instance.params.context) === anchor` 的已有实例（params.context 经 `panelContextSchema.safeParse`）。
+3. 若有：`openInstance` 同 `instanceId`，带上 `context: panelContext`，保留已有 `params`（含 source），只激活/聚焦。
+4. 若无：`openInstance` 新实例，`instanceId = pier.files.filePanel:project:${hash(anchor)}`，`params: {}`（无 source → empty + 树），`title = projectNameFromRoot(anchor)`，`context: panelContext`。
+5. `ensureProjectFileTreeExpanded(anchor)`（写 localStorage collapsed=false）。
+6. `setTimeout(80ms)` 后 `revealFilesTreePath({ root: anchor, path: "" })` 或 path=`anchor` 的相对空——树 API 对根用 `""` 或 `"."`；若 `revealPath("")` 无效则 reveal 根目录名。以现有 `PierFileTree.revealPath` 行为为准：对项目根传 `""`；若测试/运行无效，改为不传 reveal、仅展开树（仍算达标「打开到项目根」）。
+7. `openInstance` 抛错 → catch → `{ ok: false, reason: "open-failed" }`。
+
+- [ ] **Step 1: Export tree expand helper**
+
+在 `file-tree-preferences.ts` 增加：
+
+```ts
+export function ensureProjectFileTreeExpanded(root: string): void {
+  writeTreeCollapsed(root, false);
+}
+```
+
+- [ ] **Step 2: Write the failing openProjectFiles tests**
+
+```ts
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import type { PanelContext } from "@shared/contracts/panel.ts";
+import type { RendererPluginContext } from "@plugins/api/renderer.ts";
+import { FILES_FILE_PANEL_ID } from "../../../src/plugins/builtin/files/manifest.ts";
+import { openProjectFiles } from "../../../src/plugins/builtin/files/renderer/files-open-project.ts";
+import * as treeRegistry from "../../../src/plugins/builtin/files/renderer/files-tree-registry.ts";
+import * as prefs from "../../../src/plugins/builtin/files/renderer/file-tree-preferences.ts";
+
+const baseContext: PanelContext = {
+  contextId: "ctx:1",
+  projectRootPath: "/Users/a/proj",
+  updatedAt: 1,
+  cwd: "/Users/a/proj/src",
+};
+
+function makePlugin(overrides?: {
+  listInstances?: PluginPanelInstance[];
+  openInstance?: ReturnType<typeof vi.fn>;
+}): RendererPluginContext {
+  // 最小 mock：panels.listInstances / openInstance；其余用 vi.fn
+}
+
+describe("openProjectFiles", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns no-anchor when context lacks project fields", () => {
+    const plugin = makePlugin();
+    expect(
+      openProjectFiles(plugin, {
+        contextId: "x",
+        projectRootPath: "",
+        updatedAt: 1,
+      } as PanelContext)
+    ).toEqual({ ok: false, reason: "no-anchor" });
+  });
+
+  it("opens a new empty files instance for the project root", () => {
+    const openInstance = vi.fn();
+    const plugin = makePlugin({ listInstances: [], openInstance });
+    const expand = vi.spyOn(prefs, "ensureProjectFileTreeExpanded");
+    expect(openProjectFiles(plugin, baseContext)).toEqual({ ok: true });
+    expect(openInstance).toHaveBeenCalledWith(
+      expect.objectContaining({
+        componentId: FILES_FILE_PANEL_ID,
+        context: baseContext,
+        params: {},
+      })
+    );
+    expect(expand).toHaveBeenCalledWith("/Users/a/proj");
+  });
+
+  it("reuses an existing instance for the same project anchor", () => {
+    const openInstance = vi.fn();
+    const plugin = makePlugin({
+      listInstances: [
+        {
+          id: "existing-id",
+          componentId: FILES_FILE_PANEL_ID,
+          groupId: "g1",
+          title: "proj",
+          params: { context: baseContext, source: { kind: "disk", path: "a.ts", root: "/Users/a/proj" } },
+        },
+      ],
+      openInstance,
+    });
+    openProjectFiles(plugin, baseContext);
+    expect(openInstance).toHaveBeenCalledWith(
+      expect.objectContaining({ instanceId: "existing-id" })
+    );
+  });
+
+  it("schedules reveal after open", () => {
+    const reveal = vi.spyOn(treeRegistry, "revealFilesTreePath").mockReturnValue(true);
+    const plugin = makePlugin({ listInstances: [], openInstance: vi.fn() });
+    openProjectFiles(plugin, baseContext);
+    expect(reveal).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(80);
+    expect(reveal).toHaveBeenCalledWith(
+      expect.objectContaining({ root: "/Users/a/proj" })
+    );
+  });
+});
+```
+
+（按仓库现有 mock 风格补全 `makePlugin`；可参考 `tests/unit/renderer/files-tree-create.test.ts`。）
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `pnpm exec vitest run tests/unit/renderer/files-open-project.test.ts`
+
+Expected: FAIL
+
+- [ ] **Step 4: Implement `files-open-project.ts`**
+
+```ts
+import type { RendererPluginContext } from "@plugins/api/renderer.ts";
+import type { PanelContext } from "@shared/contracts/panel.ts";
+import { panelContextSchema } from "@shared/contracts/panel.ts";
+import { FILES_FILE_PANEL_ID } from "../manifest.ts";
+import { projectNameFromRoot, ensureProjectFileTreeExpanded } from "./file-tree-preferences.ts";
+import { projectAnchor } from "./files-project-anchor.ts";
+import { revealFilesTreePath } from "./files-tree-registry.ts";
+import { stableFileIdentityHash } from "./files-stable-hash.ts";
+
+const REVEAL_DELAY_MS = 80;
+
+export function createProjectFilesInstanceId(root: string): string {
+  return `${FILES_FILE_PANEL_ID}:project:${stableFileIdentityHash(root)}`;
+}
+
+function contextFromParams(params: unknown): PanelContext | undefined {
+  if (!params || typeof params !== "object" || !("context" in params)) {
+    return;
+  }
+  const parsed = panelContextSchema.safeParse(
+    (params as { context: unknown }).context
+  );
+  return parsed.success ? parsed.data : undefined;
+}
+
+export function openProjectFiles(
+  pluginContext: RendererPluginContext,
+  panelContext: PanelContext
+): { ok: true } | { ok: false; reason: "no-anchor" | "open-failed" } {
+  const anchor = projectAnchor(panelContext);
+  if (!anchor) {
+    return { ok: false, reason: "no-anchor" };
+  }
+
+  try {
+    const instances = pluginContext.panels.listInstances(FILES_FILE_PANEL_ID);
+    const existing = instances.find(
+      (instance) => projectAnchor(contextFromParams(instance.params)) === anchor
+    );
+
+    if (existing) {
+      pluginContext.panels.openInstance({
+        componentId: FILES_FILE_PANEL_ID,
+        context: panelContext,
+        instanceId: existing.id,
+        params: existing.params ? { ...existing.params } : {},
+        title: existing.title,
+        ...(existing.groupId ? { targetGroupId: existing.groupId } : {}),
+      });
+    } else {
+      pluginContext.panels.openInstance({
+        componentId: FILES_FILE_PANEL_ID,
+        context: panelContext,
+        instanceId: createProjectFilesInstanceId(anchor),
+        params: {},
+        title: projectNameFromRoot(anchor),
+      });
+    }
+
+    ensureProjectFileTreeExpanded(anchor);
+    globalThis.setTimeout(() => {
+      revealFilesTreePath({ path: "", root: anchor });
+    }, REVEAL_DELAY_MS);
+
+    return { ok: true };
+  } catch {
+    return { ok: false, reason: "open-failed" };
+  }
+}
+```
+
+若 `projectNameFromRoot` / `ensureProjectFileTreeExpanded` 导出路径需微调，以编译为准。
+
+- [ ] **Step 5: Run tests**
+
+Run: `pnpm exec vitest run tests/unit/renderer/files-open-project.test.ts`
+
+Expected: PASS
+
+- [ ] **Step 6: Commit**（需用户确认后）
+
+```bash
+git add src/plugins/builtin/files/renderer/file-tree-preferences.ts \
+  src/plugins/builtin/files/renderer/files-open-project.ts \
+  tests/unit/renderer/files-open-project.test.ts
+git commit -m "$(cat <<'EOF'
+feat(files): open project Files panel from status item helper
+
+Reuse same-project instances, expand the tree, and reveal the project root.
+EOF
+)"
+```
+
+---
+
+### Task 3: Manifest、i18n 与状态项 UI 注册
+
+**Files:**
+- Modify: `src/plugins/builtin/files/manifest.ts`
+- Modify: `src/plugins/builtin/files/locales/en.json`
+- Modify: `src/plugins/builtin/files/locales/zh-CN.json`
+- Create: `src/plugins/builtin/files/renderer/files-project-status-item.tsx`
+- Modify: `src/plugins/builtin/files/renderer/index.tsx`
+- Test: `tests/unit/renderer/files-project-status-item.test.tsx`
+
+**Interfaces:**
+- Consumes: `projectAnchor` / `formatProjectPath` / `openProjectFiles`
+- Produces: `FILES_PROJECT_STATUS_ITEM_ID = "pier.files.project"`；`registerFilesProjectStatusItem(context): () => void`
+
+- [ ] **Step 1: Manifest + locale**
+
+`manifest.ts` 增加：
+
+```ts
+export const FILES_PROJECT_STATUS_ITEM_ID = "pier.files.project";
+```
+
+`terminalStatusItems` 改为：
+
+```ts
+terminalStatusItems: [
+  {
+    alignment: "right",
+    id: FILES_PROJECT_STATUS_ITEM_ID,
+    order: 9,
+    permissions: ["panel:open", "file:read"],
+    title: "Project",
+  },
+],
+```
+
+`en.json` 增加顶层（与 git 插件同级结构）：
+
+```json
+"terminalStatusItems": {
+  "pier.files.project": {
+    "title": "Project",
+    "description": "Shows the current project and opens its file tree."
+  }
+}
+```
+
+`messages` 增加：
+
+```json
+"files.projectStatus.openLabel": "Open project files",
+"files.projectStatus.openTooltip": "Open project files",
+"files.projectStatus.openFailed": "Unable to open project files"
+```
+
+`zh-CN.json` 对应：
+
+```json
+"terminalStatusItems": {
+  "pier.files.project": {
+    "title": "项目",
+    "description": "显示当前项目并打开其文件树。"
+  }
+}
+```
+
+```json
+"files.projectStatus.openLabel": "打开项目文件",
+"files.projectStatus.openTooltip": "打开项目文件",
+"files.projectStatus.openFailed": "无法打开项目文件"
+```
+
+- [ ] **Step 2: Write status item tests**
+
+覆盖：
+
+1. `isVisible` / render：无锚点 → register 的 `isVisible` 为 false；有 `projectRootPath` → true。
+2. 点击调用 `openProjectFiles`；失败时 `notifications.error`。
+3. 按钮 `data-testid="files-project-status-trigger"` 存在；主文案为 `formatProjectPath(anchor)`（home=null → 绝对路径）。
+
+可用 `vi.mock("./files-open-project.ts")`。注册后从 registry 取 item 较重时，改为直接测导出的 `FilesProjectStatusItem` 组件 + 单独测 `isVisible` 函数（若抽出 `isFilesProjectStatusVisible`）。
+
+推荐抽出：
+
+```ts
+export function isFilesProjectStatusVisible(
+  statusContext: RendererTerminalStatusItemContext
+): boolean {
+  return projectAnchor(statusContext.context) != null;
+}
+```
+
+- [ ] **Step 3: Implement status item**
+
+`files-project-status-item.tsx`（对齐 git 触发器）：
+
+```tsx
+import { Button } from "@pier/ui/button.tsx";
+import type {
+  RendererPluginContext,
+  RendererTerminalStatusItemContext,
+} from "@plugins/api/renderer.ts";
+import { Folder } from "lucide-react";
+import { FILES_PROJECT_STATUS_ITEM_ID } from "../manifest.ts";
+import {
+  formatProjectPath,
+  projectAnchor,
+} from "./files-project-anchor.ts";
+import { openProjectFiles } from "./files-open-project.ts";
+
+export function isFilesProjectStatusVisible(
+  statusContext: RendererTerminalStatusItemContext
+): boolean {
+  return projectAnchor(statusContext.context) != null;
+}
+
+function FilesProjectStatusItem({
+  pluginContext,
+  ...statusContext
+}: RendererTerminalStatusItemContext & {
+  pluginContext: RendererPluginContext;
+}) {
+  const anchor = projectAnchor(statusContext.context);
+  if (!anchor || !statusContext.context) {
+    return null;
+  }
+  const label = formatProjectPath(anchor, null);
+  const t = (key: string, fallback: string) =>
+    pluginContext.i18n.t(key, undefined, fallback);
+  const openLabel = t("files.projectStatus.openLabel", "Open project files");
+  const openTooltip = t(
+    "files.projectStatus.openTooltip",
+    "Open project files"
+  );
+
+  return (
+    <Button
+      aria-label={openLabel}
+      className="h-5 min-w-0 max-w-56 gap-1 px-2 font-normal text-xs"
+      data-testid="files-project-status-trigger"
+      onClick={() => {
+        const result = openProjectFiles(
+          pluginContext,
+          statusContext.context as NonNullable<typeof statusContext.context>
+        );
+        if (!result.ok) {
+          pluginContext.notifications.error(
+            t(
+              "files.projectStatus.openFailed",
+              "Unable to open project files"
+            )
+          );
+        }
+      }}
+      size="xs"
+      title={`${openTooltip}\n${anchor}`}
+      type="button"
+      variant="outline"
+    >
+      <Folder className="size-3 shrink-0 opacity-70" aria-hidden="true" />
+      <span className="min-w-0 truncate" dir="rtl">
+        <span dir="ltr" style={{ unicodeBidi: "isolate" }}>
+          {label}
+        </span>
+      </span>
+    </Button>
+  );
+}
+
+export function registerFilesProjectStatusItem(
+  context: RendererPluginContext
+): () => void {
+  return context.terminalStatusItems.register({
+    id: FILES_PROJECT_STATUS_ITEM_ID,
+    isVisible: isFilesProjectStatusVisible,
+    render: (statusContext) => (
+      <FilesProjectStatusItem {...statusContext} pluginContext={context} />
+    ),
+  });
+}
+```
+
+避免 `as NonNullable`：在 `onClick` 前已 guard `statusContext.context`，把 `const panelContext = statusContext.context` 收窄后传入。
+
+- [ ] **Step 4: Wire activate**
+
+`index.tsx` 的 `disposers` 增加：
+
+```ts
+registerFilesProjectStatusItem(context),
+```
+
+- [ ] **Step 5: Run tests**
+
+```bash
+pnpm exec vitest run tests/unit/renderer/files-project-status-item.test.tsx tests/unit/renderer/files-project-anchor.test.ts tests/unit/renderer/files-open-project.test.ts
+```
+
+Expected: PASS
+
+- [ ] **Step 6: Lint / typecheck touched files**
+
+```bash
+pnpm exec biome check src/plugins/builtin/files/manifest.ts \
+  src/plugins/builtin/files/renderer/files-project-anchor.ts \
+  src/plugins/builtin/files/renderer/files-open-project.ts \
+  src/plugins/builtin/files/renderer/files-project-status-item.tsx \
+  src/plugins/builtin/files/renderer/file-tree-preferences.ts \
+  src/plugins/builtin/files/renderer/index.tsx
+pnpm exec tsc -p tsconfig.json --noEmit 2>&1 | head -40
+```
+
+（若全量 tsc 过慢，至少保证改动文件无新增诊断。）
+
+- [ ] **Step 7: Commit**（需用户确认后）
+
+```bash
+git add src/plugins/builtin/files/manifest.ts \
+  src/plugins/builtin/files/locales/en.json \
+  src/plugins/builtin/files/locales/zh-CN.json \
+  src/plugins/builtin/files/renderer/files-project-status-item.tsx \
+  src/plugins/builtin/files/renderer/index.tsx \
+  tests/unit/renderer/files-project-status-item.test.tsx
+git commit -m "$(cat <<'EOF'
+feat(files): add terminal project status item
+
+Contribute pier.files.project on the right status bar to open the
+current project file tree, matching Git item contribution patterns.
+EOF
+)"
+```
+
+---
+
+## Spec coverage（self-review）
+
+| Spec 要求 | Task |
+|---|---|
+| `pier.files.project` manifest + order 9 right | Task 3 |
+| `projectAnchor` 优先级 / 无锚点隐藏 | Task 1 + 3 |
+| `~/` 折叠（无 home → 绝对路径） | Task 1 + 3（home=null） |
+| 点击打开 Files、项目根、复用实例 | Task 2 |
+| 展开树 + reveal | Task 2 |
+| 失败 notifications.error，成功无 toast | Task 3 |
+| 不随 shell cwd 变文案 | Task 1/3 只用 anchor，不用 statusContext.cwd 主文案 |
+| 非 Git 仍显示 | Task 1 fallback 到 cwd |
+| 设置页/右键自动出现 | Task 3 manifest 声明（现有合并管道） |
+| 测试锚点/折叠/打开/注册 | Task 1–3 |
+
+**有意不做（spec 非目标）：** shell cwd 指示器、header 池、core 项、编辑器 status bar。

--- a/docs/superpowers/specs/2026-07-09-files-project-status-item-design.md
+++ b/docs/superpowers/specs/2026-07-09-files-project-status-item-design.md
@@ -1,0 +1,169 @@
+# Files 终端状态栏「当前项目」入口
+
+**日期**：2026-07-09  
+**范围**：`pier.files` 向终端状态栏贡献项目入口；点击打开 Files 并定位到当前项目根  
+**关联文档**：
+
+- [2026-07-02-plugin-configuration-and-statusbar-design.md](2026-07-02-plugin-configuration-and-statusbar-design.md)（插件状态栏贡献 / prefs 合并）
+- [2026-07-01-git-status-bar-design.md](2026-07-01-git-status-bar-design.md)（`pier.worktree.status` 形态与可见性先例）
+- [2026-07-02-project-file-tree-design.md](2026-07-02-project-file-tree-design.md)（Files 树根 = 项目锚点）
+- Loomdesk 参考：`header-directory-item.svelte`（终端目录入口；语义为本 spec **有意偏离** 的对照物）
+
+## 1. 背景与问题
+
+Loomdesk 终端顶栏有可点的 `directory` 项：展示 shell cwd（`~/...`），点击 `openExplorer` 打开文件管理。
+
+Pier 现状：
+
+- 终端状态栏已有 core agent/task + Git `pier.worktree.status`
+- `pier.files` 的 `terminalStatusItems: []`，没有对应入口
+- Files 树根锚定 `projectRootPath`（Git 优先 gitRoot，非 Git 为 cwd），不是 shell 瞬时 cwd
+- Shell cwd 已有 OSC7 → `PanelContext` → tab/title 管道，不缺「cwd 上报」
+
+若原样移植 loomdesk「展示并打开 shell cwd」，会与 Files 树根模型错位，并与 tab cwd 重复。需要的是：**终端上一键打开当前项目的文件管理**，工程形态对齐 Git 状态项。
+
+## 2. 目标 / 非目标
+
+### 目标
+
+1. `pier.files` 贡献终端状态项，作为「当前项目 → 打开 Files」入口。
+2. 可见性、右对齐、outline 小按钮形态与 `pier.worktree.status` 同构（工程模式对齐，不是同一字段）。
+3. 展示与点击均锚定**项目根**，与 Files 树根一致。
+4. 无项目上下文时不渲染；设置页 / 右键状态栏菜单自动出现该项（走现有 manifest 合并管道）。
+
+### 非目标
+
+- **不**做 loomdesk 等价的 shell cwd 常驻指示器（不随 `cd` 更新文案）。
+- **不**新建终端 header 贡献池。
+- **不**把该项做成 core 状态项。
+- **不**改 Git 状态栏、不改 cwd→tab 管道。
+- **不**在本项内做编码 / 行列 / 语言等编辑器 status bar。
+
+## 3. 产品定位（为何这是最佳实践）
+
+| 信号 | 落点 | 原因 |
+|---|---|---|
+| 项目 / 工作区身份 | 本状态项 + Files 面板 | 稳定、可行动；与树根一致 |
+| Git 分支 / 脏状态 | `pier.worktree.status` | 已有；职责不抢 |
+| Shell cwd | 终端 tab / title（已有） | 高频变化；业界也不常驻状态栏 |
+
+状态栏适合放稳定工作区动作；shell cwd 适合进程级 UI。点击目标必须等于 Files 数据模型的根，否则「显示路径 ≠ 打开结果」。
+
+相对 loomdesk：学「终端上有可点的目录/项目入口」，落点改为 Pier 的项目锚点——适配，不是 1:1 抄。
+
+## 4. 设计
+
+### 4.1 贡献声明
+
+插件：`pier.files`  
+状态项 id：`pier.files.project`
+
+```ts
+// manifest.terminalStatusItems
+{
+  id: "pier.files.project",
+  title: "Project",
+  alignment: "right",
+  order: 9, // 紧挨 pier.worktree.status (order 10) 左侧
+  permissions: ["panel:open", "file:read"],
+}
+```
+
+- locale：`terminalStatusItems.pier.files.project.{title,description}`
+- `activate` 里 `context.terminalStatusItems.register({ id, isVisible, render })`，dispose 进 cleanup
+
+### 4.2 项目锚点与可见性
+
+```ts
+function projectAnchor(context: PanelContext | undefined): string | null {
+  return (
+    context?.projectRootPath ??
+    context?.worktreeRoot ??
+    context?.gitRoot ??
+    context?.cwd ??
+    null
+  );
+}
+```
+
+- `isVisible` / `render`：无锚点 → 隐藏 / `null`（对齐 Git「无 worktree/gitRoot 不出现」的原则）
+- 非 Git 目录：仍可显示（锚点落到 `projectRootPath` 或 `cwd`）；**不要**要求 `gitRoot`
+- 启动瞬间 context 未到：隐藏，避免空路径闪烁
+
+展示用锚点路径，**不用**状态栏上下文里的瞬时 `cwd` 字段做主文案（`cwd` 仅可进 tooltip 辅助，可选）。
+
+### 4.3 展示
+
+- 文案：锚点绝对路径折叠为 `~/...`（home 前缀规则；无 home 信息时显示绝对路径）
+- 过长：`truncate` + `max-w-*`；tooltip 为全路径 + 简短说明（如「打开项目文件」）
+- 控件：`Button` `size="xs"` `variant="outline"`，可选 `Folder` 图标，与 Git 触发器同高（`h-5`）
+- `data-testid`：`files-project-status-trigger`
+- i18n：插件 messages，禁止内联用户可见字符串
+
+命名：UI / locale 用「项目 / Project」，避免「当前目录」造成 shell cwd 预期。
+
+### 4.4 点击行为
+
+```
+click
+  → resolve projectAnchor(panelContext)
+  → panels.openInstance({
+       componentId: FILES_FILE_PANEL_ID,
+       context: panelContext,
+       // 打开策略：复用现有 files 打开惯例（同 context 优先复用已有 group/instance）
+     })
+  → 确保文件树展开（若 collapsed 则展开）
+  → revealFilesTreePath({ root: anchor, path: "" | anchor-relative root })
+```
+
+细则：
+
+1. **打开**：带上当前终端的 `PanelContext`；优先聚焦已有同项目 Files 实例，避免无意义新开。
+2. **Reveal**：定位到项目根（树根本身）。不 reveal shell 子目录。
+3. **失败反馈**：打开或 reveal 失败 → `context.notifications.error`（i18n）；禁止只 `console.error`。
+4. **强自然反馈**：面板打开 / 树定位成功 → 不加成功 toast。
+
+实现上可抽 `openProjectFiles(context, panelContext)`（或等价），供状态项与未来命令复用；若现有 `openInstance` + `revealFilesTreePath` 已够，不必强行新命令。
+
+### 4.5 与 Git 项的关系
+
+| | `pier.files.project` | `pier.worktree.status` |
+|---|---|---|
+| 职责 | 打开项目文件树 | 分支 / 脏 / 特殊态 |
+| 可见性字段 | 项目锚点（含非 Git） | gitRoot / worktreeRoot |
+| order | 9 | 10 |
+| 点击 | Files | Git status dropdown |
+
+两者可同时出现；文案避免都刷长路径——本项以折叠路径为主，Git 保持现有分支/标志为主。
+
+### 4.6 Shell cwd 边界（写死）
+
+- 终端内 `cd` 到子目录：**本项文案不变**（仍是项目根）。
+- Tab / document title 仍可反映 cwd（现有管道）。
+- 若未来需要「打开 shell 当前目录」，另立状态项或 tab 交互，不扩展本项语义。
+
+## 5. 测试
+
+- 单元：`projectAnchor` 优先级；路径 `~` 折叠；无 context → 不可见。
+- 组件 / 注册：manifest 声明 + register；点击调用打开/reveal（mock panels / tree registry）。
+- 回归：Git 状态项、cwd→tab、Files 树根解析不受影响。
+
+## 6. 验收标准
+
+1. 有项目上下文的终端：右侧出现项目项，形态接近 Git 状态按钮。
+2. 点击 → Files 打开，上下文正确，树在项目根。
+3. 无项目上下文：该项不出现。
+4. `cd` 进子目录：该项文案不变；tab 仍可反映 cwd。
+5. 非 Git 目录：仍显示并可打开 Files。
+6. 设置页 / 右键「管理状态栏」能看到并开关该项。
+
+## 7. 实现提示（非绑定实现细节）
+
+主要触点（实现计划可再拆）：
+
+- `src/plugins/builtin/files/manifest.ts` — 声明 `terminalStatusItems`
+- `src/plugins/builtin/files/locales/{en,zh-CN}.json` — `terminalStatusItems` + 通知文案
+- `src/plugins/builtin/files/renderer/` — 新 status item 组件 + `openProjectFiles` 辅助 + `activate` 注册
+- 必要时扩展 `revealFilesTreePath` / group 打开路径以支持「仅打开树、无磁盘文件 tab」
+
+参考实现：`src/plugins/builtin/git/renderer/git-status-item.tsx` 的 `registerGitStatusItem`。

--- a/packages/ui/src/file-tree-types.ts
+++ b/packages/ui/src/file-tree-types.ts
@@ -29,11 +29,20 @@ export interface PierFileTreeMove {
 export interface PierFileTreeApi {
   focusSearchMatch: (direction: "next" | "previous") => void;
   getSearchMatchCount: () => number;
+  /** 从模型移除路径(新建落盘失败回滚幽灵节点用)。 */
+  removePaths: (paths: readonly string[]) => void;
   /** 展开祖先并滚动定位到该路径(面包屑点击/外部 reveal 用)。 */
   revealPath: (path: string) => void;
   /** null = 关闭搜索并恢复完整投影。搜索 UI 由业务层自绘(不用库内置头)。 */
   setSearch: (value: string | null) => void;
-  startRenaming: (path: string) => boolean;
+  /**
+   * 进入 inline rename。`removeIfCanceled: true` 时 Esc/空提交会从模型移除该路径
+   * （新建占位流用）。
+   */
+  startRenaming: (
+    path: string,
+    options?: { removeIfCanceled?: boolean }
+  ) => boolean;
 }
 
 export type PierFileTreeScrollSnapshot =
@@ -68,10 +77,15 @@ export interface PierFileTreeProps
   items: readonly PierFileTreeItem[];
   label: string;
   onLoadDirectory?: (path: string) => Promise<void> | void;
+  /** 模型层因 Esc/空提交 removeIfCanceled 删除路径时回调(caller path)。 */
+  onModelPathsRemoved?: (paths: readonly string[]) => void;
   /** 树内拖拽完成(模型层已移动);业务方执行真实 fs move,失败自行刷新回滚。 */
   onMovePaths?: (moves: readonly PierFileTreeMove[]) => void;
   onOpenPath?: (path: string) => void;
-  /** inline rename 提交;业务方执行 fs move。 */
+  /**
+   * inline rename 提交;业务方执行 fs move 或新建落盘。
+   * 同名确认(basename 未改)也会回调,便于新建占位直接采用默认名。
+   */
   onRenamePath?: (move: PierFileTreeMove & { isFolder: boolean }) => void;
   onScrollSnapshotChange?: (snapshot: PierFileTreeScrollSnapshot) => void;
   onSelectPaths?: (paths: string[]) => void;

--- a/packages/ui/src/file-tree.tsx
+++ b/packages/ui/src/file-tree.tsx
@@ -46,6 +46,7 @@ interface FileTreeRefs {
   itemsByPath: ReadonlyMap<string, PierFileTreeItem>;
   loadableDirectoryPaths: ReadonlyMap<string, string>;
   onLoadDirectory: ((path: string) => Promise<void> | void) | undefined;
+  onModelPathsRemoved: ((paths: readonly string[]) => void) | undefined;
   onMovePaths: ((moves: readonly PierFileTreeMove[]) => void) | undefined;
   onOpenPath: ((path: string) => void) | undefined;
   onRenamePath:
@@ -60,17 +61,42 @@ const EMPTY_REFS: FileTreeRefs = {
   itemsByPath: new Map(),
   loadableDirectoryPaths: new Map(),
   onLoadDirectory: undefined,
+  onModelPathsRemoved: undefined,
   onMovePaths: undefined,
   onOpenPath: undefined,
   onRenamePath: undefined,
   onSelectPaths: undefined,
 };
 
+interface RenameViewState {
+  getPath: () => string | null;
+  isActive: () => boolean;
+}
+
+/** @pierre/trees 用 unique symbol 暴露 rename view,未进包 public exports。 */
+function readRenameView(model: object): RenameViewState | null {
+  const proto = Object.getPrototypeOf(model) as object | null;
+  if (!proto) {
+    return null;
+  }
+  for (const symbol of Object.getOwnPropertySymbols(proto)) {
+    if (String(symbol) !== "Symbol(FILE_TREE_RENAME_VIEW)") {
+      continue;
+    }
+    const getter = (
+      model as Record<symbol, (() => RenameViewState) | undefined>
+    )[symbol];
+    return typeof getter === "function" ? getter.call(model) : null;
+  }
+  return null;
+}
+
 export function PierFileTree({
   directoryStates,
   items,
   label,
   onLoadDirectory,
+  onModelPathsRemoved,
   onMovePaths,
   onOpenPath,
   onRenamePath,
@@ -145,6 +171,7 @@ export function PierFileTree({
       itemsByPath,
       loadableDirectoryPaths,
       onLoadDirectory: undefined,
+      onModelPathsRemoved: undefined,
       onMovePaths: undefined,
       onOpenPath: undefined,
       onRenamePath: undefined,
@@ -153,6 +180,7 @@ export function PierFileTree({
   }, [directoryStates, items]);
 
   refs.current.onLoadDirectory = onLoadDirectory;
+  refs.current.onModelPathsRemoved = onModelPathsRemoved;
   refs.current.onMovePaths = onMovePaths;
   refs.current.onOpenPath = onOpenPath;
   refs.current.onRenamePath = onRenamePath;
@@ -215,10 +243,15 @@ export function PierFileTree({
     paths,
     renaming: {
       onRename: (event) => {
+        const from = stripTrailingSlash(event.sourcePath);
+        const to = stripTrailingSlash(event.destinationPath);
+        if (from !== to) {
+          modelAheadMovesRef.current.set(from, to);
+        }
         refs.current.onRenamePath?.({
-          from: stripTrailingSlash(event.sourcePath),
+          from,
           isFolder: event.isFolder,
-          to: stripTrailingSlash(event.destinationPath),
+          to,
         });
       },
     },
@@ -230,6 +263,9 @@ export function PierFileTree({
   });
 
   const activeSearchRef = React.useRef<string | null>(null);
+  // 库在 onRename 后会同步 model.move;React paths 尚未更新时记录已应用的 move,
+  // 避免后续 path sync 再 batch 一次造成幽灵节点。
+  const modelAheadMovesRef = React.useRef(new Map<string, string>());
 
   React.useImperativeHandle(
     treeApiRef,
@@ -276,10 +312,82 @@ export function PierFileTree({
           // 目标尚未加载(懒加载目录):祖先已展开,子层加载后用户可见。
         }
       },
-      startRenaming: (path) => {
+      removePaths: (pathsToRemove) => {
+        for (const path of pathsToRemove) {
+          const item = refs.current.itemsByPath.get(path);
+          const officialPath = item ? toOfficialPath(item) : path;
+          const directory =
+            item?.kind === "directory" || officialPath.endsWith("/");
+          try {
+            model.remove(
+              officialPath,
+              directory ? { recursive: true } : undefined
+            );
+          } catch {
+            // 路径已不在模型中:忽略。
+          }
+        }
+      },
+      startRenaming: (path, options) => {
         const item = refs.current.itemsByPath.get(path);
         const officialPath = item ? toOfficialPath(item) : path;
-        return model.startRenaming(officialPath);
+        const callerPath = item?.path ?? stripTrailingSlash(path);
+        const removeIfCanceled = options?.removeIfCanceled === true;
+        const started = model.startRenaming(
+          officialPath,
+          removeIfCanceled ? { removeIfCanceled: true } : undefined
+        );
+        if (!(started && removeIfCanceled)) {
+          return started;
+        }
+        // 库在 basename 未改时不调 onRename;新建占位确认默认名需要补一次回调。
+        // Esc/空提交走 removeIfCanceled → onMutation(remove) → onModelPathsRemoved。
+        let settled = false;
+        let renameDelivered = false;
+        const previousOnRename = refs.current.onRenamePath;
+        const settle = () => {
+          if (settled) {
+            return;
+          }
+          settled = true;
+          refs.current.onRenamePath = previousOnRename;
+          unsubscribeMutation();
+          unsubscribeSubscribe();
+        };
+        refs.current.onRenamePath = (move) => {
+          renameDelivered = true;
+          previousOnRename?.(move);
+          settle();
+        };
+        const unsubscribeMutation = model.onMutation("remove", (event) => {
+          const removed = stripTrailingSlash(event.path);
+          if (
+            removed !== callerPath &&
+            removed !== stripTrailingSlash(officialPath)
+          ) {
+            return;
+          }
+          settle();
+          refs.current.onModelPathsRemoved?.([callerPath]);
+        });
+        const unsubscribeSubscribe = model.subscribe(() => {
+          const renameView = readRenameView(model);
+          if (!renameView || renameView.isActive() || renameDelivered) {
+            return;
+          }
+          const stillPresent = Boolean(
+            model.getItem(officialPath) || model.getItem(callerPath)
+          );
+          settle();
+          if (stillPresent) {
+            previousOnRename?.({
+              from: callerPath,
+              isFolder: item?.kind === "directory",
+              to: callerPath,
+            });
+          }
+        });
+        return started;
       },
     }),
     [model]
@@ -395,7 +503,29 @@ export function PierFileTree({
 
     const localMutation = singlePathMutation(previousPaths, paths);
     if (localMutation) {
-      model.batch(localMutation);
+      const aheadMoves = modelAheadMovesRef.current;
+      const alreadyAppliedByModel =
+        localMutation.length === 1 &&
+        localMutation[0]?.type === "move" &&
+        aheadMoves.get(stripTrailingSlash(localMutation[0].from)) ===
+          stripTrailingSlash(localMutation[0].to);
+      if (alreadyAppliedByModel && localMutation[0]?.type === "move") {
+        aheadMoves.delete(stripTrailingSlash(localMutation[0].from));
+      } else {
+        model.batch(localMutation);
+        for (const [from, to] of aheadMoves) {
+          if (
+            localMutation.some(
+              (op) =>
+                op.type === "move" &&
+                stripTrailingSlash(op.from) === from &&
+                stripTrailingSlash(op.to) === to
+            )
+          ) {
+            aheadMoves.delete(from);
+          }
+        }
+      }
       previousPathsRef.current = paths;
       previousRenderSignatureRef.current = renderSignature;
       return;

--- a/src/plugins/builtin/files/locales/en.json
+++ b/src/plugins/builtin/files/locales/en.json
@@ -56,8 +56,13 @@
     "filePanel.tree.nameRequired": "Name required",
     "filePanel.tree.nameReserved": "Reserved name",
     "filePanel.tree.nameInvalidChars": "Name cannot contain / \\ or NUL",
+    "filePanel.tree.pathMustBeRelative": "Path must be relative to the parent folder",
+    "filePanel.tree.pathInvalidChars": "Path cannot contain \\ or NUL",
+    "filePanel.tree.pathEmptySegment": "Path cannot contain empty segments",
     "filePanel.tree.nameConflict": "Name already exists",
     "filePanel.tree.createFailed": "Unable to create item",
+    "filePanel.tree.createNeedsProject": "Open a project to create files.",
+    "filePanel.tree.contextMenuFailed": "Unable to open menu",
     "filePanel.tree.renameFailed": "Unable to rename",
     "filePanel.tree.deleteFailed": "Unable to delete",
     "filePanel.tree.copyFailed": "Copy failed",
@@ -109,7 +114,16 @@
     "filePanel.saveOnClose.body": "Your changes will be lost if you don't save them.",
     "filePanel.saveOnClose.saveLabel": "Save",
     "filePanel.saveOnClose.dontSaveLabel": "Don't Save",
-    "filePanel.saveOnClose.cancelLabel": "Cancel"
+    "filePanel.saveOnClose.cancelLabel": "Cancel",
+    "files.projectStatus.openLabel": "Open project files",
+    "files.projectStatus.openTooltip": "Open project files",
+    "files.projectStatus.openFailed": "Unable to open project files"
+  },
+  "terminalStatusItems": {
+    "pier.files.project": {
+      "title": "Project",
+      "description": "Shows the current project and opens its file tree."
+    }
   },
   "name": "Files",
   "panels": {

--- a/src/plugins/builtin/files/locales/zh-CN.json
+++ b/src/plugins/builtin/files/locales/zh-CN.json
@@ -56,8 +56,13 @@
     "filePanel.tree.nameRequired": "请输入名称",
     "filePanel.tree.nameReserved": "该名称保留",
     "filePanel.tree.nameInvalidChars": "名称不能包含 / \\ 或 NUL",
+    "filePanel.tree.pathMustBeRelative": "路径必须相对于父目录",
+    "filePanel.tree.pathInvalidChars": "路径不能包含 \\ 或 NUL",
+    "filePanel.tree.pathEmptySegment": "路径不能包含空段",
     "filePanel.tree.nameConflict": "名称已存在",
     "filePanel.tree.createFailed": "创建失败",
+    "filePanel.tree.createNeedsProject": "请先打开项目再创建文件。",
+    "filePanel.tree.contextMenuFailed": "无法打开菜单",
     "filePanel.tree.renameFailed": "重命名失败",
     "filePanel.tree.deleteFailed": "删除失败",
     "filePanel.tree.copyFailed": "复制失败",
@@ -109,7 +114,16 @@
     "filePanel.saveOnClose.body": "如果不保存，你的更改将会丢失。",
     "filePanel.saveOnClose.saveLabel": "保存",
     "filePanel.saveOnClose.dontSaveLabel": "不保存",
-    "filePanel.saveOnClose.cancelLabel": "取消"
+    "filePanel.saveOnClose.cancelLabel": "取消",
+    "files.projectStatus.openLabel": "打开项目文件",
+    "files.projectStatus.openTooltip": "打开项目文件",
+    "files.projectStatus.openFailed": "无法打开项目文件"
+  },
+  "terminalStatusItems": {
+    "pier.files.project": {
+      "title": "项目",
+      "description": "显示当前项目并打开其文件树。"
+    }
   },
   "name": "文件",
   "panels": {

--- a/src/plugins/builtin/files/manifest.ts
+++ b/src/plugins/builtin/files/manifest.ts
@@ -25,6 +25,7 @@ export const FILES_EDITOR_COPY_COMMAND_ID = "pier.files.editor.copy";
 export const FILES_EDITOR_PASTE_COMMAND_ID = "pier.files.editor.paste";
 export const FILES_EDITOR_SELECT_ALL_COMMAND_ID = "pier.files.editor.selectAll";
 
+export const FILES_PROJECT_STATUS_ITEM_ID = "pier.files.project";
 export const FILES_PLUGIN_MANIFEST = {
   apiVersion: 1,
   commands: [
@@ -37,13 +38,13 @@ export const FILES_PLUGIN_MANIFEST = {
     {
       category: "file",
       id: FILES_NEW_FILE_COMMAND_ID,
-      permissions: ["file:read", "file:write"],
+      permissions: ["file:read", "file:write", "panel:open"],
       title: "New File...",
     },
     {
       category: "file",
       id: FILES_NEW_FOLDER_COMMAND_ID,
-      permissions: ["file:read", "file:write"],
+      permissions: ["file:read", "file:write", "panel:open"],
       title: "New Folder...",
     },
     {
@@ -179,6 +180,14 @@ export const FILES_PLUGIN_MANIFEST = {
   ],
   publisher: "Pier",
   source: { kind: "builtin" },
-  terminalStatusItems: [],
+  terminalStatusItems: [
+    {
+      alignment: "right",
+      id: FILES_PROJECT_STATUS_ITEM_ID,
+      order: 9,
+      permissions: ["panel:open", "file:read"],
+      title: "Project",
+    },
+  ],
   version: "1.0.0",
 } satisfies PluginManifest;

--- a/src/plugins/builtin/files/renderer/file-tree-action-utils.ts
+++ b/src/plugins/builtin/files/renderer/file-tree-action-utils.ts
@@ -16,6 +16,11 @@ const treeItemMetadataSchema = z.object({
   treeId: z.string().min(1).optional(),
 });
 
+const treeBackgroundMetadataSchema = z.object({
+  root: z.string().min(1),
+  treeId: z.string().min(1).optional(),
+});
+
 const editorTargetMetadataSchema = z.object({
   path: z.string().min(1),
   projectRoot: z.string().min(1).optional(),
@@ -25,6 +30,9 @@ const editorTargetMetadataSchema = z.object({
 });
 
 export type FilesTreeItemMetadata = z.infer<typeof treeItemMetadataSchema>;
+export type FilesTreeBackgroundMetadata = z.infer<
+  typeof treeBackgroundMetadataSchema
+>;
 export type FilesEditorTargetMetadata = z.infer<
   typeof editorTargetMetadataSchema
 >;
@@ -33,6 +41,13 @@ export function parseTreeMetadata(
   invocation: RendererPluginActionInvocation | undefined
 ): FilesTreeItemMetadata | null {
   const parsed = treeItemMetadataSchema.safeParse(invocation?.metadata);
+  return parsed.success ? parsed.data : null;
+}
+
+export function parseTreeBackgroundMetadata(
+  invocation: RendererPluginActionInvocation | undefined
+): FilesTreeBackgroundMetadata | null {
+  const parsed = treeBackgroundMetadataSchema.safeParse(invocation?.metadata);
   return parsed.success ? parsed.data : null;
 }
 
@@ -98,6 +113,44 @@ export function validateName(name: string, t: FilesTranslate): string | null {
       "filePanel.tree.nameInvalidChars",
       "Name cannot contain / \\ or NUL"
     );
+  }
+  return null;
+}
+
+// biome-ignore lint/suspicious/noControlCharactersInRegex: NUL is a required path safeguard.
+const INVALID_PATH_CHAR_PATTERN = /[\u0000\\]/;
+
+/** 允许 `a/b/c.ts` 相对嵌套路径;禁绝对路径、`..`、空段、反斜杠与 NUL。 */
+export function validateRelativePath(
+  path: string,
+  t: FilesTranslate
+): string | null {
+  if (path.length === 0) {
+    return t("filePanel.tree.nameRequired", "Name required");
+  }
+  if (path.startsWith("/") || path.startsWith("~")) {
+    return t(
+      "filePanel.tree.pathMustBeRelative",
+      "Path must be relative to the parent folder"
+    );
+  }
+  if (INVALID_PATH_CHAR_PATTERN.test(path)) {
+    return t(
+      "filePanel.tree.pathInvalidChars",
+      "Path cannot contain \\ or NUL"
+    );
+  }
+  const segments = path.split("/");
+  for (const segment of segments) {
+    if (segment.length === 0) {
+      return t(
+        "filePanel.tree.pathEmptySegment",
+        "Path cannot contain empty segments"
+      );
+    }
+    if (segment === "." || segment === "..") {
+      return t("filePanel.tree.nameReserved", "Reserved name");
+    }
   }
   return null;
 }

--- a/src/plugins/builtin/files/renderer/file-tree-actions.ts
+++ b/src/plugins/builtin/files/renderer/file-tree-actions.ts
@@ -1,5 +1,6 @@
 import type {
   RendererPluginAction,
+  RendererPluginActionInvocation,
   RendererPluginContext,
 } from "@plugins/api/renderer.ts";
 import {
@@ -20,18 +21,28 @@ import {
   joinAbsolutePath,
   notifyMoveWithUndo,
   parseEditorMetadata,
+  parseTreeBackgroundMetadata,
   parseTreeMetadata,
   pluginAction,
   relativeToProjectRoot,
   validateName,
   writeClipboardText,
 } from "./file-tree-action-utils.ts";
+import { filePanelProjectRoot } from "./file-tree-preferences.ts";
 import {
   moveDiskDocumentSource,
   removeDiskDocumentForPath,
 } from "./files-document-store.ts";
 import { createFilesTranslate, type FilesTranslate } from "./files-i18n.ts";
-import { startFilesTreeInlineRename } from "./files-tree-registry.ts";
+import {
+  beginInlineCreate,
+  createViaPrompt,
+  resolveCreateParentDir,
+} from "./files-tree-create.ts";
+import {
+  findFilesTreeInstanceId,
+  startFilesTreeInlineRename,
+} from "./files-tree-registry.ts";
 import {
   addFilesTreeEntry,
   moveFilesTreeEntry,
@@ -39,6 +50,42 @@ import {
   removeFilesTreeEntry,
 } from "./files-tree-store.ts";
 import { showFilesNamePrompt } from "./name-prompt.tsx";
+
+function resolveCreateTarget(
+  context: RendererPluginContext,
+  invocation: RendererPluginActionInvocation | undefined
+): { parentDir: string; root: string; treeId?: string } | null {
+  const treeItem = parseTreeMetadata(invocation);
+  if (treeItem) {
+    return {
+      parentDir: resolveCreateParentDir({
+        kind: treeItem.kind,
+        path: treeItem.path,
+      }),
+      root: treeItem.root,
+      ...(treeItem.treeId ? { treeId: treeItem.treeId } : {}),
+    };
+  }
+  const background = parseTreeBackgroundMetadata(invocation);
+  if (background) {
+    return {
+      parentDir: "",
+      root: background.root,
+      ...(background.treeId ? { treeId: background.treeId } : {}),
+    };
+  }
+  // command-palette:落到当前活动 files 树根。
+  const root = filePanelProjectRoot(context.panels.getActiveContext());
+  if (!root) {
+    return null;
+  }
+  const treeId = findFilesTreeInstanceId(root) ?? undefined;
+  return {
+    parentDir: "",
+    root,
+    ...(treeId ? { treeId } : {}),
+  };
+}
 
 function createNewChildAction(
   kind: "file" | "folder",
@@ -53,72 +100,53 @@ function createNewChildAction(
       group: "1_new",
       sortOrder: kind === "file" ? 1 : 2,
     },
-    surfaces: ["files/tree-item"],
+    surfaces: ["files/tree-item", "files/tree-background", "command-palette"],
     title: () =>
       kind === "file"
         ? t("filePanel.tree.action.newFile", "New File...")
         : t("filePanel.tree.action.newFolder", "New Folder..."),
     handler: async (invocation) => {
-      const target = parseTreeMetadata(invocation);
+      const target = resolveCreateTarget(context, invocation);
       if (!target) {
-        return;
-      }
-      const parentDir =
-        target.kind === "directory"
-          ? target.path
-          : dirnameRelative(target.path);
-      const outcome = await showFilesNamePrompt(context, {
-        title:
-          kind === "file"
-            ? t("filePanel.tree.action.newFile", "New File...")
-            : t("filePanel.tree.action.newFolder", "New Folder..."),
-        placeholder:
-          kind === "file"
-            ? t("filePanel.tree.placeholder.newFile", "example.ts")
-            : t("filePanel.tree.placeholder.newFolder", "components"),
-        validate: async (name) => {
-          const invalid = validateName(name, t);
-          if (invalid) {
-            return invalid;
-          }
-          const targetPath =
-            parentDir.length > 0 ? `${parentDir}/${name}` : name;
-          const { exists } = await context.files.exists({
-            path: targetPath,
-            root: target.root,
-          });
-          return exists
-            ? t("filePanel.tree.nameConflict", "Name already exists")
-            : null;
-        },
-      });
-      if (outcome.cancelled) {
-        return;
-      }
-      const targetPath =
-        parentDir.length > 0 ? `${parentDir}/${outcome.value}` : outcome.value;
-      try {
-        if (kind === "file") {
-          await context.files.writeText({
-            contents: "",
-            path: targetPath,
-            root: target.root,
-          });
-        } else {
-          await context.files.mkdir({ path: targetPath, root: target.root });
-        }
-        addFilesTreeEntry(target.root, {
-          kind: kind === "file" ? "file" : "directory",
-          path: targetPath,
-          root: target.root,
-        });
-      } catch (error) {
-        context.notifications.error(
-          error instanceof Error
-            ? error.message
-            : t("filePanel.tree.createFailed", "Unable to create item")
+        context.notifications.info(
+          t(
+            "filePanel.tree.createNeedsProject",
+            "Open a project to create files."
+          )
         );
+        return;
       }
+      // 命令面板走 prompt,支持 a/b/c.ts 嵌套路径;树内右键优先 inline。
+      if (invocation?.surface === "command-palette") {
+        await createViaPrompt({
+          allowNestedPath: true,
+          context,
+          kind,
+          parentDir: target.parentDir,
+          root: target.root,
+          ...(target.treeId ? { treeId: target.treeId } : {}),
+        });
+        return;
+      }
+      const started = await beginInlineCreate({
+        context,
+        kind,
+        parentDir: target.parentDir,
+        root: target.root,
+        ...(target.treeId ? { treeId: target.treeId } : {}),
+      });
+      if (started) {
+        return;
+      }
+      // 树 API 不可用(面板折叠等):弹窗回退;背景菜单允许嵌套路径。
+      await createViaPrompt({
+        allowNestedPath: invocation?.surface === "files/tree-background",
+        context,
+        kind,
+        parentDir: target.parentDir,
+        root: target.root,
+        ...(target.treeId ? { treeId: target.treeId } : {}),
+      });
     },
   });
 }

--- a/src/plugins/builtin/files/renderer/file-tree-preferences.ts
+++ b/src/plugins/builtin/files/renderer/file-tree-preferences.ts
@@ -42,6 +42,9 @@ export function filePanelProjectRoot(
 export function projectNameFromRoot(root: string): string {
   return root.split("/").filter(Boolean).at(-1) ?? root;
 }
+export function ensureProjectFileTreeExpanded(root: string): void {
+  writeTreeCollapsed(root, false);
+}
 
 export function useProjectFileTreeCollapsed(
   root: string | null

--- a/src/plugins/builtin/files/renderer/file-tree-sidebar.tsx
+++ b/src/plugins/builtin/files/renderer/file-tree-sidebar.tsx
@@ -32,6 +32,7 @@ import {
 } from "./files-double-click.ts";
 import { createFilesTranslate } from "./files-i18n.ts";
 import { FilesSearchBar } from "./files-search-bar.tsx";
+import { cancelInlineCreate, commitInlineCreate } from "./files-tree-create.ts";
 import {
   buildGitStatusByPath,
   EMPTY_GIT_DECORATIONS,
@@ -39,7 +40,11 @@ import {
   ignoredStatusFor,
   splitIgnoredEntries,
 } from "./files-tree-git-decorations.ts";
-import { registerFilesTreeInstance } from "./files-tree-registry.ts";
+import {
+  hasPendingCreatePath,
+  peekPendingCreate,
+  registerFilesTreeInstance,
+} from "./files-tree-registry.ts";
 import {
   getFilesTreeSnapshot,
   loadFilesTreeDirectory,
@@ -305,16 +310,40 @@ export function FileTreeSidebar({
 
   const handleRenamePath = useCallback(
     (move: PierFileTreeMove & { isFolder: boolean }) => {
+      if (peekPendingCreate(root, move.from)) {
+        commitInlineCreate({
+          context,
+          from: move.from,
+          root,
+          to: move.to,
+        }).catch(() => undefined);
+        return;
+      }
       if (move.from !== move.to) {
         performMove(move.from, move.to).catch(() => undefined);
       }
     },
-    [performMove]
+    [context, performMove, root]
+  );
+
+  const handleModelPathsRemoved = useCallback(
+    (paths: readonly string[]) => {
+      for (const path of paths) {
+        if (peekPendingCreate(root, path)) {
+          cancelInlineCreate(root, path);
+        }
+      }
+    },
+    [root]
   );
 
   const lastOpenRef = useRef<DoubleClickTrack | null>(null);
   const openPath = useCallback(
     (path: string) => {
+      // 新建占位尚未落盘,禁止打开以免 readText 失败。
+      if (hasPendingCreatePath(root, path)) {
+        return;
+      }
       const entry = snapshot.entriesByPath.get(path);
       if (entry?.kind !== "file") {
         return;
@@ -328,13 +357,13 @@ export function FileTreeSidebar({
       lastOpenRef.current = nextTrack;
       onOpenFile(entry, isDouble ? { pinned: true } : undefined);
     },
-    [onOpenFile, snapshot.entriesByPath]
+    [onOpenFile, root, snapshot.entriesByPath]
   );
 
   const handleTreeDoubleClick = useCallback(
     (event: ReactMouseEvent<HTMLElement>) => {
       const path = extractItemPathFromEvent(event.nativeEvent);
-      if (!path) {
+      if (!path || hasPendingCreatePath(root, path)) {
         return;
       }
       const entry = snapshot.entriesByPath.get(path);
@@ -345,13 +374,33 @@ export function FileTreeSidebar({
       event.stopPropagation();
       onOpenFile(entry, { pinned: true });
     },
-    [onOpenFile, snapshot.entriesByPath]
+    [onOpenFile, root, snapshot.entriesByPath]
   );
 
   const handleTreeContextMenu = useCallback(
     (event: ReactMouseEvent<HTMLElement>) => {
       const path = extractItemPathFromEvent(event.nativeEvent);
       if (!path) {
+        event.preventDefault();
+        event.stopPropagation();
+        Promise.resolve(
+          context.contextMenu.popup(
+            "files/tree-background",
+            { x: event.clientX, y: event.clientY },
+            {
+              metadata: {
+                root,
+                treeId: instanceId,
+              },
+            }
+          )
+        ).catch((err: unknown) => {
+          context.notifications.error(
+            err instanceof Error
+              ? err.message
+              : t("filePanel.tree.contextMenuFailed", "Unable to open menu")
+          );
+        });
         return;
       }
       const entry = snapshot.entriesByPath.get(path);
@@ -365,8 +414,8 @@ export function FileTreeSidebar({
         selection.length > 1 && selection.includes(entry.path)
           ? [...selection]
           : undefined;
-      context.contextMenu
-        .popup(
+      Promise.resolve(
+        context.contextMenu.popup(
           "files/tree-item",
           { x: event.clientX, y: event.clientY },
           {
@@ -379,11 +428,15 @@ export function FileTreeSidebar({
             },
           }
         )
-        .catch((err: unknown) => {
-          console.error("[files] tree context menu failed:", err);
-        });
+      ).catch((err: unknown) => {
+        context.notifications.error(
+          err instanceof Error
+            ? err.message
+            : t("filePanel.tree.contextMenuFailed", "Unable to open menu")
+        );
+      });
     },
-    [context.contextMenu, instanceId, snapshot.entriesByPath]
+    [context, instanceId, root, snapshot.entriesByPath, t]
   );
 
   let content: ReactNode = null;
@@ -430,6 +483,7 @@ export function FileTreeSidebar({
         items={items}
         label={t("panel.tree.label", "Files")}
         onLoadDirectory={loadDirectory}
+        onModelPathsRemoved={handleModelPathsRemoved}
         onMovePaths={handleMovePaths}
         onOpenPath={openPath}
         onRenamePath={handleRenamePath}

--- a/src/plugins/builtin/files/renderer/files-open-project.ts
+++ b/src/plugins/builtin/files/renderer/files-open-project.ts
@@ -1,0 +1,71 @@
+import type { RendererPluginContext } from "@plugins/api/renderer.ts";
+import type { PanelContext } from "@shared/contracts/panel.ts";
+import { panelContextSchema } from "@shared/contracts/panel.ts";
+import { FILES_FILE_PANEL_ID } from "../manifest.ts";
+import {
+  ensureProjectFileTreeExpanded,
+  projectNameFromRoot,
+} from "./file-tree-preferences.ts";
+import { projectAnchor } from "./files-project-anchor.ts";
+import { stableFileIdentityHash } from "./files-stable-hash.ts";
+import { revealFilesTreePath } from "./files-tree-registry.ts";
+
+const REVEAL_DELAY_MS = 80;
+
+export function createProjectFilesInstanceId(root: string): string {
+  return `${FILES_FILE_PANEL_ID}:project:${stableFileIdentityHash(root)}`;
+}
+
+function contextFromParams(params: unknown): PanelContext | undefined {
+  if (!params || typeof params !== "object" || !("context" in params)) {
+    return;
+  }
+  const raw = (params as { context: unknown }).context;
+  const parsed = panelContextSchema.safeParse(raw);
+  return parsed.success ? parsed.data : undefined;
+}
+
+export function openProjectFiles(
+  pluginContext: RendererPluginContext,
+  panelContext: PanelContext
+): { ok: true } | { ok: false; reason: "no-anchor" | "open-failed" } {
+  const anchor = projectAnchor(panelContext);
+  if (!anchor) {
+    return { ok: false, reason: "no-anchor" };
+  }
+
+  try {
+    const instances = pluginContext.panels.listInstances(FILES_FILE_PANEL_ID);
+    const existing = instances.find(
+      (instance) => projectAnchor(contextFromParams(instance.params)) === anchor
+    );
+
+    if (existing) {
+      pluginContext.panels.openInstance({
+        componentId: FILES_FILE_PANEL_ID,
+        context: panelContext,
+        instanceId: existing.id,
+        params: existing.params ? { ...existing.params } : {},
+        title: existing.title,
+        ...(existing.groupId ? { targetGroupId: existing.groupId } : {}),
+      });
+    } else {
+      pluginContext.panels.openInstance({
+        componentId: FILES_FILE_PANEL_ID,
+        context: panelContext,
+        instanceId: createProjectFilesInstanceId(anchor),
+        params: {},
+        title: projectNameFromRoot(anchor),
+      });
+    }
+
+    ensureProjectFileTreeExpanded(anchor);
+    globalThis.setTimeout(() => {
+      revealFilesTreePath({ path: "", root: anchor });
+    }, REVEAL_DELAY_MS);
+
+    return { ok: true };
+  } catch {
+    return { ok: false, reason: "open-failed" };
+  }
+}

--- a/src/plugins/builtin/files/renderer/files-project-anchor.ts
+++ b/src/plugins/builtin/files/renderer/files-project-anchor.ts
@@ -1,0 +1,44 @@
+import type { PanelContext } from "@shared/contracts/panel.ts";
+
+function nonEmpty(value: string | undefined): string | null {
+  return value && value.length > 0 ? value : null;
+}
+
+export function projectAnchor(
+  context: PanelContext | undefined
+): string | null {
+  if (!context) {
+    return null;
+  }
+  return (
+    nonEmpty(context.projectRootPath) ??
+    nonEmpty(context.worktreeRoot) ??
+    nonEmpty(context.gitRoot) ??
+    nonEmpty(context.cwd)
+  );
+}
+
+function stripTrailingSeparators(value: string): string {
+  return value.replace(/[\\/]+$/, "") || value;
+}
+
+export function formatProjectPath(
+  path: string,
+  homeDirectory: string | null = null
+): string {
+  const normalized = stripTrailingSeparators(path);
+  const home = homeDirectory ? stripTrailingSeparators(homeDirectory) : null;
+  if (!(home && home !== "/" && home !== "\\")) {
+    return normalized;
+  }
+  if (normalized === home) {
+    return "~";
+  }
+  if (normalized.startsWith(`${home}/`)) {
+    return `~/${normalized.slice(home.length + 1)}`;
+  }
+  if (normalized.startsWith(`${home}\\`)) {
+    return `~/${normalized.slice(home.length + 1).replace(/\\/g, "/")}`;
+  }
+  return normalized;
+}

--- a/src/plugins/builtin/files/renderer/files-project-status-item.tsx
+++ b/src/plugins/builtin/files/renderer/files-project-status-item.tsx
@@ -1,0 +1,75 @@
+import { Button } from "@pier/ui/button.tsx";
+import type {
+  RendererPluginContext,
+  RendererTerminalStatusItemContext,
+} from "@plugins/api/renderer.ts";
+import { Folder } from "lucide-react";
+import { FILES_PROJECT_STATUS_ITEM_ID } from "../manifest.ts";
+import { openProjectFiles } from "./files-open-project.ts";
+import { formatProjectPath, projectAnchor } from "./files-project-anchor.ts";
+
+export function isFilesProjectStatusVisible(
+  statusContext: RendererTerminalStatusItemContext
+): boolean {
+  return projectAnchor(statusContext.context) != null;
+}
+
+function FilesProjectStatusItem({
+  pluginContext,
+  ...statusContext
+}: RendererTerminalStatusItemContext & {
+  pluginContext: RendererPluginContext;
+}) {
+  const anchor = projectAnchor(statusContext.context);
+  if (!(anchor && statusContext.context)) {
+    return null;
+  }
+  const panelContext = statusContext.context;
+  const label = formatProjectPath(anchor, null);
+  const t = (key: string, fallback: string) =>
+    pluginContext.i18n.t(key, undefined, fallback);
+  const openLabel = t("files.projectStatus.openLabel", "Open project files");
+  const openTooltip = t(
+    "files.projectStatus.openTooltip",
+    "Open project files"
+  );
+
+  return (
+    <Button
+      aria-label={openLabel}
+      className="h-5 min-w-0 max-w-56 gap-1 px-2 font-normal text-xs"
+      data-testid="files-project-status-trigger"
+      onClick={() => {
+        const result = openProjectFiles(pluginContext, panelContext);
+        if (!result.ok) {
+          pluginContext.notifications.error(
+            t("files.projectStatus.openFailed", "Unable to open project files")
+          );
+        }
+      }}
+      size="xs"
+      title={`${openTooltip}\n${anchor}`}
+      type="button"
+      variant="outline"
+    >
+      <Folder aria-hidden="true" className="size-3 shrink-0 opacity-70" />
+      <span className="min-w-0 truncate" dir="rtl">
+        <span dir="ltr" style={{ unicodeBidi: "isolate" }}>
+          {label}
+        </span>
+      </span>
+    </Button>
+  );
+}
+
+export function registerFilesProjectStatusItem(
+  context: RendererPluginContext
+): () => void {
+  return context.terminalStatusItems.register({
+    id: FILES_PROJECT_STATUS_ITEM_ID,
+    isVisible: isFilesProjectStatusVisible,
+    render: (statusContext) => (
+      <FilesProjectStatusItem {...statusContext} pluginContext={context} />
+    ),
+  });
+}

--- a/src/plugins/builtin/files/renderer/files-tree-create.ts
+++ b/src/plugins/builtin/files/renderer/files-tree-create.ts
@@ -1,0 +1,455 @@
+import type { RendererPluginContext } from "@plugins/api/renderer.ts";
+import { FILES_FILE_PANEL_ID } from "../manifest.ts";
+import { createFileFilePanelInstanceId } from "./file-panel-id.ts";
+import {
+  basename,
+  dirnameRelative,
+  validateName,
+  validateRelativePath,
+} from "./file-tree-action-utils.ts";
+import { ensureDiskDocument } from "./files-document-store.ts";
+import type { FilesDocumentPanelSource } from "./files-document-types.ts";
+import { createFilesTranslate } from "./files-i18n.ts";
+import {
+  type FilesPendingCreateKind,
+  findFilesTreeInstanceId,
+  registerPendingCreate,
+  removeFilesTreeModelPaths,
+  revealFilesTreePath,
+  startFilesTreeInlineRename,
+  takePendingCreate,
+} from "./files-tree-registry.ts";
+import {
+  addFilesTreeEntry,
+  ensureAncestorDirectoryEntries,
+  getFilesTreeSnapshot,
+  loadFilesTreeDirectory,
+  moveFilesTreeEntry,
+  reloadFilesTreeRoot,
+  removeFilesTreeEntry,
+} from "./files-tree-store.ts";
+import { showFilesNamePrompt } from "./name-prompt.tsx";
+
+export type FilesCreateKind = FilesPendingCreateKind;
+
+function waitForPaint(): Promise<void> {
+  return new Promise((resolve) => {
+    if (typeof requestAnimationFrame === "function") {
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => resolve());
+      });
+      return;
+    }
+    queueMicrotask(() => resolve());
+  });
+}
+
+function joinRelative(parentDir: string, name: string): string {
+  return parentDir.length > 0 ? `${parentDir}/${name}` : name;
+}
+
+function defaultBaseName(kind: FilesCreateKind): string {
+  return kind === "file" ? "untitled.ts" : "New Folder";
+}
+
+function nextCandidateName(base: string, attempt: number): string {
+  if (attempt <= 1) {
+    return base;
+  }
+  const dot = base.lastIndexOf(".");
+  if (dot > 0 && kindLooksLikeFileBase(base)) {
+    return `${base.slice(0, dot)} ${attempt}${base.slice(dot)}`;
+  }
+  return `${base} ${attempt}`;
+}
+
+function kindLooksLikeFileBase(base: string): boolean {
+  const dot = base.lastIndexOf(".");
+  return dot > 0 && !base.includes("/");
+}
+
+export async function allocateUniqueChildName(
+  root: string,
+  parentDir: string,
+  base: string,
+  exists: RendererPluginContext["files"]["exists"]
+): Promise<string> {
+  for (let attempt = 1; attempt <= 50; attempt += 1) {
+    const name = nextCandidateName(base, attempt);
+    const path = joinRelative(parentDir, name);
+    const result = await exists({ path, root });
+    if (!result.exists) {
+      return name;
+    }
+  }
+  return nextCandidateName(base, Date.now());
+}
+
+async function ensureParentDirectoryReady(
+  context: RendererPluginContext,
+  root: string,
+  parentDir: string
+): Promise<void> {
+  if (parentDir.length === 0) {
+    return;
+  }
+  const snapshot = getFilesTreeSnapshot(root);
+  const state = snapshot.directoryStatesByPath.get(parentDir);
+  if (state === "loaded" || state === "empty") {
+    return;
+  }
+  await loadFilesTreeDirectory(root, parentDir, context.files.list);
+}
+
+function openCreatedDiskFile(
+  context: RendererPluginContext,
+  root: string,
+  path: string,
+  treeId: string | undefined
+): void {
+  const name = basename(path);
+  ensureDiskDocument({ name, path, root });
+  const source: FilesDocumentPanelSource = { kind: "disk", path, root };
+  const panelContext = context.panels.getActiveContext();
+  context.panels.openInstance({
+    componentId: FILES_FILE_PANEL_ID,
+    ...(panelContext ? { context: panelContext } : {}),
+    dropUnpinnedInstances: false,
+    instanceId: createFileFilePanelInstanceId(source),
+    params: {
+      pinned: true,
+      source,
+    },
+    ...(treeId ? { targetGroupId: treeId } : {}),
+    title: name,
+  });
+}
+
+/**
+ * 库可能已乐观 move 到 to。失败时:
+ * - 清掉占位 from;
+ * - 仅当 to 原先不在 store(纯幽灵)时才删 to,避免误删已存在文件节点;
+ * - 再 reload 根目录愈合模型/store 漂移。
+ */
+function discardCreateAttempt(options: {
+  context: RendererPluginContext;
+  destinationAlreadyInStore: boolean;
+  from: string;
+  root: string;
+  to: string;
+  treeId?: string | undefined;
+}): void {
+  const { context, destinationAlreadyInStore, from, root, to, treeId } =
+    options;
+  removeFilesTreeEntry(root, from);
+  if (to !== from && !destinationAlreadyInStore) {
+    removeFilesTreeEntry(root, to);
+  }
+  removeFilesTreeModelPaths({
+    ...(treeId ? { instanceId: treeId } : {}),
+    paths: to === from || destinationAlreadyInStore ? [from] : [from, to],
+    root,
+  });
+  const t = createFilesTranslate(context);
+  reloadFilesTreeRoot(
+    root,
+    context.files.list,
+    t("panel.loadError.fallback", "Failed to load files")
+  );
+}
+
+export async function commitCreatedPath(options: {
+  context: RendererPluginContext;
+  kind: FilesCreateKind;
+  openAfter: boolean;
+  path: string;
+  root: string;
+  treeId?: string | undefined;
+}): Promise<boolean> {
+  const { context, kind, openAfter, path, root, treeId } = options;
+  const t = createFilesTranslate(context);
+  try {
+    if (kind === "file") {
+      await context.files.writeText({ contents: "", path, root });
+    } else {
+      await context.files.mkdir({ path, root });
+    }
+  } catch (error) {
+    context.notifications.error(
+      error instanceof Error
+        ? error.message
+        : t("filePanel.tree.createFailed", "Unable to create item")
+    );
+    return false;
+  }
+
+  ensureAncestorDirectoryEntries(root, path);
+  if (!getFilesTreeSnapshot(root).entriesByPath.has(path)) {
+    addFilesTreeEntry(root, {
+      kind: kind === "file" ? "file" : "directory",
+      path,
+      root,
+    });
+  }
+
+  if (kind === "file" && openAfter) {
+    openCreatedDiskFile(context, root, path, treeId);
+  }
+  revealFilesTreePath({
+    ...(treeId ? { instanceId: treeId } : {}),
+    path,
+    root,
+  });
+  return true;
+}
+
+export async function commitInlineCreate(options: {
+  context: RendererPluginContext;
+  from: string;
+  root: string;
+  to: string;
+}): Promise<boolean> {
+  const pending = takePendingCreate(options.root, options.from);
+  if (!pending) {
+    return false;
+  }
+  const destinationAlreadyInStore =
+    options.to !== options.from &&
+    getFilesTreeSnapshot(options.root).entriesByPath.has(options.to);
+  const t = createFilesTranslate(options.context);
+  const leaf = basename(options.to);
+  const invalid = validateName(leaf, t);
+  if (invalid) {
+    options.context.notifications.error(invalid);
+    discardCreateAttempt({
+      context: options.context,
+      destinationAlreadyInStore,
+      from: options.from,
+      root: options.root,
+      to: options.to,
+      ...(pending.treeId ? { treeId: pending.treeId } : {}),
+    });
+    return true;
+  }
+
+  const { exists } = await options.context.files.exists({
+    path: options.to,
+    root: options.root,
+  });
+  // 同名确认时磁盘尚无该文件;改名到已存在路径才算冲突。
+  if (exists && options.to !== options.from) {
+    options.context.notifications.error(
+      t("filePanel.tree.nameConflict", "Name already exists")
+    );
+    discardCreateAttempt({
+      context: options.context,
+      destinationAlreadyInStore,
+      from: options.from,
+      root: options.root,
+      to: options.to,
+      ...(pending.treeId ? { treeId: pending.treeId } : {}),
+    });
+    return true;
+  }
+
+  try {
+    if (pending.kind === "file") {
+      await options.context.files.writeText({
+        contents: "",
+        path: options.to,
+        root: options.root,
+      });
+    } else {
+      await options.context.files.mkdir({
+        path: options.to,
+        root: options.root,
+      });
+    }
+  } catch (error) {
+    options.context.notifications.error(
+      error instanceof Error
+        ? error.message
+        : t("filePanel.tree.createFailed", "Unable to create item")
+    );
+    discardCreateAttempt({
+      context: options.context,
+      destinationAlreadyInStore,
+      from: options.from,
+      root: options.root,
+      to: options.to,
+      ...(pending.treeId ? { treeId: pending.treeId } : {}),
+    });
+    return true;
+  }
+
+  if (options.from !== options.to) {
+    // 库模型已乐观 move;store 仍可能停在 from。
+    if (getFilesTreeSnapshot(options.root).entriesByPath.has(options.from)) {
+      moveFilesTreeEntry(options.root, options.from, options.to);
+    } else if (
+      !getFilesTreeSnapshot(options.root).entriesByPath.has(options.to)
+    ) {
+      addFilesTreeEntry(options.root, {
+        kind: pending.kind === "file" ? "file" : "directory",
+        path: options.to,
+        root: options.root,
+      });
+    }
+  } else if (pending.kind === "folder") {
+    addFilesTreeEntry(options.root, {
+      kind: "directory",
+      path: options.to,
+      root: options.root,
+    });
+  }
+
+  if (pending.kind === "file" && pending.openAfter) {
+    openCreatedDiskFile(
+      options.context,
+      options.root,
+      options.to,
+      pending.treeId
+    );
+  }
+  revealFilesTreePath({
+    ...(pending.treeId ? { instanceId: pending.treeId } : {}),
+    path: options.to,
+    root: options.root,
+  });
+  return true;
+}
+
+export function cancelInlineCreate(root: string, path: string): void {
+  takePendingCreate(root, path);
+  removeFilesTreeEntry(root, path);
+}
+
+export async function beginInlineCreate(options: {
+  context: RendererPluginContext;
+  kind: FilesCreateKind;
+  parentDir: string;
+  root: string;
+  treeId?: string | undefined;
+}): Promise<boolean> {
+  const { context, kind, parentDir, root } = options;
+  const treeId = options.treeId ?? findFilesTreeInstanceId(root) ?? undefined;
+  await ensureParentDirectoryReady(context, root, parentDir);
+
+  const name = await allocateUniqueChildName(
+    root,
+    parentDir,
+    defaultBaseName(kind),
+    context.files.exists
+  );
+  const placeholderPath = joinRelative(parentDir, name);
+  addFilesTreeEntry(root, {
+    kind: kind === "file" ? "file" : "directory",
+    path: placeholderPath,
+    root,
+  });
+  registerPendingCreate({
+    kind,
+    openAfter: kind === "file",
+    placeholderPath,
+    root,
+    ...(treeId ? { treeId } : {}),
+  });
+  revealFilesTreePath({
+    ...(treeId ? { instanceId: treeId } : {}),
+    path: placeholderPath,
+    root,
+  });
+
+  await waitForPaint();
+
+  const started = startFilesTreeInlineRename({
+    ...(treeId ? { instanceId: treeId } : {}),
+    path: placeholderPath,
+    removeIfCanceled: true,
+    root,
+  });
+  if (!started) {
+    takePendingCreate(root, placeholderPath);
+    removeFilesTreeEntry(root, placeholderPath);
+    return false;
+  }
+  return true;
+}
+
+export async function createViaPrompt(options: {
+  allowNestedPath: boolean;
+  context: RendererPluginContext;
+  kind: FilesCreateKind;
+  parentDir: string;
+  root: string;
+  treeId?: string | undefined;
+}): Promise<void> {
+  const { allowNestedPath, context, kind, parentDir, root, treeId } = options;
+  const t = createFilesTranslate(context);
+  const outcome = await showFilesNamePrompt(context, {
+    title:
+      kind === "file"
+        ? t("filePanel.tree.action.newFile", "New File...")
+        : t("filePanel.tree.action.newFolder", "New Folder..."),
+    placeholder:
+      kind === "file"
+        ? t("filePanel.tree.placeholder.newFile", "example.ts")
+        : t("filePanel.tree.placeholder.newFolder", "components"),
+    initialValue: defaultBaseName(kind),
+    validate: async (value) => {
+      const trimmed = value.trim();
+      if (allowNestedPath && trimmed.includes("/")) {
+        const pathInvalid = validateRelativePath(trimmed, t);
+        if (pathInvalid) {
+          return pathInvalid;
+        }
+        const targetPath = joinRelative(parentDir, trimmed);
+        const { exists } = await context.files.exists({
+          path: targetPath,
+          root,
+        });
+        return exists
+          ? t("filePanel.tree.nameConflict", "Name already exists")
+          : null;
+      }
+      const invalid = validateName(trimmed, t);
+      if (invalid) {
+        return invalid;
+      }
+      const targetPath = joinRelative(parentDir, trimmed);
+      const { exists } = await context.files.exists({
+        path: targetPath,
+        root,
+      });
+      return exists
+        ? t("filePanel.tree.nameConflict", "Name already exists")
+        : null;
+    },
+  });
+  if (outcome.cancelled) {
+    return;
+  }
+  const relative = outcome.value.trim();
+  const targetPath = joinRelative(parentDir, relative);
+  await commitCreatedPath({
+    context,
+    kind,
+    openAfter: kind === "file",
+    path: targetPath,
+    root,
+    ...(treeId ? { treeId } : {}),
+  });
+}
+
+export function resolveCreateParentDir(options: {
+  kind?: "directory" | "file";
+  path?: string;
+}): string {
+  if (!options.path) {
+    return "";
+  }
+  if (options.kind === "directory") {
+    return options.path;
+  }
+  return dirnameRelative(options.path);
+}

--- a/src/plugins/builtin/files/renderer/files-tree-registry.ts
+++ b/src/plugins/builtin/files/renderer/files-tree-registry.ts
@@ -6,7 +6,22 @@ export interface FilesTreeRegistryEntry {
   root: string;
 }
 
+export type FilesPendingCreateKind = "file" | "folder";
+
+export interface FilesPendingCreate {
+  kind: FilesPendingCreateKind;
+  openAfter: boolean;
+  placeholderPath: string;
+  root: string;
+  treeId?: string;
+}
+
 const treeRegistry = new Map<string, FilesTreeRegistryEntry>();
+const pendingCreates = new Map<string, FilesPendingCreate>();
+
+function pendingCreateKey(root: string, path: string): string {
+  return `${root}\u0000${path}`;
+}
 
 function findTreeEntry(target: {
   instanceId?: string | undefined;
@@ -43,10 +58,18 @@ export function registerFilesTreeInstance(
 export function startFilesTreeInlineRename(target: {
   instanceId?: string | undefined;
   path: string;
+  removeIfCanceled?: boolean;
   root: string;
 }): boolean {
   const entry = findTreeEntry(target);
-  return entry?.getApi()?.startRenaming(target.path) ?? false;
+  return (
+    entry
+      ?.getApi()
+      ?.startRenaming(
+        target.path,
+        target.removeIfCanceled ? { removeIfCanceled: true } : undefined
+      ) ?? false
+  );
 }
 
 export function openFilesTreeSearch(target: {
@@ -75,6 +98,72 @@ export function revealFilesTreePath(target: {
   return true;
 }
 
+export function findFilesTreeInstanceId(root: string): string | null {
+  let lastId: string | null = null;
+  for (const [instanceId, entry] of treeRegistry) {
+    if (entry.root === root) {
+      lastId = instanceId;
+    }
+  }
+  return lastId;
+}
+
+export function registerPendingCreate(pending: FilesPendingCreate): void {
+  pendingCreates.set(
+    pendingCreateKey(pending.root, pending.placeholderPath),
+    pending
+  );
+}
+
+export function peekPendingCreate(
+  root: string,
+  path: string
+): FilesPendingCreate | null {
+  return pendingCreates.get(pendingCreateKey(root, path)) ?? null;
+}
+
+/** 目录 merge/watch 时保留尚未落盘的占位路径。 */
+export function listPendingCreatePaths(root: string): readonly string[] {
+  const paths: string[] = [];
+  const prefix = `${root}\u0000`;
+  for (const [key, pending] of pendingCreates) {
+    if (key.startsWith(prefix) && pending.root === root) {
+      paths.push(pending.placeholderPath);
+    }
+  }
+  return paths;
+}
+
+export function hasPendingCreatePath(root: string, path: string): boolean {
+  return pendingCreates.has(pendingCreateKey(root, path));
+}
+
+export function takePendingCreate(
+  root: string,
+  path: string
+): FilesPendingCreate | null {
+  const key = pendingCreateKey(root, path);
+  const pending = pendingCreates.get(key) ?? null;
+  if (pending) {
+    pendingCreates.delete(key);
+  }
+  return pending;
+}
+
+export function clearPendingCreate(root: string, path: string): void {
+  pendingCreates.delete(pendingCreateKey(root, path));
+}
+
+export function removeFilesTreeModelPaths(target: {
+  instanceId?: string | undefined;
+  paths: readonly string[];
+  root: string;
+}): void {
+  const entry = findTreeEntry(target);
+  entry?.getApi()?.removePaths(target.paths);
+}
+
 export function clearFileTreeSidebarCache(): void {
   treeRegistry.clear();
+  pendingCreates.clear();
 }

--- a/src/plugins/builtin/files/renderer/files-tree-store-ops.ts
+++ b/src/plugins/builtin/files/renderer/files-tree-store-ops.ts
@@ -150,11 +150,15 @@ export function markParentEmptyAfterChildRemove(
 export function mergeDirectoryEntries(
   previousEntries: ReadonlyMap<string, FileEntry>,
   directoryPath: string,
-  loadedEntries: readonly FileEntry[]
+  loadedEntries: readonly FileEntry[],
+  retainPaths?: ReadonlySet<string>
 ): ReadonlyMap<string, FileEntry> {
   const loadedEntriesByPath = entriesByPath(loadedEntries);
   let nextEntries: Map<string, FileEntry> | null = null;
   for (const entryPath of previousEntries.keys()) {
+    if (retainPaths?.has(entryPath)) {
+      continue;
+    }
     if (
       shouldRemoveEntryOnDirectoryMerge(
         entryPath,

--- a/src/plugins/builtin/files/renderer/files-tree-store.ts
+++ b/src/plugins/builtin/files/renderer/files-tree-store.ts
@@ -2,6 +2,7 @@ import type { PierDirectoryLoadState } from "@pier/ui/file-tree.tsx";
 import type { RendererPluginContext } from "@plugins/api/renderer.ts";
 import type { FileEntry } from "@shared/contracts/file.ts";
 import type { FileWatchEvent } from "@shared/contracts/file-watch.ts";
+import { listPendingCreatePaths } from "./files-tree-registry.ts";
 import {
   addEntry,
   entriesByPath,
@@ -16,6 +17,10 @@ import {
   removeEntrySubtree,
   setDirectoryState,
 } from "./files-tree-store-ops.ts";
+
+function pendingRetainPathSet(root: string): ReadonlySet<string> {
+  return new Set(listPendingCreatePaths(root));
+}
 
 interface FilesTreeSnapshot {
   directoryStatesByPath: ReadonlyMap<string, PierDirectoryLoadState>;
@@ -140,7 +145,12 @@ function beginRootLoad(
           ? session.snapshot.directoryStatesByPath
           : new Map(),
         entriesByPath: force
-          ? mergeDirectoryEntries(session.snapshot.entriesByPath, "", entries)
+          ? mergeDirectoryEntries(
+              session.snapshot.entriesByPath,
+              "",
+              entries,
+              pendingRetainPathSet(root)
+            )
           : entriesByPath(entries),
         rootError: null,
         rootLoaded: true,
@@ -206,15 +216,26 @@ export async function loadFilesTreeDirectory(
 
   try {
     const entries = await list(root, { path });
+    const retainPaths = pendingRetainPathSet(root);
     const mergedEntriesByPath = mergeDirectoryEntries(
       session.snapshot.entriesByPath,
       path,
-      entries
+      entries,
+      retainPaths
     );
+    const hasVisibleChildren =
+      entries.length > 0 ||
+      [...retainPaths].some(
+        (retainPath) =>
+          retainPath === path ||
+          (path === ""
+            ? retainPath.length > 0
+            : retainPath.startsWith(`${path}/`))
+      );
     const loadedDirectoryStatesByPath = setDirectoryState(
       session.snapshot.directoryStatesByPath,
       path,
-      entries.length === 0 ? "empty" : "loaded"
+      hasVisibleChildren ? "loaded" : "empty"
     );
     const directoryStatesByPath = pruneDirectoryStatesForMissingEntries(
       loadedDirectoryStatesByPath,
@@ -255,10 +276,18 @@ export async function loadFilesTreeDirectory(
 export function addFilesTreeEntry(root: string, entry: FileEntry): void {
   const session = sessionForRoot(root);
   const entriesByPath = addEntry(session.snapshot.entriesByPath, entry);
-  const directoryStatesByPath = markParentLoadedAfterChildAdd(
+  let directoryStatesByPath = markParentLoadedAfterChildAdd(
     session.snapshot.directoryStatesByPath,
     entry.path
   );
+  // 新建空目录:直接 empty,避免 hasChildren:unknown → unloaded 再点一次才 Empty。
+  if (entry.kind === "directory") {
+    directoryStatesByPath = setDirectoryState(
+      directoryStatesByPath,
+      entry.path,
+      "empty"
+    );
+  }
   emitSnapshotIfChanged(
     session,
     entriesByPath === session.snapshot.entriesByPath &&
@@ -270,6 +299,49 @@ export function addFilesTreeEntry(root: string, entry: FileEntry): void {
           entriesByPath,
         }
   );
+}
+
+/** 嵌套创建时补齐缺失的中间目录节点,并标为 loaded(已知有子项)。 */
+export function ensureAncestorDirectoryEntries(
+  root: string,
+  relativePath: string
+): void {
+  const segments = relativePath.split("/").filter(Boolean);
+  if (segments.length <= 1) {
+    return;
+  }
+  const session = sessionForRoot(root);
+  let entriesByPath = session.snapshot.entriesByPath;
+  let directoryStatesByPath = session.snapshot.directoryStatesByPath;
+  let changed = false;
+  for (let index = 1; index < segments.length; index += 1) {
+    const ancestorPath = segments.slice(0, index).join("/");
+    if (!entriesByPath.has(ancestorPath)) {
+      entriesByPath = addEntry(entriesByPath, {
+        kind: "directory",
+        path: ancestorPath,
+        root,
+      });
+      changed = true;
+    }
+    const state = directoryStatesByPath.get(ancestorPath);
+    if (state !== "loaded" && state !== "empty") {
+      directoryStatesByPath = setDirectoryState(
+        directoryStatesByPath,
+        ancestorPath,
+        "loaded"
+      );
+      changed = true;
+    }
+  }
+  if (!changed) {
+    return;
+  }
+  emitSnapshotIfChanged(session, {
+    ...session.snapshot,
+    directoryStatesByPath,
+    entriesByPath,
+  });
 }
 
 export function removeFilesTreeEntry(root: string, path: string): void {
@@ -321,10 +393,21 @@ export function moveFilesTreeEntry(
     entriesByPath,
     oldPath
   );
-  const directoryStatesByPath = markParentLoadedAfterChildAdd(
+  let directoryStatesByPath = markParentLoadedAfterChildAdd(
     sourceParentUpdatedStates,
     newPath
   );
+  const movedEntry = entriesByPath.get(newPath);
+  if (movedEntry?.kind === "directory") {
+    const prior = directoryStatesByPath.get(newPath);
+    if (prior == null || prior === "unloaded") {
+      directoryStatesByPath = setDirectoryState(
+        directoryStatesByPath,
+        newPath,
+        "empty"
+      );
+    }
+  }
   emitSnapshotIfChanged(
     session,
     entriesByPath === session.snapshot.entriesByPath &&

--- a/src/plugins/builtin/files/renderer/index.tsx
+++ b/src/plugins/builtin/files/renderer/index.tsx
@@ -33,6 +33,7 @@ import { createFilesEditorActions } from "./files-editor-actions.ts";
 import { clearFilesEditorViews } from "./files-editor-view-registry.ts";
 import { clearFilesNavHistory } from "./files-nav-history.ts";
 import { hasOtherOpenFilesSourceInstance } from "./files-panel-instance-utils.ts";
+import { registerFilesProjectStatusItem } from "./files-project-status-item.tsx";
 import {
   clearFileTreeSidebarCache,
   openFilesTreeSearch,
@@ -315,6 +316,7 @@ export const filesRendererPlugin: RendererPluginModule = {
       ...createFilesEditorActions(context).map((action) =>
         context.actions.register(action)
       ),
+      registerFilesProjectStatusItem(context),
     ];
 
     return () => {

--- a/tests/component/files-file-panel.test.tsx
+++ b/tests/component/files-file-panel.test.tsx
@@ -522,14 +522,16 @@ describe("Files file-panel", () => {
     });
   });
 
-  it("swallows tree context menu when the right-click target has no data-item-path", async () => {
+  it("opens files/tree-background context menu when the right-click target has no data-item-path", async () => {
     const list = vi.fn<RendererPluginContext["files"]["list"]>(
       async () =>
         [
           { kind: "file", path: "README.md", root: PROJECT_ROOT },
         ] satisfies FileEntry[]
     );
-    const popup = vi.fn<RendererPluginContext["contextMenu"]["popup"]>();
+    const popup = vi.fn<RendererPluginContext["contextMenu"]["popup"]>(
+      async () => undefined
+    );
     const context = createMockContext({ list });
     context.contextMenu = { popup };
     const Panel = createFilePanel(context);
@@ -541,12 +543,23 @@ describe("Files file-panel", () => {
       expect(list).toHaveBeenCalledWith(PROJECT_ROOT, { path: "" });
     });
 
-    // 右键 sidebar 的顶部标题栏(在 aside 内但不属于任何 treeitem),不应弹出。
+    // 右键 sidebar 空白区(aside 内但不属于任何 treeitem) → 根级新建菜单。
     const sidebar = container.querySelector("aside") as HTMLElement;
     const header = sidebar.querySelector("div") as HTMLElement;
     fireEvent.contextMenu(header);
 
-    expect(popup).not.toHaveBeenCalled();
+    expect(popup).toHaveBeenCalledWith(
+      "files/tree-background",
+      expect.objectContaining({
+        x: expect.any(Number),
+        y: expect.any(Number),
+      }),
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          root: PROJECT_ROOT,
+        }),
+      })
+    );
   });
 
   it("dispatches files/editor context menu with selection ranges", async () => {

--- a/tests/unit/renderer/file-tree-actions.test.ts
+++ b/tests/unit/renderer/file-tree-actions.test.ts
@@ -140,6 +140,7 @@ function makeContext() {
       async () => ({ shown: true })
     ),
   };
+  const openInstance = vi.fn<RendererPluginContext["panels"]["openInstance"]>();
   const context = {
     dialogs,
     files,
@@ -158,9 +159,17 @@ function makeContext() {
       ),
     },
     notifications,
+    panels: {
+      getActiveContext: vi.fn(() => ({
+        contextId: "c",
+        cwd: ROOT,
+        projectRootPath: ROOT,
+      })),
+      openInstance,
+    },
   } as unknown as RendererPluginContext;
 
-  return { context, dialogs, files, notifications };
+  return { context, dialogs, files, notifications, openInstance };
 }
 
 function installClipboard() {
@@ -190,8 +199,8 @@ afterEach(() => {
 });
 
 describe("file-tree-actions", () => {
-  it("creates a file through the file service and adds it to the tree only after the write succeeds", async () => {
-    const { context, files } = makeContext();
+  it("falls back to the name prompt when inline create is unavailable and opens the new file", async () => {
+    const { context, files, openInstance } = makeContext();
     showFilesNamePromptMock.mockResolvedValueOnce({
       cancelled: false,
       value: "new.ts",
@@ -211,9 +220,17 @@ describe("file-tree-actions", () => {
     expect(getFilesTreeSnapshot(ROOT).entriesByPath.get("src/new.ts")).toEqual(
       file("src/new.ts")
     );
+    expect(openInstance).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({
+          pinned: true,
+          source: { kind: "disk", path: "src/new.ts", root: ROOT },
+        }),
+      })
+    );
   });
 
-  it("creates a folder through the file service and adds the directory entry to the tree", async () => {
+  it("creates a folder through the prompt fallback and marks it empty", async () => {
     const { context, files } = makeContext();
     showFilesNamePromptMock.mockResolvedValueOnce({
       cancelled: false,
@@ -233,6 +250,9 @@ describe("file-tree-actions", () => {
     expect(
       getFilesTreeSnapshot(ROOT).entriesByPath.get("src/components")
     ).toEqual(directory("src/components"));
+    expect(
+      getFilesTreeSnapshot(ROOT).directoryStatesByPath.get("src/components")
+    ).toBe("empty");
   });
 
   it("does not patch the tree when file creation fails", async () => {
@@ -252,6 +272,57 @@ describe("file-tree-actions", () => {
     expect(notifications.error).toHaveBeenCalledWith("disk full");
     expect(getFilesTreeSnapshot(ROOT).entriesByPath.has("src/new.ts")).toBe(
       false
+    );
+  });
+
+  it("creates under project root from the tree-background surface", async () => {
+    const { context, files, openInstance } = makeContext();
+    showFilesNamePromptMock.mockResolvedValueOnce({
+      cancelled: false,
+      value: "root.ts",
+    });
+    const action = actionById(
+      createFilesTreeActions(context),
+      FILES_NEW_FILE_COMMAND_ID
+    );
+
+    await action.handler({
+      metadata: { root: ROOT, treeId: "group-1" },
+      surface: "files/tree-background",
+    });
+
+    expect(files.writeText).toHaveBeenCalledWith({
+      contents: "",
+      path: "root.ts",
+      root: ROOT,
+    });
+    expect(openInstance).toHaveBeenCalled();
+  });
+
+  it("creates a nested path from the command palette prompt without inline create", async () => {
+    const { context, files } = makeContext();
+    showFilesNamePromptMock.mockResolvedValueOnce({
+      cancelled: false,
+      value: "a/b/nested.ts",
+    });
+    const action = actionById(
+      createFilesTreeActions(context),
+      FILES_NEW_FILE_COMMAND_ID
+    );
+
+    await action.handler({ surface: "command-palette" });
+
+    expect(showFilesNamePromptMock).toHaveBeenCalled();
+    expect(files.writeText).toHaveBeenCalledWith({
+      contents: "",
+      path: "a/b/nested.ts",
+      root: ROOT,
+    });
+    expect(
+      getFilesTreeSnapshot(ROOT).entriesByPath.get("a/b/nested.ts")
+    ).toEqual(file("a/b/nested.ts"));
+    expect(getFilesTreeSnapshot(ROOT).entriesByPath.get("a")?.kind).toBe(
+      "directory"
     );
   });
 

--- a/tests/unit/renderer/files-open-project.test.ts
+++ b/tests/unit/renderer/files-open-project.test.ts
@@ -1,0 +1,131 @@
+import type {
+  PluginPanelInstanceSnapshot,
+  RendererPluginContext,
+} from "@plugins/api/renderer.ts";
+import type { PanelContext } from "@shared/contracts/panel.ts";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { FILES_FILE_PANEL_ID } from "../../../src/plugins/builtin/files/manifest.ts";
+import * as prefs from "../../../src/plugins/builtin/files/renderer/file-tree-preferences.ts";
+import { openProjectFiles } from "../../../src/plugins/builtin/files/renderer/files-open-project.ts";
+import * as treeRegistry from "../../../src/plugins/builtin/files/renderer/files-tree-registry.ts";
+
+const baseContext: PanelContext = {
+  contextId: "ctx:1",
+  projectRootPath: "/Users/a/proj",
+  updatedAt: 1,
+  cwd: "/Users/a/proj/src",
+};
+
+function makePlugin(overrides?: {
+  listInstances?: PluginPanelInstanceSnapshot[];
+  openInstance?: RendererPluginContext["panels"]["openInstance"];
+}): RendererPluginContext {
+  const openInstance =
+    overrides?.openInstance ??
+    vi.fn<RendererPluginContext["panels"]["openInstance"]>();
+  const listInstances = overrides?.listInstances ?? [];
+
+  return {
+    actions: { register: vi.fn() },
+    commands: { register: vi.fn(), invoke: vi.fn() },
+    configuration: { get: vi.fn(), set: vi.fn(), onChange: vi.fn() },
+    environments: {} as RendererPluginContext["environments"],
+    files: {} as RendererPluginContext["files"],
+    git: {} as RendererPluginContext["git"],
+    i18n: { t: vi.fn((key: string) => key), lang: "en" },
+    missionControlWidgets: { register: vi.fn() },
+    notifications: {
+      error: vi.fn(),
+      info: vi.fn(),
+      success: vi.fn(),
+      warning: vi.fn(),
+    },
+    overlays: { open: vi.fn() },
+    panels: {
+      getActiveContext: vi.fn(),
+      getActiveInstanceId: vi.fn(),
+      listInstances: vi.fn().mockReturnValue(listInstances),
+      open: vi.fn(),
+      openInstance,
+      register: vi.fn(),
+      registerCloseGuard: vi.fn(),
+    },
+    commandPalette: { openQuickPick: vi.fn() },
+    settings: { openSection: vi.fn() },
+    terminal: {} as RendererPluginContext["terminal"],
+    terminalStatusItems: { register: vi.fn() },
+    worktrees: {} as RendererPluginContext["worktrees"],
+  } as unknown as RendererPluginContext;
+}
+
+describe("openProjectFiles", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns no-anchor when context lacks project fields", () => {
+    const plugin = makePlugin();
+    const result = openProjectFiles(plugin, {
+      contextId: "x",
+      projectRootPath: "",
+      updatedAt: 1,
+    } as PanelContext);
+    expect(result).toEqual({ ok: false, reason: "no-anchor" });
+  });
+
+  it("opens a new empty files instance for the project root", () => {
+    const openInstance = vi.fn();
+    const plugin = makePlugin({ listInstances: [], openInstance });
+    const expand = vi.spyOn(prefs, "ensureProjectFileTreeExpanded");
+    expect(openProjectFiles(plugin, baseContext)).toEqual({ ok: true });
+    expect(openInstance).toHaveBeenCalledWith(
+      expect.objectContaining({
+        componentId: FILES_FILE_PANEL_ID,
+        context: baseContext,
+        params: {},
+      })
+    );
+    expect(expand).toHaveBeenCalledWith("/Users/a/proj");
+    expand.mockRestore();
+  });
+
+  it("reuses an existing instance for the same project anchor", () => {
+    const openInstance = vi.fn();
+    const plugin = makePlugin({
+      listInstances: [
+        {
+          id: "existing-id",
+          componentId: FILES_FILE_PANEL_ID,
+          groupId: "g1",
+          title: "proj",
+          params: {
+            context: baseContext,
+            source: { kind: "disk", path: "a.ts", root: "/Users/a/proj" },
+          },
+        },
+      ],
+      openInstance,
+    });
+    openProjectFiles(plugin, baseContext);
+    expect(openInstance).toHaveBeenCalledWith(
+      expect.objectContaining({ instanceId: "existing-id" })
+    );
+  });
+
+  it("schedules reveal after open", () => {
+    const reveal = vi
+      .spyOn(treeRegistry, "revealFilesTreePath")
+      .mockReturnValue(true);
+    const plugin = makePlugin({ listInstances: [], openInstance: vi.fn() });
+    openProjectFiles(plugin, baseContext);
+    expect(reveal).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(80);
+    expect(reveal).toHaveBeenCalledWith(
+      expect.objectContaining({ root: "/Users/a/proj" })
+    );
+    reveal.mockRestore();
+  });
+});

--- a/tests/unit/renderer/files-project-anchor.test.ts
+++ b/tests/unit/renderer/files-project-anchor.test.ts
@@ -1,0 +1,82 @@
+import type { PanelContext } from "@shared/contracts/panel.ts";
+import { describe, expect, it } from "vitest";
+import {
+  formatProjectPath,
+  projectAnchor,
+} from "../../../src/plugins/builtin/files/renderer/files-project-anchor.ts";
+
+function ctx(
+  partial: Partial<PanelContext> &
+    Pick<PanelContext, "contextId" | "projectRootPath" | "updatedAt">
+): PanelContext {
+  return partial;
+}
+
+describe("projectAnchor", () => {
+  it("returns null when context is missing", () => {
+    expect(projectAnchor(undefined)).toBeNull();
+  });
+
+  it("prefers projectRootPath over worktree/git/cwd", () => {
+    expect(
+      projectAnchor(
+        ctx({
+          contextId: "c",
+          projectRootPath: "/repo",
+          updatedAt: 1,
+          worktreeRoot: "/repo-wt",
+          gitRoot: "/repo-git",
+          cwd: "/repo/src",
+        })
+      )
+    ).toBe("/repo");
+  });
+
+  it("falls back worktreeRoot → gitRoot → cwd when projectRootPath is empty", () => {
+    expect(
+      projectAnchor(
+        ctx({
+          contextId: "c",
+          projectRootPath: "",
+          updatedAt: 1,
+          worktreeRoot: "/wt",
+        })
+      )
+    ).toBe("/wt");
+    expect(
+      projectAnchor(
+        ctx({
+          contextId: "c",
+          projectRootPath: "",
+          updatedAt: 1,
+          gitRoot: "/git",
+        })
+      )
+    ).toBe("/git");
+    expect(
+      projectAnchor(
+        ctx({
+          contextId: "c",
+          projectRootPath: "",
+          updatedAt: 1,
+          cwd: "/cwd",
+        })
+      )
+    ).toBe("/cwd");
+  });
+});
+
+describe("formatProjectPath", () => {
+  it("returns absolute path when home is null", () => {
+    expect(formatProjectPath("/Users/a/proj", null)).toBe("/Users/a/proj");
+  });
+
+  it("folds home to ~", () => {
+    expect(formatProjectPath("/Users/a", "/Users/a")).toBe("~");
+    expect(formatProjectPath("/Users/a/proj", "/Users/a")).toBe("~/proj");
+  });
+
+  it("strips trailing separators before compare", () => {
+    expect(formatProjectPath("/Users/a/proj/", "/Users/a/")).toBe("~/proj");
+  });
+});

--- a/tests/unit/renderer/files-project-status-item.test.tsx
+++ b/tests/unit/renderer/files-project-status-item.test.tsx
@@ -1,0 +1,57 @@
+import type { PanelContext } from "@shared/contracts/panel.ts";
+import { describe, expect, it } from "vitest";
+import { isFilesProjectStatusVisible } from "../../../src/plugins/builtin/files/renderer/files-project-status-item.tsx";
+
+function makeStatusContext(panelContext?: PanelContext) {
+  return {
+    context: panelContext,
+    cwd: panelContext?.cwd ?? null,
+    panelId: "terminal-1",
+    title: "Terminal",
+  };
+}
+
+describe("isFilesProjectStatusVisible", () => {
+  it("returns false when context is undefined", () => {
+    expect(isFilesProjectStatusVisible(makeStatusContext(undefined))).toBe(
+      false
+    );
+  });
+
+  it("returns false when context has no project root", () => {
+    expect(
+      isFilesProjectStatusVisible(
+        makeStatusContext({
+          contextId: "x",
+          projectRootPath: "",
+          updatedAt: 1,
+        } as PanelContext)
+      )
+    ).toBe(false);
+  });
+
+  it("returns true when context has projectRootPath", () => {
+    expect(
+      isFilesProjectStatusVisible(
+        makeStatusContext({
+          contextId: "c",
+          projectRootPath: "/repo",
+          updatedAt: 1,
+        } as PanelContext)
+      )
+    ).toBe(true);
+  });
+
+  it("returns true when context has worktreeRoot", () => {
+    expect(
+      isFilesProjectStatusVisible(
+        makeStatusContext({
+          contextId: "c",
+          projectRootPath: "",
+          worktreeRoot: "/wt",
+          updatedAt: 1,
+        } as PanelContext)
+      )
+    ).toBe(true);
+  });
+});

--- a/tests/unit/renderer/files-tree-create.test.ts
+++ b/tests/unit/renderer/files-tree-create.test.ts
@@ -1,0 +1,365 @@
+import type { RendererPluginContext } from "@plugins/api/renderer.ts";
+import { validateRelativePath } from "@plugins/builtin/files/renderer/file-tree-action-utils.ts";
+import { createFilesTranslate } from "@plugins/builtin/files/renderer/files-i18n.ts";
+import {
+  allocateUniqueChildName,
+  beginInlineCreate,
+  cancelInlineCreate,
+  commitCreatedPath,
+  commitInlineCreate,
+} from "@plugins/builtin/files/renderer/files-tree-create.ts";
+import {
+  clearFileTreeSidebarCache,
+  peekPendingCreate,
+  registerFilesTreeInstance,
+  registerPendingCreate,
+} from "@plugins/builtin/files/renderer/files-tree-registry.ts";
+import {
+  addFilesTreeEntry,
+  clearFilesTreeStore,
+  getFilesTreeSnapshot,
+} from "@plugins/builtin/files/renderer/files-tree-store.ts";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const ROOT = "/repo";
+
+function makeContext(overrides?: {
+  existsPaths?: ReadonlySet<string>;
+  writeText?: RendererPluginContext["files"]["writeText"];
+  mkdir?: RendererPluginContext["files"]["mkdir"];
+  openInstance?: RendererPluginContext["panels"]["openInstance"];
+}) {
+  const existsPaths = overrides?.existsPaths ?? new Set<string>();
+  const openInstance =
+    overrides?.openInstance ??
+    vi.fn<RendererPluginContext["panels"]["openInstance"]>();
+  const files = {
+    exists: vi.fn<RendererPluginContext["files"]["exists"]>(
+      async (request) => ({
+        exists: existsPaths.has(request.path),
+        path: request.path,
+        root: request.root,
+      })
+    ),
+    list: vi.fn<RendererPluginContext["files"]["list"]>(async () => []),
+    mkdir:
+      overrides?.mkdir ??
+      vi.fn<RendererPluginContext["files"]["mkdir"]>(async (request) => ({
+        created: true,
+        path: request.path,
+        root: request.root,
+      })),
+    writeText:
+      overrides?.writeText ??
+      vi.fn<RendererPluginContext["files"]["writeText"]>(async (request) => ({
+        mtimeMs: 1,
+        path: request.path,
+        root: request.root,
+        written: true as const,
+      })),
+  };
+  const notifications = {
+    error: vi.fn(),
+    info: vi.fn(),
+    loading: vi.fn(() => ({
+      dismiss: vi.fn(),
+      info: vi.fn(),
+      success: vi.fn(),
+    })),
+    success: vi.fn(),
+    system: vi.fn(async () => ({ shown: true })),
+  };
+  const context = {
+    files,
+    i18n: {
+      commandDescription: vi.fn(() => undefined),
+      commandTitle: vi.fn((_id: string, fallback?: string) => fallback ?? ""),
+      language: vi.fn(() => "en"),
+      t: vi.fn(
+        (
+          _key: string,
+          _values?: Record<string, number | string>,
+          fallback?: string
+        ) => fallback ?? _key
+      ),
+    },
+    notifications,
+    panels: {
+      getActiveContext: vi.fn(() => ({
+        contextId: "c",
+        cwd: ROOT,
+        projectRootPath: ROOT,
+      })),
+      openInstance,
+    },
+  } as unknown as RendererPluginContext;
+  return { context, files, notifications, openInstance };
+}
+
+afterEach(() => {
+  clearFilesTreeStore();
+  clearFileTreeSidebarCache();
+  vi.restoreAllMocks();
+});
+
+describe("allocateUniqueChildName", () => {
+  it("returns the base name when free, then increments on conflict", async () => {
+    const { files } = makeContext({
+      existsPaths: new Set(["untitled.ts"]),
+    });
+    await expect(
+      allocateUniqueChildName(ROOT, "", "untitled.ts", files.exists)
+    ).resolves.toBe("untitled 2.ts");
+  });
+});
+
+describe("validateRelativePath", () => {
+  it("accepts nested relative paths and rejects traversal", () => {
+    const t = createFilesTranslate(makeContext().context);
+    expect(validateRelativePath("a/b/c.ts", t)).toBeNull();
+    expect(validateRelativePath("../x", t)).not.toBeNull();
+    expect(validateRelativePath("/abs", t)).not.toBeNull();
+    expect(validateRelativePath("a//b", t)).not.toBeNull();
+  });
+});
+
+describe("commitCreatedPath", () => {
+  it("writes a file, patches the tree, opens pinned, and marks nested ancestors", async () => {
+    const { context, files, openInstance } = makeContext();
+    const ok = await commitCreatedPath({
+      context,
+      kind: "file",
+      openAfter: true,
+      path: "a/b/c.ts",
+      root: ROOT,
+      treeId: "group-1",
+    });
+    expect(ok).toBe(true);
+    expect(files.writeText).toHaveBeenCalledWith({
+      contents: "",
+      path: "a/b/c.ts",
+      root: ROOT,
+    });
+    const snapshot = getFilesTreeSnapshot(ROOT);
+    expect(snapshot.entriesByPath.get("a")?.kind).toBe("directory");
+    expect(snapshot.entriesByPath.get("a/b")?.kind).toBe("directory");
+    expect(snapshot.entriesByPath.get("a/b/c.ts")).toEqual({
+      kind: "file",
+      path: "a/b/c.ts",
+      root: ROOT,
+    });
+    expect(openInstance).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({
+          pinned: true,
+          source: { kind: "disk", path: "a/b/c.ts", root: ROOT },
+        }),
+        targetGroupId: "group-1",
+      })
+    );
+  });
+
+  it("marks a new folder as empty in directoryStates", async () => {
+    const { context } = makeContext();
+    await commitCreatedPath({
+      context,
+      kind: "folder",
+      openAfter: false,
+      path: "src/components",
+      root: ROOT,
+    });
+    expect(
+      getFilesTreeSnapshot(ROOT).directoryStatesByPath.get("src/components")
+    ).toBe("empty");
+  });
+});
+
+describe("inline create commit/cancel", () => {
+  it("commits a pending placeholder to disk and opens the file", async () => {
+    const { context, files, openInstance } = makeContext();
+    addFilesTreeEntry(ROOT, {
+      kind: "file",
+      path: "src/untitled.ts",
+      root: ROOT,
+    });
+    registerPendingCreate({
+      kind: "file",
+      openAfter: true,
+      placeholderPath: "src/untitled.ts",
+      root: ROOT,
+      treeId: "g1",
+    });
+    const handled = await commitInlineCreate({
+      context,
+      from: "src/untitled.ts",
+      root: ROOT,
+      to: "src/new.ts",
+    });
+    expect(handled).toBe(true);
+    expect(files.writeText).toHaveBeenCalledWith({
+      contents: "",
+      path: "src/new.ts",
+      root: ROOT,
+    });
+    expect(
+      getFilesTreeSnapshot(ROOT).entriesByPath.has("src/untitled.ts")
+    ).toBe(false);
+    expect(getFilesTreeSnapshot(ROOT).entriesByPath.get("src/new.ts")).toEqual({
+      kind: "file",
+      path: "src/new.ts",
+      root: ROOT,
+    });
+    expect(openInstance).toHaveBeenCalled();
+    expect(peekPendingCreate(ROOT, "src/untitled.ts")).toBeNull();
+  });
+
+  it("removes the placeholder on cancel", () => {
+    addFilesTreeEntry(ROOT, {
+      kind: "file",
+      path: "src/untitled.ts",
+      root: ROOT,
+    });
+    registerPendingCreate({
+      kind: "file",
+      openAfter: true,
+      placeholderPath: "src/untitled.ts",
+      root: ROOT,
+    });
+    cancelInlineCreate(ROOT, "src/untitled.ts");
+    expect(
+      getFilesTreeSnapshot(ROOT).entriesByPath.has("src/untitled.ts")
+    ).toBe(false);
+    expect(peekPendingCreate(ROOT, "src/untitled.ts")).toBeNull();
+  });
+
+  it("discards the placeholder and reloads when create commit conflicts", async () => {
+    const removePaths = vi.fn();
+    registerFilesTreeInstance("g1", {
+      getApi: () =>
+        ({
+          focusSearchMatch: () => undefined,
+          getSearchMatchCount: () => 0,
+          removePaths,
+          revealPath: () => undefined,
+          setSearch: () => undefined,
+          startRenaming: () => false,
+        }) as never,
+      openSearch: () => undefined,
+      root: ROOT,
+    });
+    const { context, files, notifications } = makeContext({
+      existsPaths: new Set(["src/taken.ts"]),
+    });
+    files.list.mockImplementation(async () => [
+      { kind: "file" as const, path: "src/taken.ts", root: ROOT },
+    ]);
+    addFilesTreeEntry(ROOT, {
+      kind: "file",
+      path: "src/untitled.ts",
+      root: ROOT,
+    });
+    // 冲突目标本就在 store:discard 不得误删它。
+    addFilesTreeEntry(ROOT, {
+      kind: "file",
+      path: "src/taken.ts",
+      root: ROOT,
+    });
+    registerPendingCreate({
+      kind: "file",
+      openAfter: true,
+      placeholderPath: "src/untitled.ts",
+      root: ROOT,
+      treeId: "g1",
+    });
+
+    await commitInlineCreate({
+      context,
+      from: "src/untitled.ts",
+      root: ROOT,
+      to: "src/taken.ts",
+    });
+
+    expect(notifications.error).toHaveBeenCalled();
+    expect(removePaths).toHaveBeenCalledWith(["src/untitled.ts"]);
+    expect(files.list).toHaveBeenCalled();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(
+      getFilesTreeSnapshot(ROOT).entriesByPath.has("src/untitled.ts")
+    ).toBe(false);
+    expect(
+      getFilesTreeSnapshot(ROOT).entriesByPath.get("src/taken.ts")
+    ).toEqual({
+      kind: "file",
+      path: "src/taken.ts",
+      root: ROOT,
+    });
+  });
+
+  it("removes optimistic destination ghost when commit fails and to was not in store", async () => {
+    const removePaths = vi.fn();
+    registerFilesTreeInstance("g1", {
+      getApi: () =>
+        ({
+          focusSearchMatch: () => undefined,
+          getSearchMatchCount: () => 0,
+          removePaths,
+          revealPath: () => undefined,
+          setSearch: () => undefined,
+          startRenaming: () => false,
+        }) as never,
+      openSearch: () => undefined,
+      root: ROOT,
+    });
+    const { context, files } = makeContext();
+    files.writeText.mockRejectedValueOnce(new Error("disk full"));
+    addFilesTreeEntry(ROOT, {
+      kind: "file",
+      path: "src/untitled.ts",
+      root: ROOT,
+    });
+    registerPendingCreate({
+      kind: "file",
+      openAfter: true,
+      placeholderPath: "src/untitled.ts",
+      root: ROOT,
+      treeId: "g1",
+    });
+
+    await commitInlineCreate({
+      context,
+      from: "src/untitled.ts",
+      root: ROOT,
+      to: "src/new.ts",
+    });
+
+    expect(removePaths).toHaveBeenCalledWith(["src/untitled.ts", "src/new.ts"]);
+    expect(
+      getFilesTreeSnapshot(ROOT).entriesByPath.has("src/untitled.ts")
+    ).toBe(false);
+    expect(getFilesTreeSnapshot(ROOT).entriesByPath.has("src/new.ts")).toBe(
+      false
+    );
+  });
+});
+
+describe("beginInlineCreate", () => {
+  it("falls back when the tree API cannot start renaming", async () => {
+    const { context } = makeContext();
+    registerFilesTreeInstance("g1", {
+      getApi: () => null,
+      openSearch: () => undefined,
+      root: ROOT,
+    });
+    await expect(
+      beginInlineCreate({
+        context,
+        kind: "file",
+        parentDir: "src",
+        root: ROOT,
+        treeId: "g1",
+      })
+    ).resolves.toBe(false);
+    expect(getFilesTreeSnapshot(ROOT).entriesByPath.size).toBe(0);
+  });
+});

--- a/tests/unit/renderer/files-tree-store.test.ts
+++ b/tests/unit/renderer/files-tree-store.test.ts
@@ -1,5 +1,9 @@
 import type { RendererPluginContext } from "@plugins/api/renderer.ts";
 import {
+  clearFileTreeSidebarCache,
+  registerPendingCreate,
+} from "@plugins/builtin/files/renderer/files-tree-registry.ts";
+import {
   addFilesTreeEntry,
   applyFilesTreeWatchEvent,
   clearFilesTreeStore,
@@ -73,6 +77,7 @@ async function loadRoot(entries: readonly FileEntry[]): Promise<void> {
 describe("files-tree-store", () => {
   afterEach(() => {
     clearFilesTreeStore();
+    clearFileTreeSidebarCache();
     vi.restoreAllMocks();
   });
 
@@ -190,6 +195,47 @@ describe("files-tree-store", () => {
     expect(snapshot.entriesByPath.get("src/new.ts")).toEqual(
       file("src/new.ts")
     );
+  });
+
+  it("marks a newly added directory entry as empty", () => {
+    addFilesTreeEntry(ROOT, directory("src/components"));
+
+    const snapshot = getFilesTreeSnapshot(ROOT);
+    expect(snapshot.entriesByPath.get("src/components")).toEqual(
+      directory("src/components")
+    );
+    expect(snapshot.directoryStatesByPath.get("src/components")).toBe("empty");
+  });
+
+  it("retains pending-create placeholders when a directory reload omits them", async () => {
+    await loadRoot([directory("src")]);
+    await loadFilesTreeDirectory(
+      ROOT,
+      "src",
+      listFromResponses({ src: [file("src/keep.ts")] })
+    );
+    addFilesTreeEntry(ROOT, file("src/untitled.ts"));
+    registerPendingCreate({
+      kind: "file",
+      openAfter: true,
+      placeholderPath: "src/untitled.ts",
+      root: ROOT,
+    });
+
+    await loadFilesTreeDirectory(
+      ROOT,
+      "src",
+      listFromResponses({ src: [file("src/keep.ts")] })
+    );
+
+    const snapshot = getFilesTreeSnapshot(ROOT);
+    expect(snapshot.entriesByPath.get("src/keep.ts")).toEqual(
+      file("src/keep.ts")
+    );
+    expect(snapshot.entriesByPath.get("src/untitled.ts")).toEqual(
+      file("src/untitled.ts")
+    );
+    expect(snapshot.directoryStatesByPath.get("src")).toBe("loaded");
   });
 
   it("marks a loaded parent as empty after removing its last child", async () => {


### PR DESCRIPTION
## Summary

文件树内联新建文件/文件夹功能。

### 流程
1. 右键/快捷键触发新建 → 插入幽灵节点 + 自动进入 rename
2. Esc / 空提交 → 从树模型移除幽灵节点
3. 命名确认 → 落盘写入；失败则回滚幽灵节点
4. 幽灵节点在落盘前禁止打开/重命名操作

### API 扩展
- `PierFileTreeApi.startRenaming` 新增 `removeIfCanceled` 选项
- `PierFileTreeApi.removePaths` 模型层清理幽灵节点
- `PierFileTreeProps.onModelPathsRemoved` 回调

### 文件
- **新建 2**：`files-tree-create.ts`, `files-tree-create.test.ts`
- **修改 11**：组件库 `file-tree-types.ts`/`file-tree.tsx`，sidebar、registry、store、actions、test 适配
