### PR TITLE
style(ui): standardize interactive control density

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,17 @@ dev override 只允许开发/测试运行时使用；生产包默认不显示入
 - 遇到内联 toast 文案字符串（未走 i18n） → finding。
 - 遇到 `toast.*(…, { description })` → finding，详情应走 `showAppAlert`。
 
+### 交互控件密度规范
+
+Pier 桌面端的单行交互控件统一使用 28px 高度：
+
+- 高度所有权在 `packages/ui/src/interactive-density.ts`；基础控件消费统一定义，业务代码不得用 `h-8`、`h-8!` 或额外纵向内边距把标准控件恢复到 32px。
+- Button、Input、InputGroup、Select trigger、Toggle、Tabs、Menubar、命令面板输入框和同类单行控件默认高度为 28px；纯图标默认控件为 28×28px。
+- Select、Dropdown Menu、Context Menu、Menubar、Command 和 Navigation Menu 的内容型选项统一使用“最小 28px”：单行必须为 28px，多行说明可按内容自然增高，禁止为了固定 28px 裁切文字。
+- `asChild` 触发器由子控件持有尺寸；应优先组合 `@pier/ui` 的 Button 等统一控件，不在业务层复制高度。
+- Textarea、卡片内容、头像、骨架内容块、导航分组标题等非单行交互控件不适用本规则。
+- 检查点在 `tests/unit/renderer/interactive-density-governance.test.ts`；新增通用交互原语必须接入统一密度定义，例外必须在测试中说明原因。
+
 ### 颜色使用规范
 
 产品界面颜色按“主题原色 → 语义令牌 → 组件变体 → 业务映射”单向使用：

--- a/packages/plugin-codex/package.json
+++ b/packages/plugin-codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pier/plugin-codex",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/plugin-codex/plugin.json
+++ b/packages/plugin-codex/plugin.json
@@ -143,5 +143,5 @@
   "renderer": "dist/renderer.js",
   "settingsPages": [{ "id": "pier.codex.accounts" }],
   "terminalStatusItems": [],
-  "version": "1.0.4"
+  "version": "1.0.5"
 }

--- a/packages/plugin-codex/src/renderer/accounts-settings-page.tsx
+++ b/packages/plugin-codex/src/renderer/accounts-settings-page.tsx
@@ -33,7 +33,7 @@ function AccountsTableSkeleton(): JSX.Element {
     <div className="px-4 pb-4">
       <div className="mb-4 flex items-center justify-between gap-3">
         <Skeleton className="h-7 w-28 rounded-lg" />
-        <Skeleton className="h-8 w-24 rounded-full" />
+        <Skeleton className="h-7 w-24 rounded-full" />
       </div>
       <div className="pier-codex-account-table-shell">
         <Table className="pier-codex-account-table">

--- a/packages/ui/src/button.tsx
+++ b/packages/ui/src/button.tsx
@@ -2,6 +2,10 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { Slot } from "radix-ui";
 import type * as React from "react";
 
+import {
+  CONTROL_HEIGHT_CLASS,
+  CONTROL_ICON_SIZE_CLASS,
+} from "./interactive-density.ts";
 import { cn } from "./utils.ts";
 
 const buttonVariants = cva(
@@ -26,12 +30,14 @@ const buttonVariants = cva(
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
-        default:
-          "h-8 gap-1.5 px-3 has-data-[icon=inline-end]:pr-2.5 has-data-[icon=inline-start]:pl-2.5",
+        default: cn(
+          CONTROL_HEIGHT_CLASS,
+          "gap-1.5 px-3 has-data-[icon=inline-end]:pr-2.5 has-data-[icon=inline-start]:pl-2.5"
+        ),
         xs: "h-6 gap-1 px-2.5 text-xs has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2 [&_svg:not([class*='size-'])]:size-3",
         sm: "h-7 gap-1 px-3 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
         lg: "h-9 gap-1.5 px-4 has-data-[icon=inline-end]:pr-3 has-data-[icon=inline-start]:pl-3",
-        icon: "size-8",
+        icon: CONTROL_ICON_SIZE_CLASS,
         "icon-xs": "size-6 [&_svg:not([class*='size-'])]:size-3",
         "icon-sm": "size-7",
         "icon-lg": "size-9",

--- a/packages/ui/src/command.tsx
+++ b/packages/ui/src/command.tsx
@@ -9,6 +9,10 @@ import {
   DialogTitle,
 } from "./dialog.tsx";
 import { InputGroup, InputGroupAddon } from "./input-group.tsx";
+import {
+  CONTROL_HEIGHT_CLASS,
+  MENU_ITEM_DENSITY_CLASS,
+} from "./interactive-density.ts";
 import { cn } from "./utils.ts";
 
 function Command({
@@ -67,7 +71,7 @@ function CommandInput({
 }: React.ComponentProps<typeof CommandPrimitive.Input>) {
   return (
     <div className="p-1 pb-0" data-slot="command-input-wrapper">
-      <InputGroup className="h-8! bg-input/50">
+      <InputGroup className={cn(CONTROL_HEIGHT_CLASS, "bg-input/50")}>
         <CommandPrimitive.Input
           className={cn(
             // placeholder 显式绑 --foreground 50% alpha, 绕开 preflight 的
@@ -161,7 +165,8 @@ function CommandItem({
   return (
     <CommandPrimitive.Item
       className={cn(
-        "group/command-item relative flex min-h-7 select-none items-center gap-2 in-data-[slot=dialog-content]:rounded-2xl rounded-xl px-2 py-1.5 text-sm outline-hidden data-[disabled=true]:pointer-events-none data-selected:bg-accent data-selected:text-accent-foreground data-[disabled=true]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0 data-selected:*:[svg]:text-accent-foreground",
+        MENU_ITEM_DENSITY_CLASS,
+        "group/command-item relative flex select-none items-center gap-2 in-data-[slot=dialog-content]:rounded-2xl rounded-xl px-2 outline-hidden data-[disabled=true]:pointer-events-none data-selected:bg-accent data-selected:text-accent-foreground data-[disabled=true]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0 data-selected:*:[svg]:text-accent-foreground",
         className
       )}
       data-slot="command-item"

--- a/packages/ui/src/context-menu.tsx
+++ b/packages/ui/src/context-menu.tsx
@@ -2,6 +2,7 @@ import { CheckIcon, ChevronRightIcon } from "lucide-react";
 import { ContextMenu as ContextMenuPrimitive } from "radix-ui";
 import { useComposedRefs } from "radix-ui/internal";
 import type * as React from "react";
+import { MENU_ITEM_DENSITY_CLASS } from "./interactive-density.ts";
 import { useTerminalOverlay } from "./use-terminal-overlay.tsx";
 import { cn } from "./utils.ts";
 
@@ -92,7 +93,8 @@ function ContextMenuItem({
   return (
     <ContextMenuPrimitive.Item
       className={cn(
-        "group/context-menu-item relative flex min-h-7 select-none items-center gap-2 rounded-xl px-2 py-1.5 text-sm outline-hidden focus:bg-accent focus:text-accent-foreground data-disabled:pointer-events-none data-inset:pl-7 data-[variant=destructive]:text-destructive data-disabled:opacity-50 data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0 focus:*:[svg]:text-accent-foreground data-[variant=destructive]:*:[svg]:text-destructive",
+        MENU_ITEM_DENSITY_CLASS,
+        "group/context-menu-item relative flex select-none items-center gap-2 rounded-xl px-2 outline-hidden focus:bg-accent focus:text-accent-foreground data-disabled:pointer-events-none data-inset:pl-7 data-[variant=destructive]:text-destructive data-disabled:opacity-50 data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0 focus:*:[svg]:text-accent-foreground data-[variant=destructive]:*:[svg]:text-destructive",
         className
       )}
       data-inset={inset}
@@ -114,7 +116,8 @@ function ContextMenuSubTrigger({
   return (
     <ContextMenuPrimitive.SubTrigger
       className={cn(
-        "flex min-h-7 select-none items-center rounded-xl px-2 py-1.5 text-sm outline-hidden focus:bg-accent focus:text-accent-foreground data-open:bg-accent data-inset:pl-7 data-open:text-accent-foreground [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        MENU_ITEM_DENSITY_CLASS,
+        "flex select-none items-center rounded-xl px-2 outline-hidden focus:bg-accent focus:text-accent-foreground data-open:bg-accent data-inset:pl-7 data-open:text-accent-foreground [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className
       )}
       data-inset={inset}
@@ -158,7 +161,8 @@ function ContextMenuCheckboxItem({
   return (
     <ContextMenuPrimitive.CheckboxItem
       className={cn(
-        "relative flex min-h-7 select-none items-center gap-2 rounded-xl py-1.5 pr-8 pl-2 text-sm outline-hidden focus:bg-accent focus:text-accent-foreground data-disabled:pointer-events-none data-inset:pl-7 data-disabled:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        MENU_ITEM_DENSITY_CLASS,
+        "relative flex select-none items-center gap-2 rounded-xl pr-8 pl-2 outline-hidden focus:bg-accent focus:text-accent-foreground data-disabled:pointer-events-none data-inset:pl-7 data-disabled:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className
       )}
       data-inset={inset}
@@ -187,7 +191,8 @@ function ContextMenuRadioItem({
   return (
     <ContextMenuPrimitive.RadioItem
       className={cn(
-        "relative flex min-h-7 select-none items-center gap-2 rounded-xl py-1.5 pr-8 pl-2 text-sm outline-hidden focus:bg-accent focus:text-accent-foreground data-disabled:pointer-events-none data-inset:pl-7 data-disabled:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        MENU_ITEM_DENSITY_CLASS,
+        "relative flex select-none items-center gap-2 rounded-xl pr-8 pl-2 outline-hidden focus:bg-accent focus:text-accent-foreground data-disabled:pointer-events-none data-inset:pl-7 data-disabled:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className
       )}
       data-inset={inset}

--- a/packages/ui/src/dropdown-menu.tsx
+++ b/packages/ui/src/dropdown-menu.tsx
@@ -2,6 +2,7 @@ import { CheckIcon, ChevronRightIcon } from "lucide-react";
 import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui";
 import { useComposedRefs } from "radix-ui/internal";
 import type * as React from "react";
+import { MENU_ITEM_DENSITY_CLASS } from "./interactive-density.ts";
 import { useTerminalOverlay } from "./use-terminal-overlay.tsx";
 import { cn } from "./utils.ts";
 
@@ -76,7 +77,8 @@ function DropdownMenuItem({
   return (
     <DropdownMenuPrimitive.Item
       className={cn(
-        "group/dropdown-menu-item relative flex min-h-7 select-none items-center gap-2 rounded-xl px-2 py-1.5 text-sm outline-hidden focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-disabled:pointer-events-none data-inset:pl-7 data-[variant=destructive]:text-destructive data-disabled:opacity-50 data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0 data-[variant=destructive]:*:[svg]:text-destructive",
+        MENU_ITEM_DENSITY_CLASS,
+        "group/dropdown-menu-item relative flex select-none items-center gap-2 rounded-xl px-2 outline-hidden focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-disabled:pointer-events-none data-inset:pl-7 data-[variant=destructive]:text-destructive data-disabled:opacity-50 data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0 data-[variant=destructive]:*:[svg]:text-destructive",
         "data-highlighted:bg-accent data-highlighted:text-accent-foreground not-data-[variant=destructive]:data-highlighted:**:text-accent-foreground",
         className
       )}
@@ -100,7 +102,8 @@ function DropdownMenuCheckboxItem({
   return (
     <DropdownMenuPrimitive.CheckboxItem
       className={cn(
-        "relative flex min-h-7 select-none items-center gap-2 rounded-xl py-1.5 pr-8 pl-2 text-sm outline-hidden focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-disabled:pointer-events-none data-inset:pl-7 data-disabled:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        MENU_ITEM_DENSITY_CLASS,
+        "relative flex select-none items-center gap-2 rounded-xl pr-8 pl-2 outline-hidden focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-disabled:pointer-events-none data-inset:pl-7 data-disabled:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
         "data-highlighted:bg-accent data-highlighted:text-accent-foreground data-highlighted:**:text-accent-foreground",
         className
       )}
@@ -144,7 +147,8 @@ function DropdownMenuRadioItem({
   return (
     <DropdownMenuPrimitive.RadioItem
       className={cn(
-        "relative flex min-h-7 select-none items-center gap-2 rounded-xl py-1.5 pr-8 pl-2 text-sm outline-hidden focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-disabled:pointer-events-none data-inset:pl-7 data-disabled:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        MENU_ITEM_DENSITY_CLASS,
+        "relative flex select-none items-center gap-2 rounded-xl pr-8 pl-2 outline-hidden focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-disabled:pointer-events-none data-inset:pl-7 data-disabled:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
         "data-highlighted:bg-accent data-highlighted:text-accent-foreground data-highlighted:**:text-accent-foreground",
         className
       )}
@@ -231,7 +235,8 @@ function DropdownMenuSubTrigger({
   return (
     <DropdownMenuPrimitive.SubTrigger
       className={cn(
-        "flex min-h-7 select-none items-center gap-2 rounded-xl px-2 py-1.5 text-sm outline-hidden focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-open:bg-accent data-inset:pl-7 data-open:text-accent-foreground [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        MENU_ITEM_DENSITY_CLASS,
+        "flex select-none items-center gap-2 rounded-xl px-2 outline-hidden focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-open:bg-accent data-inset:pl-7 data-open:text-accent-foreground [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
         "data-highlighted:bg-accent data-highlighted:text-accent-foreground data-highlighted:**:text-accent-foreground",
         className
       )}

--- a/packages/ui/src/input-group.tsx
+++ b/packages/ui/src/input-group.tsx
@@ -4,6 +4,10 @@ import { cva, type VariantProps } from "class-variance-authority";
 import type * as React from "react";
 import { Button } from "./button.tsx";
 import { Input } from "./input.tsx";
+import {
+  CONTROL_HEIGHT_CLASS,
+  CONTROL_ICON_SIZE_CLASS,
+} from "./interactive-density.ts";
 import { Textarea } from "./textarea.tsx";
 import { cn } from "./utils.ts";
 
@@ -11,7 +15,8 @@ function InputGroup({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       className={cn(
-        "group/input-group relative flex h-8 w-full min-w-0 items-center rounded-2xl border border-transparent bg-input/50 outline-none transition-[color,box-shadow] duration-200 in-data-[slot=combobox-content]:focus-within:border-inherit in-data-[slot=combobox-content]:focus-within:ring-0 has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-start]]:h-auto has-[>textarea]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-start]]:flex-col has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot][aria-invalid=true]]:border-destructive has-[[data-slot=input-group-control]:focus-visible]:ring-3 has-[[data-slot=input-group-control]:focus-visible]:ring-ring/30 has-[[data-slot][aria-invalid=true]]:ring-3 has-[[data-slot][aria-invalid=true]]:ring-destructive/20 dark:has-[[data-slot][aria-invalid=true]]:ring-destructive/40 has-[>[data-align=block-end]]:[&>input]:pt-3 has-[>[data-align=inline-end]]:[&>input]:pr-1.5 has-[>[data-align=block-start]]:[&>input]:pb-3 has-[>[data-align=inline-start]]:[&>input]:pl-1.5",
+        CONTROL_HEIGHT_CLASS,
+        "group/input-group relative flex w-full min-w-0 items-center rounded-2xl border border-transparent bg-input/50 outline-none transition-[color,box-shadow] duration-200 in-data-[slot=combobox-content]:focus-within:border-inherit in-data-[slot=combobox-content]:focus-within:ring-0 has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-start]]:h-auto has-[>textarea]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-start]]:flex-col has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot][aria-invalid=true]]:border-destructive has-[[data-slot=input-group-control]:focus-visible]:ring-3 has-[[data-slot=input-group-control]:focus-visible]:ring-ring/30 has-[[data-slot][aria-invalid=true]]:ring-3 has-[[data-slot][aria-invalid=true]]:ring-destructive/20 dark:has-[[data-slot][aria-invalid=true]]:ring-destructive/40 has-[>[data-align=block-end]]:[&>input]:pt-3 has-[>[data-align=inline-end]]:[&>input]:pr-1.5 has-[>[data-align=block-start]]:[&>input]:pb-3 has-[>[data-align=inline-start]]:[&>input]:pl-1.5",
         className
       )}
       data-slot="input-group"
@@ -72,7 +77,7 @@ const inputGroupButtonVariants = cva(
         xs: "h-6 gap-1 rounded-xl px-1.5 [&>svg:not([class*='size-'])]:size-3.5",
         sm: "",
         "icon-xs": "size-6 rounded-xl p-0 has-[>svg]:p-0",
-        "icon-sm": "size-8 p-0 has-[>svg]:p-0",
+        "icon-sm": cn(CONTROL_ICON_SIZE_CLASS, "p-0 has-[>svg]:p-0"),
       },
     },
     defaultVariants: {

--- a/packages/ui/src/input-otp.tsx
+++ b/packages/ui/src/input-otp.tsx
@@ -1,6 +1,7 @@
 import { OTPInput, OTPInputContext } from "input-otp";
 import { MinusIcon } from "lucide-react";
 import * as React from "react";
+import { CONTROL_ICON_SIZE_CLASS } from "./interactive-density.ts";
 import { cn } from "./utils.ts";
 
 function InputOTP({
@@ -50,7 +51,8 @@ function InputOTPSlot({
   return (
     <div
       className={cn(
-        "relative flex size-8 items-center justify-center border-input border-y border-r bg-input/50 text-sm outline-none transition-[color,box-shadow] duration-200 first:rounded-l-2xl first:border-l last:rounded-r-2xl aria-invalid:border-destructive data-[active=true]:z-10 data-[active=true]:border-ring data-[active=true]:ring-3 data-[active=true]:ring-ring/30 data-[active=true]:aria-invalid:ring-destructive/20 dark:data-[active=true]:aria-invalid:ring-destructive/40",
+        CONTROL_ICON_SIZE_CLASS,
+        "relative flex items-center justify-center border-input border-y border-r bg-input/50 text-sm outline-none transition-[color,box-shadow] duration-200 first:rounded-l-2xl first:border-l last:rounded-r-2xl aria-invalid:border-destructive data-[active=true]:z-10 data-[active=true]:border-ring data-[active=true]:ring-3 data-[active=true]:ring-ring/30 data-[active=true]:aria-invalid:ring-destructive/20 dark:data-[active=true]:aria-invalid:ring-destructive/40",
         className
       )}
       data-active={isActive}

--- a/packages/ui/src/input.tsx
+++ b/packages/ui/src/input.tsx
@@ -1,12 +1,14 @@
 import type * as React from "react";
 
+import { CONTROL_HEIGHT_CLASS } from "./interactive-density.ts";
 import { cn } from "./utils.ts";
 
 function Input({ className, type, ...props }: React.ComponentProps<"input">) {
   return (
     <input
       className={cn(
-        "h-8 w-full min-w-0 rounded-2xl border border-transparent bg-input/50 px-2.5 py-1 text-base outline-none transition-[color,box-shadow] duration-200 file:inline-flex file:h-6 file:border-0 file:bg-transparent file:font-medium file:text-foreground file:text-sm placeholder:text-foreground/30 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/30 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        CONTROL_HEIGHT_CLASS,
+        "w-full min-w-0 rounded-2xl border border-transparent bg-input/50 px-2.5 text-base outline-none transition-[color,box-shadow] duration-200 file:inline-flex file:h-6 file:border-0 file:bg-transparent file:font-medium file:text-foreground file:text-sm placeholder:text-foreground/30 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/30 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
         className
       )}
       data-slot="input"

--- a/packages/ui/src/interactive-density.ts
+++ b/packages/ui/src/interactive-density.ts
@@ -1,0 +1,9 @@
+/**
+ * Pier 桌面端单行交互控件的统一密度。
+ *
+ * 固定高度控件使用 28px；内容型选项使用最小 28px，单行时由
+ * 20px 行高 + 4px 上下内边距组成，多行内容可自然增高。
+ */
+export const CONTROL_HEIGHT_CLASS = "h-7";
+export const CONTROL_ICON_SIZE_CLASS = "size-7";
+export const MENU_ITEM_DENSITY_CLASS = "min-h-7 py-1 text-sm leading-5";

--- a/packages/ui/src/menubar.tsx
+++ b/packages/ui/src/menubar.tsx
@@ -2,6 +2,10 @@ import { CheckIcon, ChevronRightIcon } from "lucide-react";
 import { Menubar as MenubarPrimitive } from "radix-ui";
 import { useComposedRefs } from "radix-ui/internal";
 import type * as React from "react";
+import {
+  CONTROL_HEIGHT_CLASS,
+  MENU_ITEM_DENSITY_CLASS,
+} from "./interactive-density.ts";
 import { useTerminalOverlay } from "./use-terminal-overlay.tsx";
 import { cn } from "./utils.ts";
 
@@ -12,7 +16,8 @@ function Menubar({
   return (
     <MenubarPrimitive.Root
       className={cn(
-        "flex h-8 items-center rounded-2xl border p-[3px]",
+        CONTROL_HEIGHT_CLASS,
+        "flex items-center rounded-2xl border p-[3px]",
         className
       )}
       data-slot="menubar"
@@ -102,7 +107,8 @@ function MenubarItem({
   return (
     <MenubarPrimitive.Item
       className={cn(
-        "group/menubar-item relative flex min-h-7 select-none items-center gap-2 rounded-xl px-2 py-1.5 text-sm outline-hidden focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-disabled:pointer-events-none data-inset:pl-7 data-[variant=destructive]:text-destructive data-disabled:opacity-50 data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0 data-[variant=destructive]:*:[svg]:text-destructive!",
+        MENU_ITEM_DENSITY_CLASS,
+        "group/menubar-item relative flex select-none items-center gap-2 rounded-xl px-2 outline-hidden focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-disabled:pointer-events-none data-inset:pl-7 data-[variant=destructive]:text-destructive data-disabled:opacity-50 data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0 data-[variant=destructive]:*:[svg]:text-destructive!",
         className
       )}
       data-inset={inset}
@@ -125,7 +131,8 @@ function MenubarCheckboxItem({
   return (
     <MenubarPrimitive.CheckboxItem
       className={cn(
-        "relative flex min-h-7 select-none items-center gap-2 rounded-xl py-1.5 pr-1.5 pl-7 text-sm outline-hidden focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-disabled:pointer-events-none data-inset:pl-7 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        MENU_ITEM_DENSITY_CLASS,
+        "relative flex select-none items-center gap-2 rounded-xl pr-1.5 pl-7 outline-hidden focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-disabled:pointer-events-none data-inset:pl-7 [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className
       )}
       data-inset={inset}
@@ -154,7 +161,8 @@ function MenubarRadioItem({
   return (
     <MenubarPrimitive.RadioItem
       className={cn(
-        "relative flex min-h-7 select-none items-center gap-2 rounded-xl py-1.5 pr-1.5 pl-7 text-sm outline-hidden focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-disabled:pointer-events-none data-inset:pl-7 data-disabled:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        MENU_ITEM_DENSITY_CLASS,
+        "relative flex select-none items-center gap-2 rounded-xl pr-1.5 pl-7 outline-hidden focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-disabled:pointer-events-none data-inset:pl-7 data-disabled:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className
       )}
       data-inset={inset}
@@ -237,7 +245,8 @@ function MenubarSubTrigger({
   return (
     <MenubarPrimitive.SubTrigger
       className={cn(
-        "flex min-h-7 select-none items-center gap-2 rounded-xl px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-open:bg-accent data-inset:pl-7 data-open:text-accent-foreground [&_svg:not([class*='size-'])]:size-4",
+        MENU_ITEM_DENSITY_CLASS,
+        "flex select-none items-center gap-2 rounded-xl px-2 outline-none focus:bg-accent focus:text-accent-foreground data-open:bg-accent data-inset:pl-7 data-open:text-accent-foreground [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       data-inset={inset}

--- a/packages/ui/src/navigation-menu.tsx
+++ b/packages/ui/src/navigation-menu.tsx
@@ -2,6 +2,10 @@ import { cva } from "class-variance-authority";
 import { ChevronDownIcon } from "lucide-react";
 import { NavigationMenu as NavigationMenuPrimitive } from "radix-ui";
 import type * as React from "react";
+import {
+  CONTROL_HEIGHT_CLASS,
+  MENU_ITEM_DENSITY_CLASS,
+} from "./interactive-density.ts";
 import { cn } from "./utils.ts";
 
 function NavigationMenu({
@@ -58,7 +62,10 @@ function NavigationMenuItem({
 }
 
 const navigationMenuTriggerStyle = cva(
-  "group/navigation-menu-trigger inline-flex h-9 w-max items-center justify-center rounded-2xl px-2.5 py-1.5 font-medium text-sm outline-none transition-all hover:bg-muted focus:bg-muted focus-visible:outline-1 focus-visible:ring-3 focus-visible:ring-ring/30 disabled:pointer-events-none disabled:opacity-50 data-open:bg-muted/50 data-popup-open:bg-muted/50 data-open:focus:bg-muted data-open:hover:bg-muted data-popup-open:hover:bg-muted"
+  cn(
+    CONTROL_HEIGHT_CLASS,
+    "group/navigation-menu-trigger inline-flex w-max items-center justify-center rounded-2xl px-2.5 font-medium text-sm outline-none transition-all hover:bg-muted focus:bg-muted focus-visible:outline-1 focus-visible:ring-3 focus-visible:ring-ring/30 disabled:pointer-events-none disabled:opacity-50 data-open:bg-muted/50 data-popup-open:bg-muted/50 data-open:focus:bg-muted data-open:hover:bg-muted data-popup-open:hover:bg-muted"
+  )
 );
 
 function NavigationMenuTrigger({
@@ -126,7 +133,8 @@ function NavigationMenuLink({
   return (
     <NavigationMenuPrimitive.Link
       className={cn(
-        "flex in-data-[slot=navigation-menu-content]:w-full items-center gap-2 in-data-[slot=navigation-menu-content]:rounded-xl rounded-2xl in-data-[slot=navigation-menu-content]:p-2 px-2.5 py-1.5 font-medium in-data-[slot=navigation-menu-content]:font-normal text-sm outline-none transition-all hover:bg-muted focus:bg-muted focus-visible:outline-1 focus-visible:ring-3 focus-visible:ring-ring/30 data-[active=true]:bg-muted/50 data-[active=true]:focus:bg-muted data-[active=true]:hover:bg-muted [&_svg:not([class*='size-'])]:size-4",
+        MENU_ITEM_DENSITY_CLASS,
+        "flex in-data-[slot=navigation-menu-content]:w-full items-center gap-2 in-data-[slot=navigation-menu-content]:rounded-xl rounded-2xl px-2.5 font-medium in-data-[slot=navigation-menu-content]:font-normal outline-none transition-all hover:bg-muted focus:bg-muted focus-visible:outline-1 focus-visible:ring-3 focus-visible:ring-ring/30 data-[active=true]:bg-muted/50 data-[active=true]:focus:bg-muted data-[active=true]:hover:bg-muted [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       data-slot="navigation-menu-link"

--- a/packages/ui/src/pagination.tsx
+++ b/packages/ui/src/pagination.tsx
@@ -5,6 +5,7 @@ import {
 } from "lucide-react";
 import type * as React from "react";
 import { Button } from "./button.tsx";
+import { CONTROL_ICON_SIZE_CLASS } from "./interactive-density.ts";
 import { cn } from "./utils.ts";
 
 function Pagination({ className, ...props }: React.ComponentProps<"nav">) {
@@ -107,7 +108,8 @@ function PaginationEllipsis({
     <span
       aria-hidden
       className={cn(
-        "flex size-8 items-center justify-center [&_svg:not([class*='size-'])]:size-4",
+        CONTROL_ICON_SIZE_CLASS,
+        "flex items-center justify-center [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       data-slot="pagination-ellipsis"

--- a/packages/ui/src/select.tsx
+++ b/packages/ui/src/select.tsx
@@ -2,6 +2,10 @@ import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react";
 import { Select as SelectPrimitive } from "radix-ui";
 import { useComposedRefs } from "radix-ui/internal";
 import type * as React from "react";
+import {
+  CONTROL_HEIGHT_CLASS,
+  MENU_ITEM_DENSITY_CLASS,
+} from "./interactive-density.ts";
 import { useTerminalOverlay } from "./use-terminal-overlay.tsx";
 import { cn } from "./utils.ts";
 
@@ -55,7 +59,8 @@ function SelectTrigger({
   return (
     <SelectPrimitive.Trigger
       className={cn(
-        "flex w-fit items-center justify-between gap-1.5 whitespace-nowrap rounded-2xl border border-transparent bg-input/50 px-3 py-2 text-sm outline-none transition-[color,box-shadow] duration-200 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/30 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-[size=default]:h-8 data-[size=sm]:h-7 data-placeholder:text-foreground/30 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        CONTROL_HEIGHT_CLASS,
+        "flex w-fit items-center justify-between gap-1.5 whitespace-nowrap rounded-2xl border border-transparent bg-input/50 px-3 text-sm outline-none transition-[color,box-shadow] duration-200 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/30 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-placeholder:text-foreground/30 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className
       )}
       data-size={size}
@@ -133,7 +138,8 @@ function SelectItem({
   return (
     <SelectPrimitive.Item
       className={cn(
-        "relative flex min-h-7 w-full select-none items-center gap-2 rounded-xl py-1.5 pr-8 pl-2 text-sm outline-hidden focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        MENU_ITEM_DENSITY_CLASS,
+        "relative flex w-full select-none items-center gap-2 rounded-xl pr-8 pl-2 outline-hidden focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
         className
       )}
       data-slot="select-item"

--- a/packages/ui/src/shortcut-input.tsx
+++ b/packages/ui/src/shortcut-input.tsx
@@ -6,6 +6,7 @@ import {
   InputGroupAddon,
   InputGroupButton,
 } from "./input-group.tsx";
+import { CONTROL_HEIGHT_CLASS } from "./interactive-density.ts";
 import { Kbd, KbdGroup } from "./kbd.tsx";
 import { Tooltip, TooltipContent, TooltipTrigger } from "./tooltip.tsx";
 import { cn } from "./utils.ts";
@@ -59,7 +60,8 @@ export function ShortcutInput({
         aria-label={recordLabel}
         aria-pressed="true"
         className={cn(
-          "h-8 w-44 rounded-2xl border-1 border-muted-foreground/40 bg-background px-4 text-muted-foreground shadow-[0_0_0_4px_var(--muted)] hover:bg-background hover:text-muted-foreground",
+          CONTROL_HEIGHT_CLASS,
+          "w-44 rounded-2xl border-1 border-muted-foreground/40 bg-background px-4 text-muted-foreground shadow-[0_0_0_4px_var(--muted)] hover:bg-background hover:text-muted-foreground",
           className
         )}
         data-recording="true"
@@ -79,7 +81,8 @@ export function ShortcutInput({
   return (
     <InputGroup
       className={cn(
-        "h-8 w-56 rounded-2xl border-input bg-background/90 p-1 shadow-xs",
+        CONTROL_HEIGHT_CLASS,
+        "w-56 rounded-2xl border-input bg-background/90 p-1 shadow-xs",
         className
       )}
       data-testid="shortcut-input"

--- a/packages/ui/src/tabs.tsx
+++ b/packages/ui/src/tabs.tsx
@@ -2,6 +2,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { Tabs as TabsPrimitive } from "radix-ui";
 import type * as React from "react";
 
+import { CONTROL_HEIGHT_CLASS } from "./interactive-density.ts";
 import { cn } from "./utils.ts";
 
 function Tabs({
@@ -23,7 +24,10 @@ function Tabs({
 }
 
 const tabsListVariants = cva(
-  "group/tabs-list inline-flex w-fit items-center justify-center rounded-2xl p-[3px] text-muted-foreground data-[variant=line]:rounded-none group-data-horizontal/tabs:h-8 group-data-vertical/tabs:h-fit group-data-vertical/tabs:flex-col group-data-vertical/tabs:p-1",
+  cn(
+    CONTROL_HEIGHT_CLASS,
+    "group/tabs-list inline-flex w-fit items-center justify-center rounded-2xl p-[3px] text-muted-foreground data-[variant=line]:rounded-none group-data-vertical/tabs:h-fit group-data-vertical/tabs:flex-col group-data-vertical/tabs:p-1"
+  ),
   {
     variants: {
       variant: {

--- a/packages/ui/src/toggle.tsx
+++ b/packages/ui/src/toggle.tsx
@@ -4,6 +4,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { Toggle as TogglePrimitive } from "radix-ui";
 import type * as React from "react";
 
+import { CONTROL_HEIGHT_CLASS } from "./interactive-density.ts";
 import { cn } from "./utils.ts";
 
 const toggleVariants = cva(
@@ -15,8 +16,10 @@ const toggleVariants = cva(
         outline: "border border-input bg-transparent hover:bg-muted",
       },
       size: {
-        default:
-          "h-8 min-w-8 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+        default: cn(
+          CONTROL_HEIGHT_CLASS,
+          "min-w-7 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2"
+        ),
         sm: "h-7 min-w-7 px-2.5 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5",
         lg: "h-9 min-w-9 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
       },

--- a/plugins/index.v1.json
+++ b/plugins/index.v1.json
@@ -1,11 +1,11 @@
 {
-  "generatedAt": 1783764671757,
+  "generatedAt": 1783777530714,
   "plugins": {
     "pier.codex": {
       "description": "Codex account management and usage monitoring for Pier.",
       "displayName": "Codex Account Management",
       "id": "pier.codex",
-      "latest": "1.0.4",
+      "latest": "1.0.5",
       "locales": {
         "en": {
           "name": "Codex Account Management",
@@ -17,20 +17,20 @@
         }
       },
       "versions": {
-        "1.0.4": {
-          "assetUrl": "https://github.com/runloom/pier/releases/download/plugin-codex-v1.0.4/pier.codex-1.0.4.tgz",
+        "1.0.5": {
+          "assetUrl": "https://github.com/runloom/pier/releases/download/plugin-codex-v1.0.5/pier.codex-1.0.5.tgz",
           "pier": ">=0.1.0 <0.2.0",
-          "sha256": "21fb6d41c2532c9af1801107b42240e077d051f410053112f4f890ec19413eea",
-          "size": 454197
+          "sha256": "0bdc4ab05730cb82c6948f039164fb9c66438010fa9124dcebb33716a6b1f4ad",
+          "size": 454709
         }
       }
     }
   },
-  "sequence": 5,
+  "sequence": 6,
   "version": 1,
   "signature": {
     "alg": "Ed25519",
     "keyId": "pier-official-dev-test",
-    "value": "3A78cK591Ik6UxwEhKOjoKrmq78PlHz2QqPmm115c6QTEvS0qUXSVZ2SFQ24sHuGeFMv9MKgfiLsU9V+yxvCBw=="
+    "value": "vyBD1L8kJwZ5UguWHs97SGoIMbbBYblVL7+v3gqA+JGpPm4xzI4YYEPn0dIFzXyQsTEoBrZGF5+EBYPrxeuyCw=="
   }
 }

--- a/src/renderer/components/common/command-palette-quick-pick-view.tsx
+++ b/src/renderer/components/common/command-palette-quick-pick-view.tsx
@@ -32,7 +32,7 @@ function QuickPickDefaultRow({ item }: { item: QuickPickItem }): ReactNode {
   const Icon = item.icon;
   const destructive = item.variant === "destructive";
   return (
-    <span className="flex min-w-0 flex-1 items-center gap-2.5 py-0.5">
+    <span className="flex min-w-0 flex-1 items-center gap-2.5">
       {Icon ? (
         <Icon
           aria-hidden="true"
@@ -98,7 +98,7 @@ export function QuickPickView({
     return (
       <CommandItem
         aria-current={item.checked === true ? "true" : undefined}
-        className="items-center gap-2 py-2"
+        className="items-center gap-2"
         data-checked={item.checked === true}
         data-disabled={disabled}
         disabled={disabled}

--- a/src/renderer/components/primitives/sidebar.tsx
+++ b/src/renderer/components/primitives/sidebar.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from "@pier/ui/button.tsx";
 import { Input } from "@pier/ui/input.tsx";
+import { CONTROL_HEIGHT_CLASS } from "@pier/ui/interactive-density.ts";
 import { Separator } from "@pier/ui/separator.tsx";
 import {
   Sheet,
@@ -301,7 +302,11 @@ function SidebarInput({
 }: React.ComponentProps<typeof Input>) {
   return (
     <Input
-      className={cn("h-8 w-full bg-input/50 shadow-none", className)}
+      className={cn(
+        CONTROL_HEIGHT_CLASS,
+        "w-full bg-input/50 shadow-none",
+        className
+      )}
       data-sidebar="input"
       data-slot="sidebar-input"
       {...props}
@@ -450,7 +455,7 @@ function SidebarMenuItem({ className, ...props }: React.ComponentProps<"li">) {
 }
 
 const sidebarMenuButtonVariants = cva(
-  "peer/menu-button group/menu-button flex w-full items-center gap-2 overflow-hidden whitespace-nowrap rounded-xl px-3 py-2 text-left text-sm outline-hidden ring-sidebar-ring transition-[width,height,padding] duration-200 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-3 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 has-[>svg:last-child]:pr-2.5 has-[>svg:first-child]:pl-2.5 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-active:bg-sidebar-accent data-active:font-medium data-active:text-sidebar-accent-foreground data-open:hover:bg-sidebar-accent data-open:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&_svg]:size-4 [&_svg]:shrink-0",
+  "peer/menu-button group/menu-button flex w-full items-center gap-2 overflow-hidden whitespace-nowrap rounded-xl px-3 text-left text-sm outline-hidden ring-sidebar-ring transition-[width,height,padding] duration-200 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-3 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 has-[>svg:last-child]:pr-2.5 has-[>svg:first-child]:pl-2.5 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-active:bg-sidebar-accent data-active:font-medium data-active:text-sidebar-accent-foreground data-open:hover:bg-sidebar-accent data-open:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:size-7! group-data-[collapsible=icon]:p-1.5! [&>span:last-child]:truncate [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {
@@ -459,7 +464,7 @@ const sidebarMenuButtonVariants = cva(
           "bg-background shadow-[0_0_0_1px_var(--sidebar-border)] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_var(--sidebar-accent)]",
       },
       size: {
-        default: "h-8 text-sm",
+        default: cn(CONTROL_HEIGHT_CLASS, "text-sm"),
         sm: "h-7 text-xs",
         lg: "h-12 px-3 text-sm group-data-[collapsible=icon]:p-0!",
       },
@@ -536,7 +541,7 @@ function SidebarMenuAction({
   return (
     <Comp
       className={cn(
-        "absolute top-1.5 right-1 flex aspect-square w-5 items-center justify-center rounded-xl p-0 text-sidebar-foreground outline-hidden ring-sidebar-ring transition-transform after:absolute after:-inset-2 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-3 peer-hover/menu-button:text-sidebar-accent-foreground group-data-[collapsible=icon]:hidden peer-data-[size=default]/menu-button:top-1.5 peer-data-[size=lg]/menu-button:top-2.5 peer-data-[size=sm]/menu-button:top-1 md:after:hidden [&>svg]:size-4 [&>svg]:shrink-0",
+        "absolute top-1 right-1 flex aspect-square w-5 items-center justify-center rounded-xl p-0 text-sidebar-foreground outline-hidden ring-sidebar-ring transition-transform after:absolute after:-inset-2 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-3 peer-hover/menu-button:text-sidebar-accent-foreground group-data-[collapsible=icon]:hidden peer-data-[size=default]/menu-button:top-1 peer-data-[size=lg]/menu-button:top-2.5 peer-data-[size=sm]/menu-button:top-1 md:after:hidden [&>svg]:size-4 [&>svg]:shrink-0",
         showOnHover &&
           "group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 aria-expanded:opacity-100 peer-data-active/menu-button:text-sidebar-accent-foreground md:opacity-0",
         className
@@ -555,7 +560,7 @@ function SidebarMenuBadge({
   return (
     <div
       className={cn(
-        "pointer-events-none absolute right-1 flex h-5 min-w-5 select-none items-center justify-center rounded-xl px-1 font-medium text-sidebar-foreground text-xs tabular-nums peer-hover/menu-button:text-sidebar-accent-foreground group-data-[collapsible=icon]:hidden peer-data-[size=default]/menu-button:top-1.5 peer-data-[size=lg]/menu-button:top-2.5 peer-data-[size=sm]/menu-button:top-1 peer-data-active/menu-button:text-sidebar-accent-foreground",
+        "pointer-events-none absolute right-1 flex h-5 min-w-5 select-none items-center justify-center rounded-xl px-1 font-medium text-sidebar-foreground text-xs tabular-nums peer-hover/menu-button:text-sidebar-accent-foreground group-data-[collapsible=icon]:hidden peer-data-[size=default]/menu-button:top-1 peer-data-[size=lg]/menu-button:top-2.5 peer-data-[size=sm]/menu-button:top-1 peer-data-active/menu-button:text-sidebar-accent-foreground",
         className
       )}
       data-sidebar="menu-badge"
@@ -579,7 +584,11 @@ function SidebarMenuSkeleton({
 
   return (
     <div
-      className={cn("flex h-8 items-center gap-2 rounded-xl px-2", className)}
+      className={cn(
+        CONTROL_HEIGHT_CLASS,
+        "flex items-center gap-2 rounded-xl px-2",
+        className
+      )}
       data-sidebar="menu-skeleton"
       data-slot="sidebar-menu-skeleton"
       {...props}

--- a/src/renderer/components/workspace/add-panel-action.tsx
+++ b/src/renderer/components/workspace/add-panel-action.tsx
@@ -425,7 +425,7 @@ export function AddPanelAction(props: IDockviewHeaderActionsProps) {
         <PopoverContent
           align="start"
           aria-labelledby={titleId}
-          className="w-80 gap-1 p-1"
+          className="w-80 gap-0 p-0 shadow-xl ring-0"
           onEscapeKeyDown={(event) => {
             if (event.isComposing || event.keyCode === IME_PENDING_KEYCODE) {
               event.preventDefault();
@@ -448,8 +448,9 @@ export function AddPanelAction(props: IDockviewHeaderActionsProps) {
             </PopoverTitle>
           </PopoverHeader>
           <Command
-            className="h-auto"
+            className="h-auto [&_[cmdk-item]]:rounded-2xl"
             label={t("workspace.addPanelMenu.title")}
+            loop
             onKeyDown={(event) => {
               if (
                 event.nativeEvent.isComposing ||
@@ -476,7 +477,6 @@ export function AddPanelAction(props: IDockviewHeaderActionsProps) {
               aria-labelledby={titleId}
               className="max-h-[min(60vh,400px)]"
               label={t("workspace.addPanelMenu.title")}
-              scrollbar="overlay"
             >
               {renderListBody()}
             </CommandList>

--- a/src/renderer/panel-kits/mission-control/core-widgets/custom-card/custom-card-settings.tsx
+++ b/src/renderer/panel-kits/mission-control/core-widgets/custom-card/custom-card-settings.tsx
@@ -266,7 +266,7 @@ export function CustomCardSettings({
               {t("missionControl.widget.customCard.labelLabel")}
             </FieldLabel>
             <Input
-              className="h-8"
+              className="h-7"
               id="custom-card-label"
               onChange={(e) => setLabel(e.target.value)}
               placeholder={t(

--- a/tests/component/workspace-header-actions.test.tsx
+++ b/tests/component/workspace-header-actions.test.tsx
@@ -778,6 +778,7 @@ describe("WorkspaceHeaderActions", () => {
     });
     const content = title.closest("[data-slot='popover-content']");
     expect(content).toHaveAccessibleName("Create in this panel group");
+    expect(content).toHaveClass("gap-0", "p-0", "ring-0", "shadow-xl");
     expect(content).toHaveStyle({
       maxWidth: "calc(var(--radix-popover-content-available-width) - 0.5rem)",
     });
@@ -789,8 +790,12 @@ describe("WorkspaceHeaderActions", () => {
       name: "Create in this panel group",
     });
     expect(listbox).toBeInTheDocument();
-    expect(listbox).toHaveAttribute("data-scrollbar", "overlay");
-    expect(listbox).not.toHaveClass("no-scrollbar");
+    expect(listbox).toHaveAttribute("data-scrollbar", "none");
+    expect(listbox).toHaveClass("no-scrollbar");
+    expect(search.closest("[data-slot='command']")).toHaveClass(
+      "p-1",
+      "[&_[cmdk-item]]:rounded-2xl"
+    );
     expect(visibleCommandItemLabels()).toEqual([
       "New Terminal",
       "Start Claude",
@@ -809,9 +814,8 @@ describe("WorkspaceHeaderActions", () => {
     expect(
       screen.getByText("Worktree", { selector: "[cmdk-group-heading]" })
     ).toBeVisible();
-    expect(await findCommandItem("Create Worktree")).toHaveTextContent(
-      "Open a project first"
-    );
+    const worktreeItem = await findCommandItem("Create Worktree");
+    expect(worktreeItem).toHaveTextContent("Open a project first");
     expect(
       (await findCommandItem("New Terminal")).querySelector("[data-slot='kbd']")
     ).toHaveTextContent(/^(?:⌘|Ctrl\+)T$/);

--- a/tests/unit/renderer/interactive-density-governance.test.ts
+++ b/tests/unit/renderer/interactive-density-governance.test.ts
@@ -1,0 +1,87 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const ROOT = process.cwd();
+
+const CONTROL_HEIGHT_CONSUMERS = [
+  "packages/ui/src/button.tsx",
+  "packages/ui/src/command.tsx",
+  "packages/ui/src/input-group.tsx",
+  "packages/ui/src/input.tsx",
+  "packages/ui/src/menubar.tsx",
+  "packages/ui/src/navigation-menu.tsx",
+  "packages/ui/src/select.tsx",
+  "packages/ui/src/shortcut-input.tsx",
+  "packages/ui/src/tabs.tsx",
+  "packages/ui/src/toggle.tsx",
+  "src/renderer/components/primitives/sidebar.tsx",
+] as const;
+
+const CONTROL_ICON_CONSUMERS = [
+  "packages/ui/src/button.tsx",
+  "packages/ui/src/input-group.tsx",
+  "packages/ui/src/input-otp.tsx",
+  "packages/ui/src/pagination.tsx",
+] as const;
+
+const MENU_ITEM_CONSUMERS = [
+  "packages/ui/src/command.tsx",
+  "packages/ui/src/context-menu.tsx",
+  "packages/ui/src/dropdown-menu.tsx",
+  "packages/ui/src/menubar.tsx",
+  "packages/ui/src/navigation-menu.tsx",
+  "packages/ui/src/select.tsx",
+] as const;
+
+function source(path: string): string {
+  return readFileSync(join(ROOT, path), "utf8");
+}
+
+describe("interactive density governance", () => {
+  it("documents the 28px single-line control policy", () => {
+    const context = source("AGENTS.md");
+
+    expect(context).toContain("### 交互控件密度规范");
+    expect(context).toContain("单行交互控件统一使用 28px 高度");
+    expect(context).toContain("单行必须为 28px，多行说明可按内容自然增高");
+  });
+
+  it("keeps the density contract in one packages/ui owner", () => {
+    const density = source("packages/ui/src/interactive-density.ts");
+
+    expect(density).toContain('CONTROL_HEIGHT_CLASS = "h-7"');
+    expect(density).toContain('CONTROL_ICON_SIZE_CLASS = "size-7"');
+    expect(density).toContain(
+      'MENU_ITEM_DENSITY_CLASS = "min-h-7 py-1 text-sm leading-5"'
+    );
+  });
+
+  it("routes standard control height through the shared contract", () => {
+    for (const path of CONTROL_HEIGHT_CONSUMERS) {
+      expect(source(path), path).toContain("CONTROL_HEIGHT_CLASS");
+    }
+    for (const path of CONTROL_ICON_CONSUMERS) {
+      expect(source(path), path).toContain("CONTROL_ICON_SIZE_CLASS");
+    }
+  });
+
+  it("routes every menu family and command item through shared item density", () => {
+    for (const path of MENU_ITEM_CONSUMERS) {
+      const contents = source(path);
+      expect(contents, path).toContain("MENU_ITEM_DENSITY_CLASS");
+      expect(contents, path).not.toMatch(
+        /min-h-7[^"\n]*py-1\.5|py-1\.5[^"\n]*min-h-7/
+      );
+    }
+  });
+
+  it("does not let command quick-pick restore the old oversized padding", () => {
+    const quickPick = source(
+      "src/renderer/components/common/command-palette-quick-pick-view.tsx"
+    );
+
+    expect(quickPick).not.toContain('className="items-center gap-2 py-2"');
+    expect(quickPick).not.toContain("gap-2.5 py-0.5");
+  });
+});


### PR DESCRIPTION
## Summary

- centralize the 28px single-line control and menu-item density contract in `packages/ui`
- align Select, menus, command rows, form controls, tabs, pagination, and settings navigation
- align the add-panel popover to the command palette baseline without changing the command palette

## Validation

- `pnpm typecheck`
- unit tests: 383 files / 3475 tests
- component tests: 33 files / 409 tests, plus targeted add-panel regressions
- `pnpm depcruise`
- `pnpm build:electron`
- `git diff --check`

## Release note

The local pre-push plugin-index check detects that rebuilding the immutable `pier.codex@1.0.4` archive with the updated shared UI changes its package digest. This PR intentionally does not rewrite the signed 1.0.4 index. A future Codex plugin release must bump the plugin version and regenerate/sign the official index through the release workflow.