### PR TITLE
fix(agent-status): stabilize lifecycle and worker tracking

### DIFF
--- a/src/main/app-core/app-core.ts
+++ b/src/main/app-core/app-core.ts
@@ -360,8 +360,15 @@ function createPierAppCore(): PierAppCore {
           }
           foregroundActivityService.taskLaunched(panelId, windowId, task);
         },
-        onFinished: (panelId, args) => {
-          foregroundActivityService.taskFinished(panelId, args);
+        onFinished: (panelId, windowId, args) => {
+          if (!windowId) {
+            console.warn(
+              "[task-activity] missing windowId on finish, activity skipped:",
+              panelId
+            );
+            return;
+          }
+          foregroundActivityService.taskFinished(panelId, windowId, args);
         },
       },
       processEnvironment,

--- a/src/main/ipc/foreground-activity.ts
+++ b/src/main/ipc/foreground-activity.ts
@@ -12,7 +12,12 @@ import {
   installAllAgentHooks,
   uninstallAllAgentHooks,
 } from "../services/agents/integrations/registry.ts";
+import {
+  type AgentTerminalReconciler,
+  createAgentTerminalReconciler,
+} from "../services/agents/integrations/terminal-reconciliation.ts";
 import { createForegroundActivityAggregator } from "../services/foreground-activity/aggregator.ts";
+import { SUSPENDED_JOB_EXIT_CODES } from "../services/foreground-activity/entry.ts";
 import {
   createJsonlObserver,
   type JsonlObserver,
@@ -36,6 +41,7 @@ const foregroundActivityAggregator = createForegroundActivityAggregator();
 /** 上次广播覆盖过的窗口——会话清空时也要给这些窗口发空快照清 store。 */
 const lastBroadcastWindowIds = new Set<string>();
 let jsonlObserver: JsonlObserver | null = null;
+let agentTerminalReconciler: AgentTerminalReconciler | null = null;
 
 function markAgentSessionExited(args: {
   exitCode?: number | undefined;
@@ -145,8 +151,15 @@ export const foregroundActivityService = {
       PIER_AGENT_EVENT_LOG: eventsJsonlPath(userData),
     };
   },
-  commandFinished(panelId: string, exitCode?: number): void {
-    foregroundActivityAggregator.ingestCommandFinished(panelId, exitCode);
+  commandFinished(panelId: string, exitCode?: number, windowId?: string): void {
+    if (exitCode === undefined || !SUSPENDED_JOB_EXIT_CODES.has(exitCode)) {
+      agentTerminalReconciler?.releasePanel(panelId, windowId);
+    }
+    foregroundActivityAggregator.ingestCommandFinished(
+      panelId,
+      exitCode,
+      windowId
+    );
   },
   ingestCommandStarted(
     panelId: string,
@@ -178,24 +191,34 @@ export const foregroundActivityService = {
   },
   taskFinished(
     panelId: string,
+    windowId: string,
     args: {
       runId: string;
       status: "success" | "failure" | "cancelled";
       exitCode?: number;
     }
   ): void {
-    foregroundActivityAggregator.taskFinished(panelId, args);
+    const win = findAppWindowByInternalId(windowId);
+    foregroundActivityAggregator.taskFinished(
+      panelId,
+      args,
+      win ? String(win.id) : windowId
+    );
   },
-  panelClosed(panelId: string): void {
-    foregroundActivityAggregator.panelClosed(panelId);
+  panelClosed(panelId: string, windowId?: string): void {
+    agentTerminalReconciler?.releasePanel(panelId, windowId);
+    foregroundActivityAggregator.panelClosed(panelId, windowId);
   },
-  ptyExited(panelId: string): void {
-    foregroundActivityAggregator.ptyExited(panelId);
+  ptyExited(panelId: string, windowId?: string): void {
+    agentTerminalReconciler?.releasePanel(panelId, windowId);
+    foregroundActivityAggregator.ptyExited(panelId, windowId);
   },
   retainPanels(windowId: string, activePanelIds: readonly string[]): void {
+    agentTerminalReconciler?.retainPanels(windowId, activePanelIds);
     foregroundActivityAggregator.retainPanels(windowId, activePanelIds);
   },
   windowClosed(windowId: string): void {
+    agentTerminalReconciler?.releaseWindow(windowId);
     foregroundActivityAggregator.windowClosed(windowId);
     lastBroadcastWindowIds.delete(windowId);
   },
@@ -208,6 +231,8 @@ export const foregroundActivityService = {
 export function closeForegroundActivityResources(): void {
   jsonlObserver?.dispose();
   jsonlObserver = null;
+  agentTerminalReconciler?.dispose();
+  agentTerminalReconciler = null;
 }
 
 export function registerForegroundActivityIpc(ipcMain: IpcMain): void {
@@ -220,6 +245,11 @@ export function registerForegroundActivityIpc(ipcMain: IpcMain): void {
   // append 到 events.jsonl，observer 250ms 轮询 → 按 kind 分派到
   // aggregator 对应 hook。commandStart/commandFinished hook 目前无消费者
   // (native shell integration 走 native callback 通路)，是 forward-compat 占位。
+  agentTerminalReconciler = createAgentTerminalReconciler({
+    onTerminalEvent: (event) => {
+      foregroundActivityAggregator.ingestAgentEvent(event);
+    },
+  });
   jsonlObserver = createJsonlObserver({
     filePath: eventsJsonlPath(app.getPath("userData")),
     onAgentEvent: (event) => {
@@ -227,6 +257,9 @@ export function registerForegroundActivityIpc(ipcMain: IpcMain): void {
       if (!accepted) {
         return;
       }
+      agentTerminalReconciler?.observe(event).catch((err) => {
+        log.warn("agent terminal reconciliation failed", { err });
+      });
       recordAgentResumeSession({
         agentId: event.agent,
         panelId: event.panelId,
@@ -240,8 +273,10 @@ export function registerForegroundActivityIpc(ipcMain: IpcMain): void {
         });
       }
     },
-    onCommandFinished: (event) =>
-      foregroundActivityAggregator.ingestCommandFinishedHook(event),
+    onCommandFinished: (event) => {
+      agentTerminalReconciler?.releasePanel(event.panelId, event.windowId);
+      foregroundActivityAggregator.ingestCommandFinishedHook(event);
+    },
     onCommandStart: (event) =>
       foregroundActivityAggregator.ingestCommandStartHook(event),
     onError: (err) => {

--- a/src/main/ipc/terminal-create-handler.ts
+++ b/src/main/ipc/terminal-create-handler.ts
@@ -59,7 +59,10 @@ export async function handleTerminalCreate(args: {
     win,
   } = args;
   if (!addon) {
-    foregroundActivityService.panelClosed(createArgs.panelId);
+    foregroundActivityService.panelClosed(
+      createArgs.panelId,
+      win ? String(win.id) : undefined
+    );
     return { ok: false, error: loadError ?? "native addon not loaded" };
   }
   if (!win) {
@@ -180,7 +183,7 @@ export async function handleTerminalCreate(args: {
       lifecycleId
     );
     if (!ok) {
-      foregroundActivityService.panelClosed(createArgs.panelId);
+      foregroundActivityService.panelClosed(createArgs.panelId, String(win.id));
       await clearTerminalPanelAgent(sessionScope, createArgs.panelId);
       return { ok: false, error: "createTerminal returned false" };
     }
@@ -219,7 +222,7 @@ export async function handleTerminalCreate(args: {
     conformTerminalPresentationAfterCreate(win, addon);
     return { ok: true };
   } catch (err) {
-    foregroundActivityService.panelClosed(createArgs.panelId);
+    foregroundActivityService.panelClosed(createArgs.panelId, String(win.id));
     await clearTerminalPanelAgent(sessionScope, createArgs.panelId);
     return {
       ok: false,

--- a/src/main/ipc/terminal-task-lifecycle-wiring.ts
+++ b/src/main/ipc/terminal-task-lifecycle-wiring.ts
@@ -92,7 +92,11 @@ export function registerTerminalTaskLifecycleForwarding(
       // tab/状态栏呈现。覆盖崩溃/kill 等无 SessionEnd hook 的路径。
       // 透传原始 exitCode：悬挂家族(145-148, Ctrl+Z)不视为 agent 退出。
       if (!lifecycleId) {
-        foregroundActivityService.commandFinished(rawPanelId, exitCode);
+        foregroundActivityService.commandFinished(
+          rawPanelId,
+          exitCode,
+          String(id)
+        );
       }
       if (
         !lifecycleId &&
@@ -201,7 +205,7 @@ export function registerTerminalTaskLifecycleForwarding(
       }
       // pty 进程退出 ≠ 面板关闭：task 面板保留终态 activity（tab 退出
       // chrome 单源）, 其余面板照旧清理。真正的面板关闭走 pier:terminal:close。
-      foregroundActivityService.ptyExited(rawPanelId);
+      foregroundActivityService.ptyExited(rawPanelId, String(id));
       if (
         !lifecycleId &&
         targetWindow &&

--- a/src/main/ipc/terminal.ts
+++ b/src/main/ipc/terminal.ts
@@ -380,7 +380,7 @@ export function registerTerminalIpc(
         // 旧 PTY 的收尾由 native process-closed → ptyExited 按层语义处理。
         taskLifecycle.ignoreNextNativeUserClose(panelId, windowId);
       } else {
-        foregroundActivityService.panelClosed(panelId);
+        foregroundActivityService.panelClosed(panelId, String(win.id));
         deps.taskService?.markPanelClosed(panelId, windowId);
         taskLifecycle.releasePanel(panelId, windowId);
       }

--- a/src/main/services/agents/agent-hooks-install.ts
+++ b/src/main/services/agents/agent-hooks-install.ts
@@ -20,7 +20,9 @@ export const EVENTS_JSONL_NAME = "events.jsonl";
  * - `$1` = kind（commandStart | commandFinished | agentEvent）
  * - commandStart: `$2` = 命令行文本
  * - commandFinished: `$2` = 退出码（整数字符串）
- * - agentEvent: `$2` = agent id，`$3` = pierEvent 名，`$4` = sessionId（可选）
+ * - agentEvent: `$2` = agent id，`$3` = pierEvent 名，`$4..$11` 依次为
+ *   sessionId / turnId / toolUseId / toolName / agentInstanceId / agentType /
+ *   transcriptPath / 已筛选身份元数据的 base64（均可为空，不含 prompt/tool input）。
  *
  * 要点：
  * - PIER_PANEL_ID / PIER_WINDOW_ID 缺失时 exit 0（非 Pier 启动的 agent 静默跳过）
@@ -41,6 +43,21 @@ const EMIT_SCRIPT = `#!/bin/sh
 [ -z "$PIER_AGENT_EVENT_LOG" ] && PIER_AGENT_EVENT_LOG="\${HOME}/.pier/agent-events.jsonl"
 mkdir -p "$(dirname "$PIER_AGENT_EVENT_LOG")"
 _ts=$(date +%s%N 2>/dev/null || date +%s000000000)
+_lock="\${PIER_AGENT_EVENT_LOG}.lock"
+_lock_token="$$.$_ts"
+_lock_candidate="$_lock.$_lock_token"
+printf '%s' "$_lock_token" > "$_lock_candidate" || exit 0
+_lock_attempt=0
+while ! ln "$_lock_candidate" "$_lock" 2>/dev/null; do
+  _lock_attempt=$((_lock_attempt + 1))
+  if [ "$_lock_attempt" -ge 500 ]; then
+    rm -f "$_lock_candidate"
+    exit 0
+  fi
+  sleep 0.01
+done
+rm -f "$_lock_candidate"
+trap '[ "$(cat "$_lock" 2>/dev/null || true)" = "$_lock_token" ] && rm -f "$_lock"; rm -f "$_lock_candidate"' EXIT HUP INT TERM
 case "$1" in
   commandStart)
     _cmd=$(printf '%s' "$2" | head -c 4096 | LC_ALL=C tr -d '\\000-\\037\\177' | sed 's/\\\\/\\\\\\\\/g; s/"/\\\\"/g')
@@ -53,15 +70,19 @@ case "$1" in
     ;;
   agentEvent)
     _sid=$(printf '%s' "$4" | head -c 128 | LC_ALL=C tr -d '\\000-\\037\\177' | sed 's/\\\\/\\\\\\\\/g; s/"/\\\\"/g')
-    if [ -n "$_sid" ]; then
-      printf '{"v":1,"kind":"agentEvent","ts":%s,"panelId":"%s","windowId":"%s","pid":%s,"agent":"%s","event":"%s","sessionId":"%s"}\\n' \\
-        "$_ts" "$PIER_PANEL_ID" "$PIER_WINDOW_ID" "$$" "$2" "$3" "$_sid" >> "$PIER_AGENT_EVENT_LOG"
-    else
-      printf '{"v":1,"kind":"agentEvent","ts":%s,"panelId":"%s","windowId":"%s","pid":%s,"agent":"%s","event":"%s"}\\n' \\
-        "$_ts" "$PIER_PANEL_ID" "$PIER_WINDOW_ID" "$$" "$2" "$3" >> "$PIER_AGENT_EVENT_LOG"
-    fi
+    _turn=$(printf '%s' "$5" | head -c 128 | LC_ALL=C tr -d '\\000-\\037\\177' | sed 's/\\\\/\\\\\\\\/g; s/"/\\\\"/g')
+    _tool_id=$(printf '%s' "$6" | head -c 128 | LC_ALL=C tr -d '\\000-\\037\\177' | sed 's/\\\\/\\\\\\\\/g; s/"/\\\\"/g')
+    _tool_name=$(printf '%s' "$7" | head -c 256 | LC_ALL=C tr -d '\\000-\\037\\177' | sed 's/\\\\/\\\\\\\\/g; s/"/\\\\"/g')
+    _agent_instance=$(printf '%s' "$8" | head -c 128 | LC_ALL=C tr -d '\\000-\\037\\177' | sed 's/\\\\/\\\\\\\\/g; s/"/\\\\"/g')
+    _agent_type=$(printf '%s' "$9" | head -c 128 | LC_ALL=C tr -d '\\000-\\037\\177' | sed 's/\\\\/\\\\\\\\/g; s/"/\\\\"/g')
+    _transcript=$(printf '%s' "\${10}" | head -c 8192 | LC_ALL=C tr -d '\\000-\\037\\177' | sed 's/\\\\/\\\\\\\\/g; s/"/\\\\"/g')
+    _metadata_b64=$(printf '%s' "\${11}" | head -c 16384 | LC_ALL=C tr -cd 'A-Za-z0-9+/=')
+    printf '{"v":1,"kind":"agentEvent","ts":%s,"panelId":"%s","windowId":"%s","pid":%s,"agent":"%s","event":"%s","sessionId":"%s","turnId":"%s","toolUseId":"%s","toolName":"%s","agentInstanceId":"%s","agentType":"%s","transcriptPath":"%s","metadataBase64":"%s"}\\n' \\
+      "$_ts" "$PIER_PANEL_ID" "$PIER_WINDOW_ID" "$$" "$2" "$3" "$_sid" "$_turn" "$_tool_id" "$_tool_name" "$_agent_instance" "$_agent_type" "$_transcript" "$_metadata_b64" >> "$PIER_AGENT_EVENT_LOG"
     ;;
 esac
+[ "$(cat "$_lock" 2>/dev/null || true)" = "$_lock_token" ] && rm -f "$_lock"
+trap - EXIT HUP INT TERM
 `;
 
 /** 返回 agent-hooks 目录绝对路径。 */

--- a/src/main/services/agents/integrations/amp.ts
+++ b/src/main/services/agents/integrations/amp.ts
@@ -5,6 +5,7 @@ import { dirname, join } from "node:path";
 import type { AgentKind } from "@shared/contracts/agent.ts";
 import { atomicWriteFile, commandExistsOnPath } from "./shared.ts";
 import type { AgentHookIntegration } from "./types.ts";
+import { JAVASCRIPT_LOCKED_APPEND_SOURCE } from "./writer-lock-source.ts";
 
 const AGENT_ID: AgentKind = "amp";
 
@@ -56,18 +57,7 @@ const PIER_EVENT_MAP = {
 ${eventMapLines}
 };
 
-function pierAppend(log, line) {
-	if (typeof process.getBuiltinModule === "function") {
-		// 同步写:保文件序 + 进程退出前落盘(Bun 与 Node >= 20.16)。
-		const { appendFileSync } = process.getBuiltinModule("node:fs");
-		appendFileSync(log, line);
-		return;
-	}
-	// 旧 Node 宿主退化为异步 best-effort(与旧行为一致, 不更糟)。
-	import("node:fs/promises")
-		.then(({ appendFile }) => appendFile(log, line))
-		.catch(() => {});
-}
+${JAVASCRIPT_LOCKED_APPEND_SOURCE}
 
 function pierSessionIdFrom(values) {
   for (const value of values) {

--- a/src/main/services/agents/integrations/codex-transcript-reconciler.ts
+++ b/src/main/services/agents/integrations/codex-transcript-reconciler.ts
@@ -8,7 +8,10 @@ const POLL_INTERVAL_MS = 250;
 const MAX_READ_BYTES = 1024 * 1024;
 const MAX_TRANSCRIPTS = 32;
 const MAX_TURN_CONTEXTS = 64;
+const MAX_PENDING_TERMINALS = 64;
 const MAX_SEEN_TERMINALS = 256;
+
+type TerminalType = "task_complete" | "turn_aborted";
 
 interface TranscriptEntry {
   contextsByTurnId: Map<string, AgentHookEventPayload>;
@@ -16,6 +19,7 @@ interface TranscriptEntry {
   offset: number;
   owners: Map<string, AgentHookEventPayload>;
   pending: boolean;
+  pendingTerminalsByTurnId: Map<string, TerminalType>;
   processing: boolean;
   seenTerminalEvents: Set<string>;
   watcher: (curr: Stats, prev: Stats) => void;
@@ -125,34 +129,52 @@ export function createCodexTranscriptReconciler(
       }
       const turnId =
         typeof payload?.turn_id === "string" ? payload.turn_id : "";
-      if (turnId) {
-        const dedupeKey = `${terminalType}:${turnId}`;
-        if (entry.seenTerminalEvents.has(dedupeKey)) return;
-        entry.seenTerminalEvents.add(dedupeKey);
-        if (entry.seenTerminalEvents.size > MAX_SEEN_TERMINALS) {
-          entry.seenTerminalEvents.delete(
-            entry.seenTerminalEvents.values().next().value ?? ""
-          );
-        }
-      }
       let context: AgentHookEventPayload | undefined;
       if (turnId) context = entry.contextsByTurnId.get(turnId);
       else if (entry.owners.size === 1) {
         context = entry.owners.values().next().value;
       }
-      if (!context) return;
-      if (turnId) {
-        entry.contextsByTurnId.delete(turnId);
+      if (!context) {
+        if (turnId && !entry.pendingTerminalsByTurnId.has(turnId)) {
+          entry.pendingTerminalsByTurnId.set(turnId, terminalType);
+          if (entry.pendingTerminalsByTurnId.size > MAX_PENDING_TERMINALS) {
+            entry.pendingTerminalsByTurnId.delete(
+              entry.pendingTerminalsByTurnId.keys().next().value ?? ""
+            );
+          }
+        }
+        return;
       }
-      opts.onTerminalEvent({
-        ...context,
-        event:
-          terminalType === "turn_aborted" ? "TurnInterrupted" : "TurnCompleted",
-        ...(turnId ? { turnId } : {}),
-      });
+      emitTerminalEvent(entry, context, terminalType, turnId);
     } catch {
       // transcript 是兼容性对账源；坏行和格式升级不得影响主 hook 通路。
     }
+  }
+
+  function emitTerminalEvent(
+    entry: TranscriptEntry,
+    context: AgentHookEventPayload,
+    terminalType: TerminalType,
+    turnId: string
+  ): void {
+    if (turnId) {
+      const dedupeKey = `${terminalType}:${turnId}`;
+      if (entry.seenTerminalEvents.has(dedupeKey)) return;
+      entry.seenTerminalEvents.add(dedupeKey);
+      if (entry.seenTerminalEvents.size > MAX_SEEN_TERMINALS) {
+        entry.seenTerminalEvents.delete(
+          entry.seenTerminalEvents.values().next().value ?? ""
+        );
+      }
+      entry.contextsByTurnId.delete(turnId);
+      entry.pendingTerminalsByTurnId.delete(turnId);
+    }
+    opts.onTerminalEvent({
+      ...context,
+      event:
+        terminalType === "turn_aborted" ? "TurnInterrupted" : "TurnCompleted",
+      ...(turnId ? { turnId } : {}),
+    });
   }
 
   function scheduleDrain(path: string, entry: TranscriptEntry): void {
@@ -233,6 +255,7 @@ export function createCodexTranscriptReconciler(
       offset: initial.size,
       owners: new Map(),
       pending: false,
+      pendingTerminalsByTurnId: new Map(),
       processing: false,
       seenTerminalEvents: new Set(),
       watcher,
@@ -330,6 +353,10 @@ export function createCodexTranscriptReconciler(
           entry.contextsByTurnId.delete(
             entry.contextsByTurnId.keys().next().value ?? ""
           );
+        }
+        const pendingTerminal = entry.pendingTerminalsByTurnId.get(turnId);
+        if (pendingTerminal) {
+          emitTerminalEvent(entry, event, pendingTerminal, turnId);
         }
       }
       scheduleDrain(canonicalPath, entry);

--- a/src/main/services/agents/integrations/codex-transcript-reconciler.ts
+++ b/src/main/services/agents/integrations/codex-transcript-reconciler.ts
@@ -1,0 +1,375 @@
+import { type Stats, unwatchFile, watchFile } from "node:fs";
+import { open, realpath, stat } from "node:fs/promises";
+import { isAbsolute, relative, resolve } from "node:path";
+import type { AgentHookEventPayload } from "@shared/contracts/agent-session.ts";
+import { codexHomeDir } from "./codex.ts";
+
+const POLL_INTERVAL_MS = 250;
+const MAX_READ_BYTES = 1024 * 1024;
+const MAX_TRANSCRIPTS = 32;
+const MAX_TURN_CONTEXTS = 64;
+const MAX_SEEN_TERMINALS = 256;
+
+interface TranscriptEntry {
+  contextsByTurnId: Map<string, AgentHookEventPayload>;
+  disposed: boolean;
+  offset: number;
+  owners: Map<string, AgentHookEventPayload>;
+  pending: boolean;
+  processing: boolean;
+  seenTerminalEvents: Set<string>;
+  watcher: (curr: Stats, prev: Stats) => void;
+}
+
+export interface CodexTranscriptReconciler {
+  dispose(): void;
+  observe(event: AgentHookEventPayload): Promise<void>;
+  releasePanel(panelId: string, windowId?: string): void;
+  releasePanelsWhere(
+    predicate: (panelId: string, windowId: string) => boolean
+  ): void;
+  releaseWindow(windowId: string): void;
+}
+
+interface CodexTranscriptReconcilerOpts {
+  onTerminalEvent: (event: AgentHookEventPayload) => void;
+  transcriptRoot?: string;
+}
+
+/**
+ * Codex TUI 兼容性终态对账器。
+ *
+ * hooks 当前没有独立的 interrupt 事件；Esc 中断会写入 transcript 的
+ * `event_msg/turn_aborted`。这里仅消费 task_complete / turn_aborted 两种终态，
+ * 不把 transcript 当工具或过程状态的权威源。格式变化时静默失效，hook 与
+ * PTY 退出兜底仍然有效。
+ */
+export function createCodexTranscriptReconciler(
+  opts: CodexTranscriptReconcilerOpts
+): CodexTranscriptReconciler {
+  const entries = new Map<string, TranscriptEntry>();
+  const entryCreations = new Map<string, Promise<TranscriptEntry | null>>();
+  const pendingScopeTokens = new Map<string, symbol>();
+  const transcriptRoot = resolve(
+    opts.transcriptRoot ?? resolve(codexHomeDir(), "sessions")
+  );
+  let disposed = false;
+
+  async function drain(path: string, entry: TranscriptEntry): Promise<void> {
+    do {
+      entry.pending = false;
+      const current = await stat(path).catch(() => null);
+      if (!current) {
+        continue;
+      }
+      if (current.size < entry.offset) {
+        entry.offset = 0;
+      }
+      if (current.size === entry.offset) {
+        continue;
+      }
+      const readSize = Math.min(current.size - entry.offset, MAX_READ_BYTES);
+      const fd = await open(path, "r");
+      let chunk: Buffer;
+      try {
+        chunk = Buffer.alloc(readSize);
+        const result = await fd.read(chunk, 0, chunk.length, entry.offset);
+        chunk = chunk.subarray(0, result.bytesRead);
+      } finally {
+        await fd.close();
+      }
+      const lastNewline = chunk.lastIndexOf(0x0a);
+      if (lastNewline === -1) {
+        if (chunk.length >= MAX_READ_BYTES) {
+          // Codex transcript 可能包含超大 tool output 单行。跳过固定大小片段
+          // 直到下一个换行，保证后续终态可达且内存有界。
+          entry.offset += chunk.length;
+          entry.pending = true;
+        }
+        continue;
+      }
+      const consumed = chunk.subarray(0, lastNewline + 1);
+      entry.offset += consumed.length;
+      for (const line of consumed.toString("utf8").split("\n")) {
+        processLine(entry, line);
+      }
+      if (entry.offset < current.size) {
+        entry.pending = true;
+      }
+    } while (!(disposed || entry.disposed) && entry.pending);
+  }
+
+  function processLine(entry: TranscriptEntry, line: string): void {
+    if (disposed || entry.disposed || !line.trim()) {
+      return;
+    }
+    try {
+      const parsed = JSON.parse(line) as {
+        payload?: { reason?: unknown; turn_id?: unknown; type?: unknown };
+        type?: unknown;
+      };
+      if (parsed.type !== "event_msg") {
+        return;
+      }
+      const payload = parsed.payload;
+      const terminalType = payload?.type;
+      if (terminalType !== "task_complete" && terminalType !== "turn_aborted") {
+        return;
+      }
+      if (
+        terminalType === "turn_aborted" &&
+        payload?.reason !== undefined &&
+        payload.reason !== "interrupted"
+      ) {
+        return;
+      }
+      const turnId =
+        typeof payload?.turn_id === "string" ? payload.turn_id : "";
+      if (turnId) {
+        const dedupeKey = `${terminalType}:${turnId}`;
+        if (entry.seenTerminalEvents.has(dedupeKey)) return;
+        entry.seenTerminalEvents.add(dedupeKey);
+        if (entry.seenTerminalEvents.size > MAX_SEEN_TERMINALS) {
+          entry.seenTerminalEvents.delete(
+            entry.seenTerminalEvents.values().next().value ?? ""
+          );
+        }
+      }
+      let context: AgentHookEventPayload | undefined;
+      if (turnId) context = entry.contextsByTurnId.get(turnId);
+      else if (entry.owners.size === 1) {
+        context = entry.owners.values().next().value;
+      }
+      if (!context) return;
+      if (turnId) {
+        entry.contextsByTurnId.delete(turnId);
+      }
+      opts.onTerminalEvent({
+        ...context,
+        event:
+          terminalType === "turn_aborted" ? "TurnInterrupted" : "TurnCompleted",
+        ...(turnId ? { turnId } : {}),
+      });
+    } catch {
+      // transcript 是兼容性对账源；坏行和格式升级不得影响主 hook 通路。
+    }
+  }
+
+  function scheduleDrain(path: string, entry: TranscriptEntry): void {
+    if (disposed || entry.disposed) {
+      return;
+    }
+    if (entry.processing) {
+      entry.pending = true;
+      return;
+    }
+    entry.processing = true;
+    drain(path, entry).finally(() => {
+      entry.processing = false;
+    });
+  }
+
+  function disposeEntry(path: string, entry: TranscriptEntry): void {
+    if (entries.get(path) === entry) {
+      entry.disposed = true;
+      unwatchFile(path, entry.watcher);
+      entries.delete(path);
+    }
+  }
+
+  const scopeKey = (event: AgentHookEventPayload): string =>
+    `${event.windowId}\0${event.panelId}`;
+
+  function releaseScope(panelId: string, windowId?: string): void {
+    const releasedKeys = new Set<string>();
+    for (const key of pendingScopeTokens.keys()) {
+      const [scopeWindowId, scopePanelId] = key.split("\0");
+      if (
+        scopePanelId === panelId &&
+        (windowId === undefined || scopeWindowId === windowId)
+      ) {
+        pendingScopeTokens.delete(key);
+        releasedKeys.add(key);
+      }
+    }
+    for (const [path, entry] of entries) {
+      for (const [key, context] of entry.owners) {
+        if (
+          context.panelId === panelId &&
+          (windowId === undefined || context.windowId === windowId)
+        ) {
+          entry.owners.delete(key);
+          releasedKeys.add(key);
+        }
+      }
+      for (const [turnId, context] of entry.contextsByTurnId) {
+        if (releasedKeys.has(scopeKey(context))) {
+          entry.contextsByTurnId.delete(turnId);
+        }
+      }
+      if (entry.owners.size === 0) disposeEntry(path, entry);
+    }
+  }
+
+  async function createEntry(
+    canonicalPath: string
+  ): Promise<TranscriptEntry | null> {
+    if (entries.size + entryCreations.size >= MAX_TRANSCRIPTS) {
+      return null;
+    }
+    const initial = await stat(canonicalPath).catch(() => null);
+    if (!(initial?.isFile() && !disposed)) {
+      return null;
+    }
+    const watcher = (): void => {
+      const current = entries.get(canonicalPath);
+      if (current) {
+        scheduleDrain(canonicalPath, current);
+      }
+    };
+    const entry: TranscriptEntry = {
+      contextsByTurnId: new Map(),
+      disposed: false,
+      offset: initial.size,
+      owners: new Map(),
+      pending: false,
+      processing: false,
+      seenTerminalEvents: new Set(),
+      watcher,
+    };
+    entries.set(canonicalPath, entry);
+    watchFile(canonicalPath, { interval: POLL_INTERVAL_MS }, watcher);
+    return entry;
+  }
+
+  async function canonicalTranscriptPath(path: string): Promise<string | null> {
+    const resolvedPath = resolve(path);
+    const relativePath = relative(transcriptRoot, resolvedPath);
+    if (relativePath.startsWith("..") || isAbsolute(relativePath)) return null;
+    const [canonicalRoot, canonicalPath] = await Promise.all([
+      realpath(transcriptRoot).catch(() => null),
+      realpath(resolvedPath).catch(() => null),
+    ]);
+    if (!(canonicalRoot && canonicalPath)) return null;
+    const canonicalRelative = relative(canonicalRoot, canonicalPath);
+    return canonicalRelative.startsWith("..") || isAbsolute(canonicalRelative)
+      ? null
+      : canonicalPath;
+  }
+
+  return {
+    dispose() {
+      disposed = true;
+      for (const [path, entry] of entries) {
+        entry.disposed = true;
+        unwatchFile(path, entry.watcher);
+      }
+      entries.clear();
+      entryCreations.clear();
+      pendingScopeTokens.clear();
+    },
+    async observe(event) {
+      if (disposed || event.agent !== "codex") {
+        return;
+      }
+      if (event.event === "SessionEnd") {
+        releaseScope(event.panelId, event.windowId);
+        return;
+      }
+      const path = event.transcriptPath?.trim();
+      if (!path) {
+        return;
+      }
+      const key = scopeKey(event);
+      const token = Symbol(key);
+      pendingScopeTokens.set(key, token);
+      const canonicalPath = await canonicalTranscriptPath(path);
+      if (!canonicalPath || pendingScopeTokens.get(key) !== token) {
+        if (pendingScopeTokens.get(key) === token)
+          pendingScopeTokens.delete(key);
+        return;
+      }
+      let entry: TranscriptEntry | null | undefined =
+        entries.get(canonicalPath);
+      if (!entry) {
+        let creation = entryCreations.get(canonicalPath);
+        if (!creation) {
+          creation = createEntry(canonicalPath).finally(() => {
+            entryCreations.delete(canonicalPath);
+          });
+          entryCreations.set(canonicalPath, creation);
+        }
+        entry = await creation;
+      }
+      if (!entry || pendingScopeTokens.get(key) !== token) {
+        if (pendingScopeTokens.get(key) === token)
+          pendingScopeTokens.delete(key);
+        if (entry?.owners.size === 0) {
+          const cleanupTimer = setTimeout(() => {
+            if (entry?.owners.size === 0) disposeEntry(canonicalPath, entry);
+          }, 0);
+          cleanupTimer.unref();
+        }
+        return;
+      }
+      pendingScopeTokens.delete(key);
+      for (const [otherPath, otherEntry] of entries) {
+        if (otherEntry === entry || !otherEntry.owners.delete(key)) continue;
+        for (const [turnId, context] of otherEntry.contextsByTurnId) {
+          if (scopeKey(context) === key) {
+            otherEntry.contextsByTurnId.delete(turnId);
+          }
+        }
+        if (otherEntry.owners.size === 0) disposeEntry(otherPath, otherEntry);
+      }
+      entry.owners.set(key, event);
+      const turnId = event.turnId?.trim();
+      if (turnId) {
+        entry.contextsByTurnId.set(turnId, event);
+        if (entry.contextsByTurnId.size > MAX_TURN_CONTEXTS) {
+          entry.contextsByTurnId.delete(
+            entry.contextsByTurnId.keys().next().value ?? ""
+          );
+        }
+      }
+      scheduleDrain(canonicalPath, entry);
+    },
+    releasePanel(panelId, windowId) {
+      releaseScope(panelId, windowId);
+    },
+    releasePanelsWhere(predicate) {
+      const scopes = new Set<string>();
+      for (const key of pendingScopeTokens.keys()) {
+        const [windowId, panelId] = key.split("\0");
+        if (panelId && windowId && predicate(panelId, windowId)) {
+          scopes.add(key);
+        }
+      }
+      for (const entry of entries.values()) {
+        for (const context of entry.owners.values()) {
+          if (predicate(context.panelId, context.windowId)) {
+            scopes.add(scopeKey(context));
+          }
+        }
+      }
+      for (const key of scopes) {
+        const [windowId, panelId] = key.split("\0");
+        if (panelId && windowId) releaseScope(panelId, windowId);
+      }
+    },
+    releaseWindow(windowId) {
+      const panelIds = new Set<string>();
+      for (const key of pendingScopeTokens.keys()) {
+        if (key.startsWith(`${windowId}\0`)) {
+          panelIds.add(key.slice(windowId.length + 1));
+        }
+      }
+      for (const entry of entries.values()) {
+        for (const context of entry.owners.values()) {
+          if (context.windowId === windowId) panelIds.add(context.panelId);
+        }
+      }
+      for (const panelId of panelIds) releaseScope(panelId, windowId);
+    },
+  };
+}

--- a/src/main/services/agents/integrations/codex.ts
+++ b/src/main/services/agents/integrations/codex.ts
@@ -39,8 +39,7 @@ const codexConfigPath = () => join(codexHomeDir(), "hooks.json");
  * `/hooks` 信任审查警告（见 issue#21639），这是预期 UX，用户首次触发时
  * 需要在 codex 内确认信任该 hooks.json，不代表集成出错。
  *
- * 官方事件全集（openai/codex main 分支 codex-rs/hooks/src/events/ 源码级
- * 确认, mod.rs 逐条列出）共 7 个 hook 模块 → 8 个事件类型：
+ * 当前 Codex hook 事件全集（以发布版文档与本机 generated schema 为准）：
  * - session_start.rs → SessionStart
  * - user_prompt_submit.rs → UserPromptSubmit
  * - pre_tool_use.rs → PreToolUse
@@ -48,11 +47,8 @@ const codexConfigPath = () => join(codexHomeDir(), "hooks.json");
  * - permission_request.rs → PermissionRequest
  * - stop.rs → Stop
  * - compact.rs → PreCompact + PostCompact
- *
- * **翻案**：先前版本装了 SubagentStart/SubagentStop——是从 claude schema
- * 想当然搬来的**杜撰死条目**, codex 官方并无此事件类型（sub-agent 上下文
- * 通过其他 hook 的 SubagentCommandInputFields 字段透传, 而非独立事件）。
- * 已删除。
+ * - subagent_start.rs → SubagentStart
+ * - subagent_stop.rs → SubagentStop
  *
  * **补装**：PreCompact/PostCompact 官方源码级存在, 先前版本漏装。
  * 都映射为 processing——避免上下文压缩期间被 30min TTL 误衰减状态。
@@ -81,6 +77,8 @@ const CODEX_SPEC: NestedJsonIntegrationSpec = {
     { nativeEvent: "PermissionRequest", pierEvent: "PermissionRequest" },
     { nativeEvent: "PreCompact", pierEvent: "processing" },
     { nativeEvent: "PostCompact", pierEvent: "processing" },
+    { nativeEvent: "SubagentStart", pierEvent: "SubagentStart" },
+    { nativeEvent: "SubagentStop", pierEvent: "SubagentStop" },
     { nativeEvent: "Stop", pierEvent: "Stop" },
   ],
 };
@@ -104,8 +102,7 @@ export async function installCodexHooks(
   settingsPath: string = CODEX_SPEC.configPath()
 ): Promise<void> {
   // 先剔全部 pier 条目再按当前 spec 装, 与工厂 createNestedJsonIntegration
-  // 保持一致——清理「上一版 spec 装过但本版已移出」的遗留(如 codex 曾装
-  // 的 SubagentStart/SubagentStop)。
+  // 保持一致——清理上一版 spec 装过但本版已移出的遗留。
   await transformJsonConfig(
     settingsPath,
     (s) => withPierCodexHooks(withoutPierCodexHooks(s)),

--- a/src/main/services/agents/integrations/hermes.ts
+++ b/src/main/services/agents/integrations/hermes.ts
@@ -144,14 +144,42 @@ def _pier_emit(pier_event: str, payload: dict[str, Any]) -> None:
     line = json.dumps(
         body
     ) + "\\n"
+    lock = log + ".lock"
+    token = f"{os.getpid()}.{time.time_ns()}"
+    candidate = lock + "." + token
+    try:
+        with open(candidate, "x", encoding="ascii") as fp:
+            fp.write(token)
+    except OSError:
+        return
+    acquired = False
+    for _ in range(500):
+        try:
+            os.link(candidate, lock)
+            acquired = True
+            break
+        except FileExistsError:
+            time.sleep(0.01)
+        except OSError:
+            return
+    try:
+        os.remove(candidate)
+    except OSError:
+        pass
+    if not acquired:
+        return
     try:
         with open(log, "a", encoding="utf-8") as fp:
             fp.write(line)
     except OSError:
-        # 磁盘满 / 权限 / broken pipe 等文件 IO 失败——静默降级不干扰
-        # hermes 本体。不宽泛 catch Exception, 否则会掩盖 os.getpid /
-        # json.dumps 等内部 bug (review Commit B P1#2)。
         pass
+    finally:
+        try:
+            with open(lock, encoding="ascii") as fp:
+                if fp.read() == token:
+                    os.remove(lock)
+        except OSError:
+            pass
 
 
 def _make_hook(event_name: str) -> Callable[..., None]:

--- a/src/main/services/agents/integrations/kilo.ts
+++ b/src/main/services/agents/integrations/kilo.ts
@@ -5,6 +5,7 @@ import { dirname, join } from "node:path";
 import type { AgentKind } from "@shared/contracts/agent.ts";
 import { atomicWriteFile, commandExistsOnPath } from "./shared.ts";
 import type { AgentHookIntegration } from "./types.ts";
+import { JAVASCRIPT_LOCKED_APPEND_SOURCE } from "./writer-lock-source.ts";
 
 const AGENT_ID: AgentKind = "kilo";
 
@@ -61,32 +62,32 @@ export function buildKiloPluginSource(pluginId: AgentKind = AGENT_ID): string {
 // call — not an ImportDeclaration — so the scan stays inert; available in
 // Bun (kilo's host) and Node >= 20.16.
 
-function pierAppend(log, line) {
-	if (typeof process.getBuiltinModule === "function") {
-		// 同步写:保文件序 + 进程退出前落盘(Bun 与 Node >= 20.16)。
-		const { appendFileSync } = process.getBuiltinModule("node:fs");
-		appendFileSync(log, line);
-		return;
-	}
-	// ts-no-dynamic-import 例外：运行时 import() 非 ImportDeclaration,
-	// 旧 Node 宿主退化为异步 best-effort(与旧行为一致, 不更糟)。
-	import("node:fs/promises")
-		.then(({ appendFile }) => appendFile(log, line))
-		.catch(() => {});
-}
+${JAVASCRIPT_LOCKED_APPEND_SOURCE}
 
 function pierSessionIdFrom(event) {
-	const values = [event, event && event.properties];
+	const values = Array.isArray(event) ? [...event] : [event];
+	values.push(...values.map((value) => value && value.properties));
 	for (const value of values) {
 		if (!value || typeof value !== "object") continue;
 		for (const key of ["sessionId", "sessionID", "session_id"]) {
 			if (typeof value[key] === "string" && value[key]) return value[key];
 		}
-		const session = value.session || value.thread;
+		const session = value.info || value.session || value.thread;
 		if (session && typeof session === "object") {
 			for (const key of ["id", "sessionId", "sessionID", "session_id"]) {
 				if (typeof session[key] === "string" && session[key]) return session[key];
 			}
+		}
+	}
+	return undefined;
+}
+
+function pierToolIdFrom(event) {
+	const values = Array.isArray(event) ? event : [event];
+	for (const value of values) {
+		if (!value || typeof value !== "object") continue;
+		for (const key of ["callID", "callId", "toolCallID", "toolCallId", "toolUseId", "tool_use_id"]) {
+			if (typeof value[key] === "string" && value[key]) return value[key];
 		}
 	}
 	return undefined;
@@ -98,6 +99,7 @@ function pierEmit(pierEvent, rawEvent) {
 	const windowId = process.env.PIER_WINDOW_ID;
 	if (!log || !panelId || !windowId) return;
 	const sessionId = pierSessionIdFrom(rawEvent);
+	const toolUseId = pierToolIdFrom(rawEvent);
 	const line = JSON.stringify({
 		v: 1,
 		kind: "agentEvent",
@@ -108,6 +110,7 @@ function pierEmit(pierEvent, rawEvent) {
 		agent: "${pluginId}",
 		event: pierEvent,
 		...(sessionId ? { sessionId } : {}),
+		...(toolUseId ? { toolUseId } : {}),
 	}) + "\\n";
 	try {
 		pierAppend(log, line);
@@ -146,11 +149,11 @@ const server = async () => {
 			const mapped = mapPierEvent(event);
 			if (mapped) pierEmit(mapped, event);
 		},
-		"tool.execute.before": async () => {
-			pierEmit("ToolStart");
+		"tool.execute.before": async (...args) => {
+			pierEmit("ToolStart", args);
 		},
-		"tool.execute.after": async () => {
-			pierEmit("ToolComplete");
+		"tool.execute.after": async (...args) => {
+			pierEmit("ToolComplete", args);
 		},
 	};
 };

--- a/src/main/services/agents/integrations/mimo-code.ts
+++ b/src/main/services/agents/integrations/mimo-code.ts
@@ -5,6 +5,7 @@ import { dirname, join } from "node:path";
 import type { AgentKind } from "@shared/contracts/agent.ts";
 import { atomicWriteFile, commandExistsOnPath } from "./shared.ts";
 import type { AgentHookIntegration } from "./types.ts";
+import { JAVASCRIPT_LOCKED_APPEND_SOURCE } from "./writer-lock-source.ts";
 
 const AGENT_ID: AgentKind = "mimo-code";
 
@@ -56,31 +57,32 @@ export function buildMimoCodePluginSource(): string {
 // call — not an ImportDeclaration; older Node falls back to async best-effort.
 // (Exception to ts-no-dynamic-import: generated file for a foreign host.)
 
-function pierAppend(log, line) {
-	if (typeof process.getBuiltinModule === "function") {
-		// 同步写:保文件序 + 进程退出前落盘(Bun 与 Node >= 20.16)。
-		const { appendFileSync } = process.getBuiltinModule("node:fs");
-		appendFileSync(log, line);
-		return;
-	}
-	// 旧 Node 宿主退化为异步 best-effort(与旧行为一致, 不更糟)。
-	import("node:fs/promises")
-		.then(({ appendFile }) => appendFile(log, line))
-		.catch(() => {});
-}
+${JAVASCRIPT_LOCKED_APPEND_SOURCE}
 
 function pierSessionIdFrom(event) {
-  const values = [event, event && event.properties];
+  const values = Array.isArray(event) ? [...event] : [event];
+  values.push(...values.map((value) => value && value.properties));
   for (const value of values) {
     if (!value || typeof value !== "object") continue;
     for (const key of ["sessionId", "sessionID", "session_id"]) {
       if (typeof value[key] === "string" && value[key]) return value[key];
     }
-    const session = value.session || value.thread;
+    const session = value.info || value.session || value.thread;
     if (session && typeof session === "object") {
       for (const key of ["id", "sessionId", "sessionID", "session_id"]) {
         if (typeof session[key] === "string" && session[key]) return session[key];
       }
+    }
+  }
+  return undefined;
+}
+
+function pierToolIdFrom(event) {
+  const values = Array.isArray(event) ? event : [event];
+  for (const value of values) {
+    if (!value || typeof value !== "object") continue;
+    for (const key of ["callID", "callId", "toolCallID", "toolCallId", "toolUseId", "tool_use_id"]) {
+      if (typeof value[key] === "string" && value[key]) return value[key];
     }
   }
   return undefined;
@@ -92,6 +94,7 @@ function emitPierEvent(pierEvent, rawEvent) {
   const windowId = process.env.PIER_WINDOW_ID;
   if (!log || !panelId || !windowId) return;
   const sessionId = pierSessionIdFrom(rawEvent);
+  const toolUseId = pierToolIdFrom(rawEvent);
   const line = JSON.stringify({
     v: 1,
     kind: "agentEvent",
@@ -102,6 +105,7 @@ function emitPierEvent(pierEvent, rawEvent) {
     agent: "mimo-code",
     event: pierEvent,
     ...(sessionId ? { sessionId } : {}),
+    ...(toolUseId ? { toolUseId } : {}),
   }) + "\\n";
   try {
     pierAppend(log, line);
@@ -115,6 +119,7 @@ function mapPierEvent(event) {
   if (event.type === "session.created") return "SessionStart";
   if (event.type === "session.idle") return "Stop";
   if (event.type === "session.error") return "error";
+  if (event.type === "session.deleted") return "SessionEnd";
   if (event.type === "session.status") {
     // 同 opencode（MiMo 是 opencode fork, SDK 事件同源）:
     // busy/retry 推进心跳, idle 回合结束。
@@ -141,11 +146,11 @@ export const PierAgentStatus = () => {
       const mapped = mapPierEvent(event);
       if (mapped) emitPierEvent(mapped, event);
     },
-    "tool.execute.before": () => {
-      emitPierEvent("ToolStart");
+    "tool.execute.before": (...args) => {
+      emitPierEvent("ToolStart", args);
     },
-    "tool.execute.after": () => {
-      emitPierEvent("ToolComplete");
+    "tool.execute.after": (...args) => {
+      emitPierEvent("ToolComplete", args);
     },
   };
 };

--- a/src/main/services/agents/integrations/omp.ts
+++ b/src/main/services/agents/integrations/omp.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import type { AgentKind } from "@shared/contracts/agent.ts";
 import { atomicWriteFile, commandExistsOnPath } from "./shared.ts";
 import type { AgentHookIntegration } from "./types.ts";
+import { JAVASCRIPT_LOCKED_APPEND_SOURCE } from "./writer-lock-source.ts";
 
 const AGENT_ID: AgentKind = "omp";
 const EXTENSION_FILE_NAME = "pier-agent-status.ts";
@@ -137,6 +138,8 @@ export function buildOmpExtensionSource(): string {
 // call — not an ImportDeclaration — so the scan stays inert; available in
 // Bun (omp's extension host) and Node >= 20.16.
 
+${JAVASCRIPT_LOCKED_APPEND_SOURCE}
+
 let pierInstanceCount = 0;
 
 function pierSessionIdFrom(values) {
@@ -172,16 +175,7 @@ function pierEmit(event, ...values) {
 		event,
 		...(sessionId ? { sessionId } : {}),
 	}) + "\\n";
-	try {
-		// Synchronous append: keeps file order (the aggregator consumes JSONL
-		// in file order; same-ms events reorder under unawaited async appends)
-		// and survives host exit (the final session_shutdown must not race
-		// process teardown). Local ~200B appends are microsecond-scale.
-		const { appendFileSync } = process.getBuiltinModule("node:fs");
-		appendFileSync(log, line);
-	} catch {
-		// best-effort, never throw into the agent's own event loop
-	}
+	pierAppend(log, line);
 }
 
 export default function PierAgentStatus(pi) {

--- a/src/main/services/agents/integrations/opencode.ts
+++ b/src/main/services/agents/integrations/opencode.ts
@@ -5,6 +5,7 @@ import { dirname, join } from "node:path";
 import type { AgentKind } from "@shared/contracts/agent.ts";
 import { atomicWriteFile, transformJsonConfig } from "./shared.ts";
 import type { AgentHookIntegration } from "./types.ts";
+import { JAVASCRIPT_LOCKED_APPEND_SOURCE } from "./writer-lock-source.ts";
 
 const AGENT_ID: AgentKind = "opencode";
 
@@ -75,31 +76,32 @@ export function buildOpencodePluginSource(
 // call — not an ImportDeclaration; older Node falls back to async best-effort.
 // (Exception to ts-no-dynamic-import: generated file for a foreign host.)
 
-function pierAppend(log, line) {
-	if (typeof process.getBuiltinModule === "function") {
-		// 同步写:保文件序 + 进程退出前落盘(Bun 与 Node >= 20.16)。
-		const { appendFileSync } = process.getBuiltinModule("node:fs");
-		appendFileSync(log, line);
-		return;
-	}
-	// 旧 Node 宿主退化为异步 best-effort(与旧行为一致, 不更糟)。
-	import("node:fs/promises")
-		.then(({ appendFile }) => appendFile(log, line))
-		.catch(() => {});
-}
+${JAVASCRIPT_LOCKED_APPEND_SOURCE}
 
 function pierSessionIdFrom(event) {
-  const values = [event, event && event.properties];
+  const values = Array.isArray(event) ? [...event] : [event];
+  values.push(...values.map((value) => value && value.properties));
   for (const value of values) {
     if (!value || typeof value !== "object") continue;
     for (const key of ["sessionId", "sessionID", "session_id"]) {
       if (typeof value[key] === "string" && value[key]) return value[key];
     }
-    const session = value.session || value.thread;
+    const session = value.info || value.session || value.thread;
     if (session && typeof session === "object") {
       for (const key of ["id", "sessionId", "sessionID", "session_id"]) {
         if (typeof session[key] === "string" && session[key]) return session[key];
       }
+    }
+  }
+  return undefined;
+}
+
+function pierToolIdFrom(event) {
+  const values = Array.isArray(event) ? event : [event];
+  for (const value of values) {
+    if (!value || typeof value !== "object") continue;
+    for (const key of ["callID", "callId", "toolCallID", "toolCallId", "toolUseId", "tool_use_id"]) {
+      if (typeof value[key] === "string" && value[key]) return value[key];
     }
   }
   return undefined;
@@ -111,6 +113,7 @@ function emitPierEvent(pierEvent, rawEvent) {
   const windowId = process.env.PIER_WINDOW_ID;
   if (!log || !panelId || !windowId) return;
   const sessionId = pierSessionIdFrom(rawEvent);
+  const toolUseId = pierToolIdFrom(rawEvent);
   const line = JSON.stringify({
     v: 1,
     kind: "agentEvent",
@@ -121,6 +124,7 @@ function emitPierEvent(pierEvent, rawEvent) {
     agent: "${pluginId}",
     event: pierEvent,
     ...(sessionId ? { sessionId } : {}),
+    ...(toolUseId ? { toolUseId } : {}),
   }) + "\\n";
   try {
     pierAppend(log, line);
@@ -134,6 +138,7 @@ function mapPierEvent(event) {
   if (event.type === "session.created") return "SessionStart";
   if (event.type === "session.idle") return "Stop";
   if (event.type === "session.error") return "error";
+  if (event.type === "session.deleted") return "SessionEnd";
   if (event.type === "session.status") {
     // SDK EventSessionStatus: properties.status.type = busy/retry/idle
     // （sst/opencode packages/sdk/js/src/gen/types.gen.ts SessionStatus 联合）。
@@ -161,11 +166,11 @@ export const PierAgentStatus = () => {
       const mapped = mapPierEvent(event);
       if (mapped) emitPierEvent(mapped, event);
     },
-    "tool.execute.before": () => {
-      emitPierEvent("ToolStart");
+    "tool.execute.before": (...args) => {
+      emitPierEvent("ToolStart", args);
     },
-    "tool.execute.after": () => {
-      emitPierEvent("ToolComplete");
+    "tool.execute.after": (...args) => {
+      emitPierEvent("ToolComplete", args);
     },
   };
 };

--- a/src/main/services/agents/integrations/pi.ts
+++ b/src/main/services/agents/integrations/pi.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import type { AgentKind } from "@shared/contracts/agent.ts";
 import { atomicWriteFile, commandExistsOnPath } from "./shared.ts";
 import type { AgentHookIntegration } from "./types.ts";
+import { JAVASCRIPT_LOCKED_APPEND_SOURCE } from "./writer-lock-source.ts";
 
 const AGENT_ID: AgentKind = "pi";
 const EXTENSION_FILE_NAME = "pier-agent-status.ts";
@@ -68,18 +69,7 @@ export function buildPiExtensionSource(): string {
 // Bun and Node >= 20.16. Older Node falls back to async best-effort.
 // (Exception to ts-no-dynamic-import: generated file for a foreign host.)
 
-function pierAppend(log, line) {
-	if (typeof process.getBuiltinModule === "function") {
-		// 同步写:保文件序 + 进程退出前落盘(Bun 与 Node >= 20.16)。
-		const { appendFileSync } = process.getBuiltinModule("node:fs");
-		appendFileSync(log, line);
-		return;
-	}
-	// 旧 Node 宿主退化为异步 best-effort(与旧行为一致, 不更糟)。
-	import("node:fs/promises")
-		.then(({ appendFile }) => appendFile(log, line))
-		.catch(() => {});
-}
+${JAVASCRIPT_LOCKED_APPEND_SOURCE}
 
 function pierSessionIdFrom(values) {
 	for (const value of values) {

--- a/src/main/services/agents/integrations/shared.ts
+++ b/src/main/services/agents/integrations/shared.ts
@@ -22,14 +22,14 @@ export const PIER_AGENT_HOOKS_DIR_MARK = "PIER_AGENT_HOOKS_DIR";
 export function pierHookCommand(
   agentId: AgentKind,
   pierEvent: string,
-  sessionIdShellExpression?: string
+  ...payloadShellExpressions: string[]
 ): string {
-  const sessionIdArg = sessionIdShellExpression
-    ? ` "${sessionIdShellExpression}"`
-    : "";
+  const payloadArgs = payloadShellExpressions
+    .map((expression) => ` "${expression}"`)
+    .join("");
   return (
     `[ -x "\${${PIER_AGENT_HOOKS_DIR_MARK}}/emit" ] && ` +
-    `"\${${PIER_AGENT_HOOKS_DIR_MARK}}/emit" "agentEvent" "${agentId}" "${pierEvent}"${sessionIdArg} || true`
+    `"\${${PIER_AGENT_HOOKS_DIR_MARK}}/emit" "agentEvent" "${agentId}" "${pierEvent}"${payloadArgs} || true`
   );
 }
 
@@ -37,11 +37,38 @@ export function pierHookCommandWithStdinSessionId(
   agentId: AgentKind,
   pierEvent: string
 ): string {
+  const nodeExecutable = shellDoubleQuote(process.execPath);
   return [
     "_pier_payload=$(cat 2>/dev/null | head -c 65536)",
+    `_pier_metadata_b64=$(printf '%s' "$_pier_payload" | ELECTRON_RUN_AS_NODE=1 "${nodeExecutable}" -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{try{const p=JSON.parse(s),o={};for(const k of ["session_id","sessionId","turn_id","tool_use_id","tool_name","agent_id","agent_type","transcript_path"])if(typeof p[k]==="string")o[k]=p[k];process.stdout.write(Buffer.from(JSON.stringify(o)).toString("base64"))}catch{}})' 2>/dev/null || true)`,
     `_pier_session_id=$(printf '%s' "$_pier_payload" | sed -n 's/.*"session_id"[[:space:]]*:[[:space:]]*"\\([^"]*\\)".*/\\1/p; s/.*"sessionId"[[:space:]]*:[[:space:]]*"\\([^"]*\\)".*/\\1/p' | head -n 1)`,
-    pierHookCommand(agentId, pierEvent, "$_pier_session_id"),
+    `_pier_turn_id=$(printf '%s' "$_pier_payload" | sed -n 's/.*"turn_id"[[:space:]]*:[[:space:]]*"\\([^"]*\\)".*/\\1/p' | head -n 1)`,
+    `_pier_tool_use_id=$(printf '%s' "$_pier_payload" | sed -n 's/.*"tool_use_id"[[:space:]]*:[[:space:]]*"\\([^"]*\\)".*/\\1/p' | head -n 1)`,
+    `_pier_tool_name=$(printf '%s' "$_pier_payload" | sed -n 's/.*"tool_name"[[:space:]]*:[[:space:]]*"\\([^"]*\\)".*/\\1/p' | head -n 1)`,
+    `_pier_agent_id=$(printf '%s' "$_pier_payload" | sed -n 's/.*"agent_id"[[:space:]]*:[[:space:]]*"\\([^"]*\\)".*/\\1/p' | head -n 1)`,
+    `_pier_agent_type=$(printf '%s' "$_pier_payload" | sed -n 's/.*"agent_type"[[:space:]]*:[[:space:]]*"\\([^"]*\\)".*/\\1/p' | head -n 1)`,
+    `_pier_transcript_path=$(printf '%s' "$_pier_payload" | sed -n 's/.*"transcript_path"[[:space:]]*:[[:space:]]*"\\([^"]*\\)".*/\\1/p' | head -n 1)`,
+    pierHookCommand(
+      agentId,
+      pierEvent,
+      "$_pier_session_id",
+      "$_pier_turn_id",
+      "$_pier_tool_use_id",
+      "$_pier_tool_name",
+      "$_pier_agent_id",
+      "$_pier_agent_type",
+      "$_pier_transcript_path",
+      "$_pier_metadata_b64"
+    ),
   ].join("; ");
+}
+
+function shellDoubleQuote(value: string): string {
+  return value
+    .replaceAll("\\", "\\\\")
+    .replaceAll('"', '\\"')
+    .replaceAll("$", "\\$")
+    .replaceAll("`", "\\`");
 }
 
 /**
@@ -236,8 +263,8 @@ export function createNestedJsonIntegration(
     detect: spec.detect ?? (() => existsSync(spec.configPath())),
     id: spec.agentId,
     // install 先剔全部 pier 条目再按当前 spec 写入——覆盖「上一版 spec 装过
-    // 但本版已移出」的遗留(如 codex 曾装 SubagentStart/SubagentStop、后来
-    // 移除, withPierNestedHooks 只处理当前 spec 内事件, 不会清废弃事件)。
+    // 但本版已移出」的遗留；withPierNestedHooks 只处理当前 spec 内事件，
+    // 不会自行清理已经废弃的事件键。
     install: () =>
       transformJsonConfig(
         spec.configPath(),

--- a/src/main/services/agents/integrations/terminal-reconciliation.ts
+++ b/src/main/services/agents/integrations/terminal-reconciliation.ts
@@ -1,0 +1,33 @@
+import type { AgentHookEventPayload } from "@shared/contracts/agent-session.ts";
+import { createCodexTranscriptReconciler } from "./codex-transcript-reconciler.ts";
+
+/**
+ * Agent 私有终态对账的统一宿主边界。foreground-activity 只投递已验收的
+ * 规范事件，不感知 Codex transcript 路径、格式或 watcher 生命周期。
+ */
+export interface AgentTerminalReconciler {
+  dispose(): void;
+  observe(event: AgentHookEventPayload): Promise<void>;
+  releasePanel(panelId: string, windowId?: string): void;
+  releaseWindow(windowId: string): void;
+  retainPanels(windowId: string, activePanelIds: readonly string[]): void;
+}
+
+export function createAgentTerminalReconciler(args: {
+  onTerminalEvent: (event: AgentHookEventPayload) => void;
+}): AgentTerminalReconciler {
+  const codex = createCodexTranscriptReconciler(args);
+  return {
+    dispose: () => codex.dispose(),
+    observe: (event) => codex.observe(event),
+    releasePanel: (panelId, windowId) => codex.releasePanel(panelId, windowId),
+    retainPanels: (windowId, activePanelIds) => {
+      const active = new Set(activePanelIds);
+      codex.releasePanelsWhere(
+        (panelId, ownerWindowId) =>
+          ownerWindowId === windowId && !active.has(panelId)
+      );
+    },
+    releaseWindow: (windowId) => codex.releaseWindow(windowId),
+  };
+}

--- a/src/main/services/agents/integrations/writer-lock-source.ts
+++ b/src/main/services/agents/integrations/writer-lock-source.ts
@@ -1,0 +1,45 @@
+/** 注入第三方 JavaScript 插件的跨语言原子 JSONL 写锁协议。 */
+export const JAVASCRIPT_LOCKED_APPEND_SOURCE = `
+function pierAppend(log, line) {
+	const lock = log + ".lock";
+	const token = String(process.pid) + "." + Date.now() + "." + Math.random();
+	const candidate = lock + "." + token;
+	if (typeof process.getBuiltinModule === "function") {
+		const fs = process.getBuiltinModule("node:fs");
+		try { fs.writeFileSync(candidate, token, { flag: "wx" }); } catch { return; }
+		try {
+			for (let attempt = 0; attempt < 500; attempt += 1) {
+				try {
+					fs.linkSync(candidate, lock);
+					fs.rmSync(candidate, { force: true });
+					try { fs.appendFileSync(log, line); }
+					finally {
+						try { if (fs.readFileSync(lock, "utf8") === token) fs.rmSync(lock); } catch {}
+					}
+					return;
+				} catch (error) {
+					if (error?.code !== "EEXIST") return;
+					Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
+				}
+			}
+		} finally { try { fs.rmSync(candidate, { force: true }); } catch {} }
+		return;
+	}
+	import("node:fs/promises").then(async (fs) => {
+		try { await fs.writeFile(candidate, token, { flag: "wx" }); } catch { return; }
+		try {
+			for (let attempt = 0; attempt < 500; attempt += 1) {
+				try {
+					await fs.link(candidate, lock);
+					await fs.rm(candidate, { force: true });
+					try { await fs.appendFile(log, line); }
+					finally { if (await fs.readFile(lock, "utf8").catch(() => "") === token) await fs.rm(lock, { force: true }); }
+					return;
+				} catch (error) {
+					if (error?.code !== "EEXIST") return;
+					await new Promise((resolve) => setTimeout(resolve, 10));
+				}
+			}
+		} finally { await fs.rm(candidate, { force: true }); }
+	}).catch(() => {});
+}`;

--- a/src/main/services/foreground-activity/aggregator-hook-scopes.ts
+++ b/src/main/services/foreground-activity/aggregator-hook-scopes.ts
@@ -50,7 +50,7 @@ export interface HookScopeCoordinator {
     key: string,
     event: AgentHookEventPayload,
     identity: HookScopeIdentity
-  ) => boolean;
+  ) => boolean | null;
   noteStatusEvent: (
     key: string,
     hook: HookLayer,
@@ -97,19 +97,20 @@ export function createHookScopeCoordinator({
     key: string,
     scopeKey: string,
     agent: AgentHookEventPayload["agent"]
-  ): void {
+  ): boolean {
     const cooldownKey = scopeCooldownKey(key, scopeKey);
     hookScopeCooldownUntil.set(cooldownKey, now() + SESSION_END_COOLDOWN_MS);
     const hook = slots.get(key)?.hook ?? null;
     if (!hook?.scopes.delete(scopeKey)) {
-      return;
+      return false;
     }
     if (hook.scopes.size === 0) {
       endHookSession(key);
-      return;
+      return true;
     }
     refreshHookProjectionWithLog(key, hook, now(), agent);
     scheduleEmit();
+    return true;
   }
 
   function allowsAgentEventAfterCooldowns(
@@ -150,13 +151,12 @@ export function createHookScopeCoordinator({
     key: string,
     event: AgentHookEventPayload,
     identity: HookScopeIdentity
-  ): boolean {
+  ): boolean | null {
     if (event.event !== "SessionEnd") {
-      return false;
+      return null;
     }
     if (identity.isolated) {
-      endHookScope(key, identity.key, event.agent);
-      return true;
+      return endHookScope(key, identity.key, event.agent);
     }
     endHookSession(key);
     return true;

--- a/src/main/services/foreground-activity/aggregator-panel-key.ts
+++ b/src/main/services/foreground-activity/aggregator-panel-key.ts
@@ -1,0 +1,16 @@
+import type { PanelSlot } from "./entry.ts";
+
+export function panelKey(windowId: string, panelId: string): string {
+  return `${windowId}\0${panelId}`;
+}
+
+export function keysForPanel(
+  slots: Map<string, PanelSlot>,
+  panelId: string,
+  windowId?: string
+): string[] {
+  if (windowId !== undefined) return [panelKey(windowId, panelId)];
+  return [...slots.entries()]
+    .filter(([, slot]) => slot.panelId === panelId)
+    .map(([key]) => key);
+}

--- a/src/main/services/foreground-activity/aggregator-visibility.ts
+++ b/src/main/services/foreground-activity/aggregator-visibility.ts
@@ -1,0 +1,52 @@
+import {
+  type AgentLaunchLayer,
+  type HookLayer,
+  type PanelSlot,
+  VISIBILITY_DEBOUNCE_MS,
+} from "./entry.ts";
+
+interface VisibilityContext {
+  scheduleEmit: () => void;
+  slots: Map<string, PanelSlot>;
+}
+
+export function armLaunchVisibility(
+  key: string,
+  layer: AgentLaunchLayer,
+  context: VisibilityContext
+): void {
+  layer.visibilityTimer = setTimeout(() => {
+    const current = context.slots.get(key)?.command;
+    if (current?.kind !== "agent-launch" || current !== layer) return;
+    current.visibilityTimer = null;
+    if (current.hidden) {
+      current.hidden = false;
+      context.scheduleEmit();
+    }
+  }, VISIBILITY_DEBOUNCE_MS);
+}
+
+export function armHookVisibility(
+  key: string,
+  layer: HookLayer,
+  context: VisibilityContext
+): void {
+  layer.visibilityTimer = setTimeout(() => {
+    const current = context.slots.get(key)?.hook;
+    if (current !== layer) return;
+    current.visibilityTimer = null;
+    if (current.hidden) {
+      current.hidden = false;
+      context.scheduleEmit();
+    }
+  }, VISIBILITY_DEBOUNCE_MS);
+}
+
+export function revealHook(hook: HookLayer): void {
+  if (!hook.hidden) return;
+  hook.hidden = false;
+  if (hook.visibilityTimer) {
+    clearTimeout(hook.visibilityTimer);
+    hook.visibilityTimer = null;
+  }
+}

--- a/src/main/services/foreground-activity/aggregator.ts
+++ b/src/main/services/foreground-activity/aggregator.ts
@@ -8,6 +8,7 @@ import {
   createHookScopeCoordinator,
   isInCooldown,
 } from "./aggregator-hook-scopes.ts";
+import { keysForPanel, panelKey } from "./aggregator-panel-key.ts";
 import {
   logAgentEventDropped,
   logClearForeignHook,
@@ -17,8 +18,11 @@ import {
   logRouting,
 } from "./aggregator-tracing.ts";
 import {
-  type AgentLaunchLayer,
-  applyTurnBookkeeping,
+  armHookVisibility,
+  armLaunchVisibility,
+  revealHook,
+} from "./aggregator-visibility.ts";
+import {
   armHookTtlTimer,
   CLOSE_COOLDOWN_MS,
   clearCommandTimers,
@@ -38,8 +42,11 @@ import {
   SESSION_END_COOLDOWN_MS,
   SUSPENDED_JOB_EXIT_CODES,
   type TimerCtx,
-  VISIBILITY_DEBOUNCE_MS,
 } from "./entry.ts";
+import {
+  applyTurnBookkeeping,
+  hookScopeHasActiveTools,
+} from "./turn-bookkeeping.ts";
 import type {
   ForegroundActivityAggregator,
   ForegroundActivityAggregatorOpts,
@@ -63,8 +70,8 @@ export function createForegroundActivityAggregator(
   function buildBroadcast(): ForegroundActivityBroadcast {
     broadcastSeq += 1;
     const activities: ForegroundActivity[] = [];
-    for (const [panelId, slot] of slots) {
-      const activity = projectSlot(panelId, slot);
+    for (const slot of slots.values()) {
+      const activity = projectSlot(slot.panelId, slot);
       if (activity) {
         activities.push(activity);
       }
@@ -87,10 +94,10 @@ export function createForegroundActivityAggregator(
 
   const timerCtx: TimerCtx = { now, scheduleEmit, slots };
 
-  function slotFor(key: string): PanelSlot {
+  function slotFor(key: string, panelId: string): PanelSlot {
     let slot = slots.get(key);
     if (!slot) {
-      slot = { command: null, hook: null };
+      slot = { command: null, hook: null, panelId };
       slots.set(key, slot);
     }
     return slot;
@@ -131,47 +138,6 @@ export function createForegroundActivityAggregator(
       }
     }
     hookScopes.pruneExpiredCooldowns();
-  }
-
-  /** launch 层 250ms 消抖显形（`omp --version` 瞬时命令不闪条）。 */
-  function armLaunchVisibility(key: string, layer: AgentLaunchLayer): void {
-    layer.visibilityTimer = setTimeout(() => {
-      const current = slots.get(key)?.command;
-      if (current?.kind !== "agent-launch" || current !== layer) {
-        return;
-      }
-      current.visibilityTimer = null;
-      if (current.hidden) {
-        current.hidden = false;
-        scheduleEmit();
-      }
-    }, VISIBILITY_DEBOUNCE_MS);
-  }
-
-  /** hook 层 SessionStart 消抖显形（防瞬时闪条）。 */
-  function armHookVisibility(key: string, layer: HookLayer): void {
-    layer.visibilityTimer = setTimeout(() => {
-      const current = slots.get(key)?.hook;
-      if (current !== layer) {
-        return;
-      }
-      current.visibilityTimer = null;
-      if (current.hidden) {
-        current.hidden = false;
-        scheduleEmit();
-      }
-    }, VISIBILITY_DEBOUNCE_MS);
-  }
-
-  /** 非 SessionStart 的 hook 事件是真实进展证据——立即显形。 */
-  function revealHook(hook: HookLayer): void {
-    if (hook.hidden) {
-      hook.hidden = false;
-      if (hook.visibilityTimer) {
-        clearTimeout(hook.visibilityTimer);
-        hook.visibilityTimer = null;
-      }
-    }
   }
 
   /**
@@ -219,7 +185,7 @@ export function createForegroundActivityAggregator(
     event: AgentHookEventPayload,
     at: number
   ): HookLayer | null {
-    const slot = slotFor(key);
+    const slot = slotFor(key, event.panelId);
     const existing = slot.hook;
     if (existing) {
       if (event.event !== "SessionStart") {
@@ -234,7 +200,7 @@ export function createForegroundActivityAggregator(
     const hook = newHookLayer(event, at);
     slot.hook = hook;
     if (hook.hidden) {
-      armHookVisibility(key, hook);
+      armHookVisibility(key, hook, { scheduleEmit, slots });
     }
     return hook;
   }
@@ -244,10 +210,10 @@ export function createForegroundActivityAggregator(
       if (disposed) {
         return;
       }
-      const key = panelId;
+      const key = panelKey(windowId, panelId);
       panelCooldownUntil.delete(key);
       hookCooldownUntil.delete(key);
-      const slot = slotFor(key);
+      const slot = slotFor(key, panelId);
       const existing = slot.command;
       if (existing?.kind === "agent-launch" && existing.agentId === agentId) {
         // launcher 先验 + OSC 133 C 双击（同 agent）→ 去抖：保层保消抖 timer。
@@ -259,7 +225,7 @@ export function createForegroundActivityAggregator(
         }
         const layer = newAgentLaunchLayer(windowId, agentId, now());
         slot.command = layer;
-        armLaunchVisibility(key, layer);
+        armLaunchVisibility(key, layer, { scheduleEmit, slots });
       }
       // 异 agent 的 hook 证据在新 agent 命令启动时作废（loomdesk
       // clearAgentHookActivitiesBySession 同语义）；同 agent 保留——
@@ -281,13 +247,13 @@ export function createForegroundActivityAggregator(
         api.agentLaunched(windowId, panelId, matchedAgent);
         return;
       }
-      const key = panelId;
+      const key = panelKey(windowId, panelId);
       // 只查 panel 死亡冷却：命令收尾的 hook 冷却不拦新命令——
       // 相邻命令 <5s 也必须正常呈现（loomdesk ingestCommandStart 同语义）。
       if (isInCooldown(panelCooldownUntil, key, now)) {
         return;
       }
-      const slot = slotFor(key);
+      const slot = slotFor(key, panelId);
       if (slot.command) {
         clearCommandTimers(slot.command);
       }
@@ -296,16 +262,21 @@ export function createForegroundActivityAggregator(
       scheduleEmit();
     },
 
-    ingestCommandFinished(panelId, exitCode) {
+    ingestCommandFinished(panelId, exitCode, windowId) {
       if (exitCode !== undefined && SUSPENDED_JOB_EXIT_CODES.has(exitCode)) {
         return;
       }
-      const key = panelId;
-      if (disposed || !slots.has(key)) {
+      if (disposed) {
         return;
       }
-      logCommandFinished(key, exitCode);
-      if (closeSlot(key, { map: hookCooldownUntil, ms: CLOSE_COOLDOWN_MS })) {
+      let removed = false;
+      for (const key of keysForPanel(slots, panelId, windowId)) {
+        logCommandFinished(key, exitCode);
+        removed =
+          closeSlot(key, { map: hookCooldownUntil, ms: CLOSE_COOLDOWN_MS }) ||
+          removed;
+      }
+      if (removed) {
         scheduleEmit();
       }
       pruneExpiredCooldowns();
@@ -322,7 +293,7 @@ export function createForegroundActivityAggregator(
       if (disposed) {
         return false;
       }
-      const key = event.panelId;
+      const key = panelKey(event.windowId, event.panelId);
       const slotBefore = slots.get(key);
       logRouting(event.event, event.agent, key, slotBefore?.hook ?? null);
       const ownerAgent = commandOwnedAgent(slotBefore);
@@ -337,8 +308,13 @@ export function createForegroundActivityAggregator(
       if (!hookScopes.allowsAgentEventAfterCooldowns(key, event, identity)) {
         return false;
       }
-      if (hookScopes.handleSessionEnd(key, event, identity)) {
-        return true;
+      const sessionEndHandled = hookScopes.handleSessionEnd(
+        key,
+        event,
+        identity
+      );
+      if (sessionEndHandled !== null) {
+        return sessionEndHandled;
       }
       const status = activityStatusForHookEvent(event.event);
       if (status === null) {
@@ -352,13 +328,23 @@ export function createForegroundActivityAggregator(
         return false;
       }
       const scope = getOrCreateHookScope(hook, identity, at);
-      if (!applyTurnBookkeeping(scope, event.event)) {
+      if (!applyTurnBookkeeping(scope, event)) {
         logAgentEventDropped("absorbed", key, event.event, {
           frozenStatus: scope.status,
         });
         return false;
       }
-      hookScopes.noteStatusEvent(key, hook, scope, event, status, at);
+      hookScopes.noteStatusEvent(
+        key,
+        hook,
+        scope,
+        event,
+        event.event === "ToolComplete" &&
+          (!event.toolUseId?.trim() || hookScopeHasActiveTools(scope))
+          ? "tool"
+          : status,
+        at
+      );
       armHookTtlTimer(key, timerCtx);
       scheduleEmit();
       return true;
@@ -368,10 +354,10 @@ export function createForegroundActivityAggregator(
       if (disposed) {
         return;
       }
-      const key = panelId;
+      const key = panelKey(windowId, panelId);
       panelCooldownUntil.delete(key);
       hookCooldownUntil.delete(key);
-      const slot = slotFor(key);
+      const slot = slotFor(key, panelId);
       // 用户显式操作优先：task 接管 pty，旧会话证据作废。
       clearSlotTimers(slot);
       slot.hook = null;
@@ -385,46 +371,56 @@ export function createForegroundActivityAggregator(
       scheduleEmit();
     },
 
-    taskFinished(panelId, args) {
-      const slot = slots.get(panelId);
-      const command = slot?.command;
-      if (command?.kind !== "task" || command.runId !== args.runId) {
+    taskFinished(panelId, args, windowId) {
+      for (const key of keysForPanel(slots, panelId, windowId)) {
+        const command = slots.get(key)?.command;
+        if (command?.kind !== "task" || command.runId !== args.runId) {
+          continue;
+        }
+        command.status = args.status;
+        command.updatedAt = now();
+        if (args.exitCode !== undefined) {
+          command.exitCode = args.exitCode;
+        }
+        scheduleEmit();
         return;
-      }
-      command.status = args.status;
-      command.updatedAt = now();
-      if (args.exitCode !== undefined) {
-        command.exitCode = args.exitCode;
       }
       // 终态常驻：task 层保留最终状态直到 panelClosed / rerun(taskLaunched) /
       // 新命令接管。activity 只保留任务活动投影和 TaskRuns 不可用时的兼容回退；
       // 实时任务状态由带 runId 的 TaskRunsSnapshot 负责。
-      scheduleEmit();
     },
 
-    panelClosed(panelId) {
-      if (
-        closeSlot(panelId, { map: panelCooldownUntil, ms: CLOSE_COOLDOWN_MS })
-      ) {
+    panelClosed(panelId, windowId) {
+      let removed = false;
+      for (const key of keysForPanel(slots, panelId, windowId)) {
+        removed =
+          closeSlot(key, { map: panelCooldownUntil, ms: CLOSE_COOLDOWN_MS }) ||
+          removed;
+      }
+      if (removed) {
         scheduleEmit();
       }
       pruneExpiredCooldowns();
     },
-    ptyExited(panelId) {
-      const slot = slots.get(panelId);
-      if (slot?.command?.kind === "task") {
+    ptyExited(panelId, windowId) {
+      const keys = keysForPanel(slots, panelId, windowId);
+      for (const key of keys) {
+        const slot = slots.get(key);
+        if (slot?.command?.kind !== "task") {
+          continue;
+        }
         // pty 死亡 ≠ 面板关闭：task 面板仍开着呈现结果；只清 hook 证据。
-        logPtyExitedTaskRetain(panelId);
+        logPtyExitedTaskRetain(key);
         if (slot.hook) {
           clearHookTimers(slot.hook);
           slot.hook = null;
           scheduleEmit();
         }
-        hookCooldownUntil.set(panelId, now() + CLOSE_COOLDOWN_MS);
+        hookCooldownUntil.set(key, now() + CLOSE_COOLDOWN_MS);
         pruneExpiredCooldowns();
         return;
       }
-      api.panelClosed(panelId);
+      api.panelClosed(panelId, windowId);
     },
 
     windowClosed(windowId) {
@@ -449,7 +445,7 @@ export function createForegroundActivityAggregator(
       let anyRemoved = false;
       for (const [key, slot] of [...slots.entries()]) {
         const slotWindowId = slot.command?.windowId ?? slot.hook?.windowId;
-        if (slotWindowId !== windowId || active.has(key)) {
+        if (slotWindowId !== windowId || active.has(slot.panelId)) {
           continue;
         }
         if (

--- a/src/main/services/foreground-activity/entry.ts
+++ b/src/main/services/foreground-activity/entry.ts
@@ -46,7 +46,12 @@ export const VISIBILITY_DEBOUNCE_MS = 250;
  * omp 集成已用「不订阅 turn_end」规避同类问题，codex 因 Stop 是唯一回合
  * 边界信号不能照搬，改在此处统一豁免。`Stop → ready` 映射保留不变。
  */
-export const TURN_BOUNDARY_EVENTS = new Set(["SessionStart", "error"]);
+export const TURN_BOUNDARY_EVENTS = new Set([
+  "SessionStart",
+  "TurnCompleted",
+  "TurnInterrupted",
+  "error",
+]);
 /** 回合重置事件（新回合开始）——解除吸收 + 清 subagent 计数。 */
 export const TURN_RESET_EVENTS = new Set([
   "PromptSubmit",
@@ -87,6 +92,11 @@ export interface HookScopeIdentity {
 }
 
 export interface HookScope {
+  activeSubagentIds: Set<string>;
+  activeToolIds: Set<string>;
+  anonymousSubagentCount: number;
+  anonymousToolCount: number;
+  currentTurnId: string | undefined;
   key: string;
   stateStartedAt: number;
   status: ActivityStatus;
@@ -151,6 +161,7 @@ export type CommandLayer = AgentLaunchLayer | ShellLayer | TaskLayer;
 export interface PanelSlot {
   command: CommandLayer | null;
   hook: HookLayer | null;
+  panelId: string;
 }
 
 export interface TimerCtx {
@@ -204,6 +215,11 @@ export function hookScopeIdentity(
 
 export function newHookScope(key: string, at: number): HookScope {
   return {
+    activeSubagentIds: new Set(),
+    activeToolIds: new Set(),
+    anonymousSubagentCount: 0,
+    anonymousToolCount: 0,
+    currentTurnId: undefined,
     key,
     stateStartedAt: at,
     status: "ready",
@@ -251,7 +267,8 @@ export function refreshHookProjection(hook: HookLayer, at?: number): void {
   for (const scope of hook.scopes.values()) {
     selected = selected ? preferredScope(selected, scope) : scope;
     maxUpdatedAt = Math.max(maxUpdatedAt, scope.updatedAt);
-    subagentCount += scope.subagentCount;
+    subagentCount +=
+      scope.activeSubagentIds.size + scope.anonymousSubagentCount;
   }
   if (!selected) {
     return;
@@ -374,33 +391,6 @@ export function newTaskLayer(
     updatedAt: at,
     windowId,
   };
-}
-
-/**
- * 回合边界/重置/吸收 + 子代理计数记账。返回 false 表示事件应被吸收丢弃。
- * PermissionRequest 豁免吸收——权限弹窗是回合复活的证据。
- */
-export function applyTurnBookkeeping(
-  scope: HookScope,
-  eventName: string
-): boolean {
-  if (TURN_BOUNDARY_EVENTS.has(eventName)) {
-    scope.turnEnded = true;
-    scope.subagentCount = 0;
-  } else if (TURN_RESET_EVENTS.has(eventName)) {
-    scope.turnEnded = false;
-    scope.subagentCount = 0;
-  } else if (eventName === "PermissionRequest") {
-    scope.turnEnded = false;
-  } else if (scope.turnEnded) {
-    return false;
-  }
-  if (eventName === "SubagentStart") {
-    scope.subagentCount += 1;
-  } else if (eventName === "SubagentStop") {
-    scope.subagentCount = Math.max(0, scope.subagentCount - 1);
-  }
-  return true;
 }
 
 /**

--- a/src/main/services/foreground-activity/jsonl-observer.ts
+++ b/src/main/services/foreground-activity/jsonl-observer.ts
@@ -1,11 +1,5 @@
-import {
-  readFileSync,
-  type Stats,
-  statSync,
-  unwatchFile,
-  watchFile,
-} from "node:fs";
-import { open, readFile, stat, writeFile } from "node:fs/promises";
+import { type Stats, unwatchFile, watchFile } from "node:fs";
+import { open, rename, rm, stat, writeFile } from "node:fs/promises";
 import {
   type AgentHookEventPayload,
   agentHookEventSchema,
@@ -13,17 +7,26 @@ import {
   type CommandStartHookEvent,
 } from "@shared/contracts/agent-session.ts";
 import { createLogger } from "@shared/logger.ts";
+import {
+  acquireRotationLock,
+  LOCK_SUFFIX,
+  loadOffset,
+  OFFSET_SUFFIX,
+  persistOffset,
+  prepareInterruptedRotation,
+  ROTATING_SUFFIX,
+  type RotationRecovery,
+  reapStaleRotationLock,
+} from "./jsonl-rotation.ts";
 
 const log = createLogger("foreground-activity.jsonl-observer");
 
 /** rotate 阈值：10MB。 */
 const ROTATE_SIZE = 10 * 1024 * 1024;
 
-/** rotate 后保留行数。 */
-const ROTATE_TAIL_LINES = 1000;
-
 /** watchFile 轮询间隔（ms）。 */
 const POLL_INTERVAL_MS = 250;
+const MAX_READ_BYTES = 1024 * 1024;
 
 export interface JsonlObserver {
   /** 停止监听并释放资源。 */
@@ -48,9 +51,6 @@ export interface JsonlObserverOpts {
   onError?: (err: unknown) => void;
 }
 
-/** offset 持久化文件后缀。 */
-const OFFSET_SUFFIX = ".offset";
-
 /**
  * JSONL 尾读 observer（spec §4.4）。
  *
@@ -63,26 +63,47 @@ export function createJsonlObserver(opts: JsonlObserverOpts): JsonlObserver {
   const { filePath, onCommandStart, onCommandFinished, onAgentEvent, onError } =
     opts;
   const offsetPath = filePath + OFFSET_SUFFIX;
-  let offset = loadOffset(filePath, offsetPath);
+  let recovery = prepareInterruptedRotation(filePath, offsetPath);
+  let offset = recovery ? 0 : loadOffset(filePath, offsetPath);
   let processing = false;
+  let pending = false;
   let disposed = false;
+  const reapTimer = setInterval(() => {
+    if (!(disposed || processing)) startDrain();
+  }, 1000);
+  reapTimer.unref();
 
   watchFile(filePath, { interval: POLL_INTERVAL_MS }, onFileChange);
 
   function onFileChange(_curr: Stats, _prev: Stats): void {
-    if (disposed || processing) {
+    if (disposed) {
       return;
     }
+    if (processing) {
+      pending = true;
+      return;
+    }
+    startDrain();
+  }
+
+  function startDrain(): void {
     processing = true;
-    processChanges().finally(() => {
+    drainChanges().finally(() => {
       processing = false;
     });
+  }
+
+  async function drainChanges(): Promise<void> {
+    do {
+      pending = false;
+      await processChanges();
+    } while (!disposed && pending);
   }
 
   async function readNewBytes(size: number): Promise<Buffer> {
     const fd = await open(filePath, "r");
     try {
-      const buf = Buffer.alloc(size - offset);
+      const buf = Buffer.alloc(Math.min(size - offset, MAX_READ_BYTES));
       const { bytesRead } = await fd.read(buf, 0, buf.length, offset);
       return buf.subarray(0, bytesRead);
     } finally {
@@ -111,7 +132,7 @@ export function createJsonlObserver(opts: JsonlObserverOpts): JsonlObserver {
         onError?.(result.error);
         return;
       }
-      const event = result.data;
+      const event = enrichAgentEventFromRawPayload(result.data);
       if (event.kind === "agentEvent") {
         log.debug("event-line", {
           kind: event.kind,
@@ -147,6 +168,31 @@ export function createJsonlObserver(opts: JsonlObserverOpts): JsonlObserver {
 
   async function processChanges(): Promise<void> {
     try {
+      await reapStaleRotationLock(filePath + LOCK_SUFFIX);
+      if (recovery) {
+        const releaseLock = await acquireRotationLock(
+          filePath + LOCK_SUFFIX,
+          () => disposed
+        );
+        if (!releaseLock) return;
+        try {
+          const mainExists = await stat(filePath)
+            .then(() => true)
+            .catch(() => false);
+          if (mainExists) {
+            await finishInterruptedRotation(recovery);
+          } else {
+            await rename(recovery.path, filePath);
+            await rename(recovery.offsetPath, offsetPath).catch(
+              () => undefined
+            );
+            offset = loadOffset(filePath, offsetPath);
+          }
+          recovery = null;
+        } finally {
+          await releaseLock();
+        }
+      }
       const st = await stat(filePath).catch(() => null);
       if (!st) {
         return;
@@ -159,11 +205,6 @@ export function createJsonlObserver(opts: JsonlObserverOpts): JsonlObserver {
       if (st.size === offset) {
         return;
       }
-      if (st.size > ROTATE_SIZE) {
-        await rotate();
-        return;
-      }
-
       const chunk = await readNewBytes(st.size);
       // 只消费到最后一个完整行边界（字节层面找 0x0A——JSONL 写端不保证
       // 原子换行边界, 半行必须留在文件里等补齐; 按字节切割也天然规避
@@ -171,14 +212,33 @@ export function createJsonlObserver(opts: JsonlObserverOpts): JsonlObserver {
       // 过完整行, 崩溃恢复永不丢已落盘的完整事件。
       const lastNewline = chunk.lastIndexOf(0x0a);
       if (lastNewline === -1) {
+        if (chunk.length >= MAX_READ_BYTES) {
+          onError?.(new Error("JSONL line exceeds 1 MiB; discarded"));
+          offset += chunk.length;
+          await persistOffset(offsetPath, offset);
+          pending = true;
+        }
         return;
       }
       const consumed = chunk.subarray(0, lastNewline + 1);
-      offset += consumed.length;
-      await persistOffset(offsetPath, offset);
-
-      for (const line of consumed.toString("utf8").split("\n")) {
-        processLine(line);
+      let lineStart = 0;
+      for (let index = 0; index < consumed.length; index += 1) {
+        if (consumed[index] !== 0x0a) {
+          continue;
+        }
+        processLine(consumed.subarray(lineStart, index).toString("utf8"));
+        const lineBytes = index + 1 - lineStart;
+        offset += lineBytes;
+        lineStart = index + 1;
+        // callback 成功后再 checkpoint：崩溃最多重放当前行，不会跳过尚未派发
+        // 的后续完整行。
+        await persistOffset(offsetPath, offset);
+      }
+      if (st.size - offset >= MAX_READ_BYTES) {
+        pending = true;
+      }
+      if (st.size > ROTATE_SIZE && offset >= st.size) {
+        await rotate();
       }
     } catch (err) {
       onError?.(err);
@@ -186,32 +246,113 @@ export function createJsonlObserver(opts: JsonlObserverOpts): JsonlObserver {
   }
 
   async function rotate(): Promise<void> {
+    const rotatedPath = `${filePath}${ROTATING_SUFFIX}`;
+    const rotatedOffsetPath = `${rotatedPath}${OFFSET_SUFFIX}`;
+    const releaseLock = await acquireRotationLock(
+      filePath + LOCK_SUFFIX,
+      () => disposed
+    );
+    if (!releaseLock) {
+      return;
+    }
     try {
-      const content = await readFile(filePath, "utf8");
-      const allLines = content.split("\n").filter((l) => l.trim());
-      const tail = allLines.slice(-ROTATE_TAIL_LINES);
-      const newContent = `${tail.join("\n")}\n`;
-      await writeFile(filePath, newContent);
-      offset = Buffer.byteLength(newContent);
-      await persistOffset(offsetPath, offset);
+      await rm(rotatedPath, { force: true });
+      await rm(rotatedOffsetPath, { force: true });
+      await persistOffset(rotatedOffsetPath, offset);
+      await rename(filePath, rotatedPath);
+      await writeFile(filePath, "");
+      await finishInterruptedRotation({
+        offset,
+        offsetPath: rotatedOffsetPath,
+        path: rotatedPath,
+      });
+      pending = true;
     } catch (err) {
       onError?.(err);
+    } finally {
+      await releaseLock();
     }
+  }
+
+  async function finishInterruptedRotation(
+    interrupted: RotationRecovery
+  ): Promise<void> {
+    const rotated = await stat(interrupted.path).catch(() => null);
+    if (rotated) {
+      let recoveryOffset = Math.min(interrupted.offset, rotated.size);
+      while (rotated.size > recoveryOffset) {
+        const fd = await open(interrupted.path, "r");
+        try {
+          const tail = Buffer.alloc(
+            Math.min(rotated.size - recoveryOffset, MAX_READ_BYTES)
+          );
+          const result = await fd.read(tail, 0, tail.length, recoveryOffset);
+          const bytes = tail.subarray(0, result.bytesRead);
+          const lastNewline = bytes.lastIndexOf(0x0a);
+          if (lastNewline === -1) {
+            if (recoveryOffset + bytes.length < rotated.size) {
+              onError?.(
+                new Error("recovery JSONL line exceeds 1 MiB; discarded")
+              );
+            } else {
+              processLine(bytes.toString("utf8"));
+            }
+            recoveryOffset += bytes.length;
+            await persistOffset(interrupted.offsetPath, recoveryOffset);
+          } else {
+            const consumed = bytes.subarray(0, lastNewline + 1);
+            let lineStart = 0;
+            for (let index = 0; index < consumed.length; index += 1) {
+              if (consumed[index] !== 0x0a) {
+                continue;
+              }
+              processLine(consumed.subarray(lineStart, index).toString("utf8"));
+              recoveryOffset += index + 1 - lineStart;
+              lineStart = index + 1;
+              await persistOffset(interrupted.offsetPath, recoveryOffset);
+            }
+            const remainingStart = lastNewline + 1;
+            if (
+              remainingStart < bytes.length &&
+              recoveryOffset === rotated.size - (bytes.length - remainingStart)
+            ) {
+              processLine(bytes.subarray(remainingStart).toString("utf8"));
+              recoveryOffset += bytes.length - remainingStart;
+              await persistOffset(interrupted.offsetPath, recoveryOffset);
+            }
+          }
+        } finally {
+          await fd.close();
+        }
+      }
+    }
+
+    // 先把新日志 checkpoint 归零，再删除旧日志；任一位置崩溃，下一次
+    // 启动都只会重放尚未 checkpoint 的旧行，不会拼接或重复消费新日志。
+    offset = 0;
+    await persistOffset(offsetPath, offset);
+    await rm(interrupted.path, { force: true });
+    await rm(interrupted.offsetPath, { force: true });
   }
 
   return {
     dispose() {
       disposed = true;
+      clearInterval(reapTimer);
       unwatchFile(filePath, onFileChange);
     },
     async pollNow() {
       // 与 watchFile 触发共享同一 processing 闸门，避免并发读同段字节。
-      if (disposed || processing) {
+      if (disposed) {
+        return;
+      }
+      if (processing) {
+        pending = true;
         return;
       }
       processing = true;
       try {
-        await processChanges();
+        await drainChanges();
       } finally {
         processing = false;
       }
@@ -219,30 +360,47 @@ export function createJsonlObserver(opts: JsonlObserverOpts): JsonlObserver {
   };
 }
 
-/**
- * 加载 offset：优先读 offset 文件（崩溃恢复），fallback 到当前文件大小
- * （首次启动跳过历史），文件不存在返回 0。
- */
-function loadOffset(filePath: string, offsetPath: string): number {
+function enrichAgentEventFromRawPayload(
+  event:
+    | AgentHookEventPayload
+    | CommandFinishedHookEvent
+    | CommandStartHookEvent
+): AgentHookEventPayload | CommandFinishedHookEvent | CommandStartHookEvent {
+  if (event.kind !== "agentEvent" || !event.metadataBase64) {
+    return event;
+  }
   try {
-    const raw = readFileSync(offsetPath, "utf8").trim();
-    const n = Number(raw);
-    if (Number.isFinite(n) && n >= 0) {
-      return n;
+    const parsed: unknown = JSON.parse(
+      Buffer.from(event.metadataBase64, "base64").toString("utf8")
+    );
+    if (!(parsed && typeof parsed === "object" && !Array.isArray(parsed))) {
+      return event;
     }
+    const payload = parsed as Record<string, unknown>;
+    const readString = (...keys: string[]): string | undefined => {
+      for (const key of keys) {
+        const value = payload[key];
+        if (typeof value === "string") {
+          return value;
+        }
+      }
+      return;
+    };
+    const candidate = {
+      ...event,
+      agentInstanceId:
+        readString("agent_id", "agentId") ?? event.agentInstanceId,
+      agentType: readString("agent_type", "agentType") ?? event.agentType,
+      sessionId: readString("session_id", "sessionId") ?? event.sessionId,
+      toolName: readString("tool_name", "toolName") ?? event.toolName,
+      toolUseId: readString("tool_use_id", "toolUseId") ?? event.toolUseId,
+      transcriptPath:
+        readString("transcript_path", "transcriptPath") ?? event.transcriptPath,
+      turnId: readString("turn_id", "turnId") ?? event.turnId,
+    };
+    const validated = agentHookEventSchema.safeParse(candidate);
+    return validated.success ? validated.data : event;
   } catch {
-    // offset 文件不存在——首次启动
+    return event;
   }
-  try {
-    return statSync(filePath).size;
-  } catch {
-    return 0;
-  }
-}
-
-/** 异步写 offset 到持久化文件。 */
-async function persistOffset(offsetPath: string, value: number): Promise<void> {
-  await writeFile(offsetPath, String(value)).catch(() => {
-    // offset 写失败仅影响崩溃恢复精度，进程继续跑不阻塞——静默降级即可。
-  });
 }

--- a/src/main/services/foreground-activity/jsonl-rotation.ts
+++ b/src/main/services/foreground-activity/jsonl-rotation.ts
@@ -1,0 +1,108 @@
+import { randomUUID } from "node:crypto";
+import { readFileSync, statSync } from "node:fs";
+import { link, readFile, rm, writeFile } from "node:fs/promises";
+
+export const OFFSET_SUFFIX = ".offset";
+export const ROTATING_SUFFIX = ".rotating";
+export const LOCK_SUFFIX = ".lock";
+
+export interface RotationRecovery {
+  offset: number;
+  offsetPath: string;
+  path: string;
+}
+
+export function prepareInterruptedRotation(
+  filePath: string,
+  offsetPath: string
+): RotationRecovery | null {
+  const rotatedPath = `${filePath}${ROTATING_SUFFIX}`;
+  const rotatedOffsetPath = `${rotatedPath}${OFFSET_SUFFIX}`;
+  try {
+    statSync(rotatedPath);
+  } catch {
+    return null;
+  }
+  return {
+    offset:
+      loadPersistedOffset(rotatedOffsetPath) ??
+      loadOffset(filePath, offsetPath),
+    offsetPath: rotatedOffsetPath,
+    path: rotatedPath,
+  };
+}
+
+export function loadOffset(filePath: string, offsetPath: string): number {
+  const persisted = loadPersistedOffset(offsetPath);
+  if (persisted !== null) return persisted;
+  try {
+    return statSync(filePath).size;
+  } catch {
+    return 0;
+  }
+}
+
+function loadPersistedOffset(offsetPath: string): number | null {
+  try {
+    const value = Number(readFileSync(offsetPath, "utf8").trim());
+    return Number.isFinite(value) && value >= 0 ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function persistOffset(
+  offsetPath: string,
+  value: number
+): Promise<void> {
+  await writeFile(offsetPath, String(value)).catch(() => undefined);
+}
+
+/** 单一 observer 所有的死亡锁回收；外部 writer 禁止调用。 */
+export async function reapStaleRotationLock(path: string): Promise<void> {
+  const current = await readFile(path, "utf8").catch(() => "");
+  const owner = Number(current.split(".", 1)[0]);
+  if (!(current && Number.isInteger(owner) && owner > 0)) return;
+  try {
+    process.kill(owner, 0);
+  } catch {
+    if ((await readFile(path, "utf8").catch(() => "")) === current) {
+      await rm(path, { force: true });
+    }
+  }
+}
+
+export async function acquireRotationLock(
+  path: string,
+  isDisposed: () => boolean
+): Promise<(() => Promise<void>) | null> {
+  // 死亡锁只由单实例、串行 drain 的 observer 回收。所有外部 writer 只等待，
+  // 不参与删除，因此不存在两个 stale waiter 交错误删新 owner 活锁的 ABA。
+  const token = `${process.pid}.${randomUUID()}`;
+  const candidatePath = `${path}.${token}`;
+  await writeFile(candidatePath, token, { flag: "wx" });
+  const deadline = Date.now() + 5000;
+  try {
+    while (!isDisposed() && Date.now() < deadline) {
+      try {
+        await link(candidatePath, path);
+        await rm(candidatePath, { force: true });
+        return async () => {
+          const current = await readFile(path, "utf8").catch(() => "");
+          if (current === token) await rm(path, { force: true });
+        };
+      } catch (error) {
+        const code =
+          error && typeof error === "object" && "code" in error
+            ? String(error.code)
+            : "";
+        if (code !== "EEXIST") throw error;
+        await reapStaleRotationLock(path);
+        await new Promise<void>((resolveDelay) => setTimeout(resolveDelay, 10));
+      }
+    }
+    return null;
+  } finally {
+    await rm(candidatePath, { force: true });
+  }
+}

--- a/src/main/services/foreground-activity/turn-bookkeeping.ts
+++ b/src/main/services/foreground-activity/turn-bookkeeping.ts
@@ -1,0 +1,73 @@
+import type { AgentHookEventPayload } from "@shared/contracts/agent-session.ts";
+import type { HookScope } from "./entry.ts";
+import { TURN_BOUNDARY_EVENTS, TURN_RESET_EVENTS } from "./entry.ts";
+
+/** 回合边界、工具与子代理身份记账。false 表示迟到事件应被吸收。 */
+export function applyTurnBookkeeping(
+  scope: HookScope,
+  event: AgentHookEventPayload
+): boolean {
+  const eventName = event.event;
+  const eventTurnId = event.turnId?.trim();
+  if (
+    (eventName === "Stop" ||
+      eventName === "TurnCompleted" ||
+      eventName === "TurnInterrupted") &&
+    eventTurnId &&
+    scope.currentTurnId &&
+    eventTurnId !== scope.currentTurnId
+  ) {
+    return false;
+  }
+  if (TURN_BOUNDARY_EVENTS.has(eventName)) {
+    scope.turnEnded = true;
+    clearActiveWork(scope);
+  } else if (TURN_RESET_EVENTS.has(eventName)) {
+    scope.turnEnded = false;
+    clearActiveWork(scope);
+    scope.currentTurnId = eventTurnId;
+  } else if (eventName === "PermissionRequest") {
+    scope.turnEnded = false;
+  } else if (scope.turnEnded) {
+    return false;
+  }
+  if (eventName === "Stop" || eventName === "SessionEnd") {
+    clearActiveWork(scope);
+  } else if (eventName === "ToolStart") {
+    const id = event.toolUseId?.trim();
+    if (id) scope.activeToolIds.add(id);
+    else scope.anonymousToolCount += 1;
+  } else if (eventName === "ToolComplete") {
+    const id = event.toolUseId?.trim();
+    if (id) scope.activeToolIds.delete(id);
+    else scope.anonymousToolCount = Math.max(0, scope.anonymousToolCount - 1);
+  } else if (eventName === "SubagentStart") {
+    const id = event.agentInstanceId?.trim();
+    if (id) scope.activeSubagentIds.add(id);
+    else scope.anonymousSubagentCount += 1;
+  } else if (eventName === "SubagentStop") {
+    const id = event.agentInstanceId?.trim();
+    if (id) scope.activeSubagentIds.delete(id);
+    else {
+      scope.anonymousSubagentCount = Math.max(
+        0,
+        scope.anonymousSubagentCount - 1
+      );
+    }
+  }
+  scope.subagentCount =
+    scope.activeSubagentIds.size + scope.anonymousSubagentCount;
+  return true;
+}
+
+function clearActiveWork(scope: HookScope): void {
+  scope.activeSubagentIds.clear();
+  scope.activeToolIds.clear();
+  scope.anonymousSubagentCount = 0;
+  scope.anonymousToolCount = 0;
+  scope.subagentCount = 0;
+}
+
+export function hookScopeHasActiveTools(scope: HookScope): boolean {
+  return scope.activeToolIds.size > 0 || scope.anonymousToolCount > 0;
+}

--- a/src/main/services/foreground-activity/types.ts
+++ b/src/main/services/foreground-activity/types.ts
@@ -33,7 +33,11 @@ export interface ForegroundActivityAggregator {
    * 前台命令退出：双层同清 + 5s 冷却（覆盖崩溃/kill 等无 SessionEnd hook
    * 的路径）。Ctrl+Z 悬挂（145-148）双层保留。
    */
-  ingestCommandFinished(panelId: string, exitCode?: number): void;
+  ingestCommandFinished(
+    panelId: string,
+    exitCode?: number,
+    windowId?: string
+  ): void;
   /** Path B 三 kind 占位入口——本 aggregator 不消费, 保 union 完整。 */
   ingestCommandFinishedHook(event: CommandFinishedHookEvent): void;
   /**
@@ -53,12 +57,12 @@ export interface ForegroundActivityAggregator {
   onChange(cb: (b: ForegroundActivityBroadcast) => void): () => void;
 
   /** panel 关闭 → 清 activity + 冷却拦迟到 hook。 */
-  panelClosed(panelId: string): void;
+  panelClosed(panelId: string, windowId?: string): void;
   /**
    * native pty 进程退出（面板可能仍开着）：task 面板保留终态 activity
    * （只清 hook 证据 + hook 冷却）；其余面板等同 panelClosed。
    */
-  ptyExited(panelId: string): void;
+  ptyExited(panelId: string, windowId?: string): void;
   /** reconcile 对账：该窗口不在 activePanelIds 集合内的活动按 panelClosed 处理。 */
   retainPanels(windowId: string, activePanelIds: readonly string[]): void;
 
@@ -73,7 +77,8 @@ export interface ForegroundActivityAggregator {
       runId: string;
       status: "success" | "failure" | "cancelled";
       exitCode?: number;
-    }
+    },
+    windowId?: string
   ): void;
 
   /** Task 拉起：用户显式操作优先, 双层全清后建 task 层。 */

--- a/src/main/services/tasks/task-service-types.ts
+++ b/src/main/services/tasks/task-service-types.ts
@@ -45,6 +45,7 @@ export interface TaskTerminalProcessController {
 export interface TaskActivityCallbacks {
   onFinished(
     panelId: string,
+    windowId: string | undefined,
     args: {
       runId: string;
       status: "success" | "failure" | "cancelled";

--- a/src/main/services/tasks/task-service.ts
+++ b/src/main/services/tasks/task-service.ts
@@ -302,7 +302,7 @@ export function createTaskService({
         // 只把 pending/running 改为 cancelled；succeeded/failed 节点保留原状态）。
         // 无过滤会把已 success 的 activity 覆盖为 cancelled（终态常驻后即永久谎报）。
         if (node.status === "cancelled") {
-          onTaskActivity?.onFinished(node.panelId, {
+          onTaskActivity?.onFinished(node.panelId, node.windowId, {
             runId: result.runId,
             status: "cancelled",
           });
@@ -335,7 +335,7 @@ export function createTaskService({
         } else {
           activityStatus = exitCode === 0 ? "success" : "failure";
         }
-        onTaskActivity?.onFinished(panelId, {
+        onTaskActivity?.onFinished(panelId, windowId, {
           runId: result.runId,
           status: activityStatus,
           exitCode,

--- a/src/shared/contracts/agent-session.ts
+++ b/src/shared/contracts/agent-session.ts
@@ -48,7 +48,14 @@ const agentEventPayloadSchema = z
     ...baseHookFields,
     agent: agentKindSchema,
     event: z.string().min(1).max(64),
+    metadataBase64: z.string().max(16_384).optional(),
+    agentInstanceId: z.string().max(128).optional(),
+    agentType: z.string().max(128).optional(),
     sessionId: z.string().max(128).optional(),
+    toolName: z.string().max(256).optional(),
+    toolUseId: z.string().max(128).optional(),
+    transcriptPath: z.string().max(8192).optional(),
+    turnId: z.string().max(128).optional(),
   })
   .strict();
 export type AgentHookEventPayload = z.infer<typeof agentEventPayloadSchema>;

--- a/src/shared/contracts/foreground-activity.ts
+++ b/src/shared/contracts/foreground-activity.ts
@@ -124,15 +124,17 @@ export function activityStatusForHookEvent(
     case "PermissionRequest":
       return "waiting";
     case "ToolStart":
-    case "ToolComplete":
       return "tool";
     case "error":
       return "error";
     case "SessionStart":
     case "Stop":
+    case "TurnCompleted":
+    case "TurnInterrupted":
     case "SessionEnd":
       return "ready";
     case "PromptSubmit":
+    case "ToolComplete":
     case "SubagentStart":
     case "SubagentStop":
     case "processing":

--- a/tests/unit/agent-integrations/codex.test.ts
+++ b/tests/unit/agent-integrations/codex.test.ts
@@ -20,6 +20,8 @@ const CODEX_EVENTS = [
   "PermissionRequest",
   "PreCompact",
   "PostCompact",
+  "SubagentStart",
+  "SubagentStop",
   "Stop",
 ];
 
@@ -44,7 +46,7 @@ function matcherEntries(
 }
 
 describe("withPierCodexHooks", () => {
-  it("为 8 个 Codex hook 事件各注入一条 pier 命令", () => {
+  it("为当前 Codex hook 事件各注入一条 pier 命令", () => {
     const next = withPierCodexHooks({});
     const hooks = next.hooks as Record<string, unknown[]>;
     for (const evt of CODEX_EVENTS) {
@@ -181,8 +183,8 @@ describe("install/uninstallCodexHooks (文件 IO)", () => {
   });
 });
 
-describe("安装遗留清理（spec 事件表更迭后清理旧 pier 条目）", () => {
-  it("清理上一版装过但已从 spec 移除的事件下的 pier 条目", async () => {
+describe("安装遗留更新（spec 事件表更迭后替换旧 pier 条目）", () => {
+  it("替换旧版 Subagent 事件下的 pier 条目并保留用户条目", async () => {
     const dir = await mkdtemp(join(tmpdir(), "pier-codex-legacy-"));
     const path = join(dir, "hooks.json");
     // 模拟上一版装过 SubagentStart/SubagentStop 的遗留:
@@ -220,13 +222,12 @@ describe("安装遗留清理（spec 事件表更迭后清理旧 pier 条目）",
     await installCodexHooks(path);
     const installed = JSON.parse(await readFile(path, "utf8"));
     const hooks = installed.hooks as Record<string, unknown[]>;
-    // pier 从 SubagentStart 里被清理, 用户其他条目保留;
-    // SubagentStop 全部是 pier 条目 → 键被清空并删除。
-    expect(hooks.SubagentStart).toHaveLength(1);
-    expect("SubagentStop" in hooks).toBe(false);
-    // 当前 spec 事件都装到঩了。
+    // 旧 pier 条目被替换为当前命令，用户其他条目保留。
+    expect(hooks.SubagentStart).toHaveLength(2);
+    expect(hooks.SubagentStop).toHaveLength(1);
+    // 当前 spec 事件都已安装。
     for (const evt of CODEX_EVENTS) {
-      expect(hooks[evt], evt).toHaveLength(1);
+      expect(hooks[evt], evt).toHaveLength(evt === "SubagentStart" ? 2 : 1);
     }
   });
 });

--- a/tests/unit/agent-integrations/kilo.test.ts
+++ b/tests/unit/agent-integrations/kilo.test.ts
@@ -105,8 +105,10 @@ describe("buildKiloPluginSource", () => {
     expect(source).not.toContain("permission.updated");
     expect(source).toContain('"tool.execute.before"');
     expect(source).toContain('"tool.execute.after"');
-    expect(source).toContain('pierEmit("ToolStart")');
-    expect(source).toContain('pierEmit("ToolComplete")');
+    expect(source).toContain('pierEmit("ToolStart", args)');
+    expect(source).toContain('pierEmit("ToolComplete", args)');
+    expect(source).toContain("value.info || value.session || value.thread");
+    expect(source).toContain("toolUseId");
   });
 
   it("不装 PromptSubmit：command.executed payload 未确认, session.status(busy/retry) 已提供 TURN_RESET", async () => {

--- a/tests/unit/agent-integrations/mimo-code.test.ts
+++ b/tests/unit/agent-integrations/mimo-code.test.ts
@@ -73,8 +73,11 @@ describe("buildMimoCodePluginSource", () => {
     expect(source).toContain('"permission.replied") return "processing"');
     expect(source).toContain('"tool.execute.before"');
     expect(source).toContain('"tool.execute.after"');
-    expect(source).toContain('emitPierEvent("ToolStart")');
-    expect(source).toContain('emitPierEvent("ToolComplete")');
+    expect(source).toContain('emitPierEvent("ToolStart", args)');
+    expect(source).toContain('emitPierEvent("ToolComplete", args)');
+    expect(source).toContain('event.type === "session.deleted"');
+    expect(source).toContain("value.info || value.session || value.thread");
+    expect(source).toContain("toolUseId");
   });
 
   it("无加载合成 SessionStart：factory 体到 return 之间无独立 emit（真实 session.created 覆盖）", () => {

--- a/tests/unit/agent-integrations/opencode.test.ts
+++ b/tests/unit/agent-integrations/opencode.test.ts
@@ -77,8 +77,11 @@ describe("buildOpencodePluginSource", () => {
     expect(source).toContain('"permission.replied") return "processing"');
     expect(source).toContain('"tool.execute.before"');
     expect(source).toContain('"tool.execute.after"');
-    expect(source).toContain('emitPierEvent("ToolStart")');
-    expect(source).toContain('emitPierEvent("ToolComplete")');
+    expect(source).toContain('emitPierEvent("ToolStart", args)');
+    expect(source).toContain('emitPierEvent("ToolComplete", args)');
+    expect(source).toContain('event.type === "session.deleted"');
+    expect(source).toContain("value.info || value.session || value.thread");
+    expect(source).toContain("toolUseId");
   });
 
   it("无加载合成 SessionStart：factory 体到 return 之间无独立 emit（真实 session.created 覆盖）", () => {

--- a/tests/unit/agent-session-contract.test.ts
+++ b/tests/unit/agent-session-contract.test.ts
@@ -105,10 +105,11 @@ describe("activityStatusForHookEvent", () => {
   it.each([
     ["PermissionRequest", "waiting"],
     ["ToolStart", "tool"],
-    ["ToolComplete", "tool"],
+    ["ToolComplete", "processing"],
     ["error", "error"],
     ["SessionStart", "ready"],
     ["Stop", "ready"],
+    ["TurnCompleted", "ready"],
     ["SessionEnd", "ready"],
     ["PromptSubmit", "processing"],
     ["SubagentStart", "processing"],

--- a/tests/unit/main/agent-hooks-install.test.ts
+++ b/tests/unit/main/agent-hooks-install.test.ts
@@ -89,6 +89,9 @@ describe("installAgentHooksEmitScript", () => {
     expect(parsed.panelId).toBe("p1");
     expect(parsed.windowId).toBe("w1");
     expect(typeof parsed.pid).toBe("number");
+    await expect(stat(`${logPath}.lock`)).rejects.toMatchObject({
+      code: "ENOENT",
+    });
   });
 
   it("agentEvent kind 第 4 个参数写入可选 sessionId", async () => {

--- a/tests/unit/main/codex-transcript-reconciler.test.ts
+++ b/tests/unit/main/codex-transcript-reconciler.test.ts
@@ -1,0 +1,292 @@
+import { appendFileSync, writeFileSync } from "node:fs";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AgentHookEventPayload } from "@shared/contracts/agent-session.ts";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createCodexTranscriptReconciler } from "../../../src/main/services/agents/integrations/codex-transcript-reconciler.ts";
+
+function hookEvent(
+  transcriptPath: string,
+  turnId: string
+): AgentHookEventPayload {
+  return {
+    agent: "codex",
+    event: "PromptSubmit",
+    kind: "agentEvent",
+    panelId: "panel-1",
+    sessionId: "session-1",
+    transcriptPath,
+    turnId,
+    v: 1,
+    windowId: "1",
+  };
+}
+
+describe("codex transcript reconciler", () => {
+  let dir: string;
+  let path: string;
+  let transcriptRoot: string;
+
+  beforeEach(async () => {
+    vi.useRealTimers();
+    dir = await mkdtemp(join(tmpdir(), "pier-codex-transcript-"));
+    transcriptRoot = join(dir, "sessions");
+    await mkdir(transcriptRoot);
+    path = join(transcriptRoot, "rollout.jsonl");
+    writeFileSync(path, '{"type":"session_meta"}\n');
+  });
+
+  afterEach(async () => {
+    await rm(dir, { force: true, recursive: true });
+  });
+
+  it("把 Esc 中断记录对账为 TurnInterrupted", async () => {
+    const received: AgentHookEventPayload[] = [];
+    const reconciler = createCodexTranscriptReconciler({
+      onTerminalEvent: (event) => received.push(event),
+      transcriptRoot,
+    });
+    await reconciler.observe(hookEvent(path, "turn-1"));
+    appendFileSync(
+      path,
+      `${JSON.stringify({
+        type: "event_msg",
+        payload: {
+          reason: "interrupted",
+          turn_id: "turn-1",
+          type: "turn_aborted",
+        },
+      })}\n`
+    );
+
+    await vi.waitFor(() => {
+      expect(received).toHaveLength(1);
+    });
+    expect(received[0]).toMatchObject({
+      event: "TurnInterrupted",
+      panelId: "panel-1",
+      turnId: "turn-1",
+      windowId: "1",
+    });
+    reconciler.dispose();
+  });
+
+  it("把正常完成记录对账为 TurnCompleted，并按 turn 去重", async () => {
+    const received: AgentHookEventPayload[] = [];
+    const reconciler = createCodexTranscriptReconciler({
+      onTerminalEvent: (event) => received.push(event),
+      transcriptRoot,
+    });
+    await reconciler.observe(hookEvent(path, "turn-2"));
+    const line = `${JSON.stringify({
+      type: "event_msg",
+      payload: { turn_id: "turn-2", type: "task_complete" },
+    })}\n`;
+    appendFileSync(path, line + line);
+
+    await vi.waitFor(() => {
+      expect(received).toHaveLength(1);
+    });
+    expect(received[0]?.event).toBe("TurnCompleted");
+    reconciler.dispose();
+  });
+
+  it("缺少 turn_id 的多个终态不会跨回合误去重", async () => {
+    const received: AgentHookEventPayload[] = [];
+    const reconciler = createCodexTranscriptReconciler({
+      onTerminalEvent: (event) => received.push(event),
+      transcriptRoot,
+    });
+    await reconciler.observe(hookEvent(path, "turn-1"));
+    const aborted = `${JSON.stringify({
+      payload: { reason: "interrupted", type: "turn_aborted" },
+      type: "event_msg",
+    })}\n`;
+    appendFileSync(path, aborted);
+    await vi.waitFor(() => expect(received).toHaveLength(1));
+    await reconciler.observe(hookEvent(path, "turn-2"));
+    appendFileSync(path, aborted);
+    await vi.waitFor(() => expect(received).toHaveLength(2));
+    reconciler.dispose();
+  });
+
+  it("拒绝 Codex sessions 根目录之外的 transcript 路径", async () => {
+    const outside = join(dir, "outside.jsonl");
+    writeFileSync(outside, '{"type":"session_meta"}\n');
+    const received: AgentHookEventPayload[] = [];
+    const reconciler = createCodexTranscriptReconciler({
+      onTerminalEvent: (event) => received.push(event),
+      transcriptRoot,
+    });
+
+    await reconciler.observe(hookEvent(outside, "turn-outside"));
+    appendFileSync(
+      outside,
+      '{"type":"event_msg","payload":{"type":"task_complete"}}\n'
+    );
+    await new Promise<void>((resolveDelay) => setTimeout(resolveDelay, 300));
+
+    expect(received).toHaveLength(0);
+    reconciler.dispose();
+  });
+
+  it("同一路径并发首次 observe 只创建一个监听并只派发一次", async () => {
+    const received: AgentHookEventPayload[] = [];
+    const reconciler = createCodexTranscriptReconciler({
+      onTerminalEvent: (event) => received.push(event),
+      transcriptRoot,
+    });
+    const event = hookEvent(path, "turn-concurrent");
+
+    await Promise.all([reconciler.observe(event), reconciler.observe(event)]);
+    appendFileSync(
+      path,
+      '{"type":"event_msg","payload":{"turn_id":"turn-concurrent","type":"task_complete"}}\n'
+    );
+    await vi.waitFor(() => expect(received).toHaveLength(1));
+
+    reconciler.dispose();
+  });
+
+  it("面板释放后停止监听 transcript", async () => {
+    const received: AgentHookEventPayload[] = [];
+    const reconciler = createCodexTranscriptReconciler({
+      onTerminalEvent: (event) => received.push(event),
+      transcriptRoot,
+    });
+    await reconciler.observe(hookEvent(path, "turn-release"));
+
+    reconciler.releasePanel("panel-1", "1");
+    appendFileSync(
+      path,
+      '{"type":"event_msg","payload":{"turn_id":"turn-release","type":"task_complete"}}\n'
+    );
+    await new Promise<void>((resolveDelay) => setTimeout(resolveDelay, 300));
+
+    expect(received).toHaveLength(0);
+    reconciler.dispose();
+  });
+
+  it("并发首次 observe 尚未完成时释放面板，不会晚建 watcher", async () => {
+    const received: AgentHookEventPayload[] = [];
+    const reconciler = createCodexTranscriptReconciler({
+      onTerminalEvent: (event) => received.push(event),
+      transcriptRoot,
+    });
+
+    const observing = reconciler.observe(hookEvent(path, "turn-race"));
+    reconciler.releasePanel("panel-1", "1");
+    await observing;
+    appendFileSync(
+      path,
+      '{"type":"event_msg","payload":{"turn_id":"turn-race","type":"task_complete"}}\n'
+    );
+    await new Promise<void>((resolveDelay) => setTimeout(resolveDelay, 300));
+
+    expect(received).toHaveLength(0);
+    reconciler.dispose();
+  });
+
+  it("retain 对账能取消尚在创建中的 inactive panel watcher", async () => {
+    const received: AgentHookEventPayload[] = [];
+    const reconciler = createCodexTranscriptReconciler({
+      onTerminalEvent: (event) => received.push(event),
+      transcriptRoot,
+    });
+    const observing = reconciler.observe(hookEvent(path, "turn-retain-race"));
+
+    reconciler.releasePanelsWhere(
+      (panelId, windowId) => windowId === "1" && panelId === "panel-1"
+    );
+    await observing;
+    appendFileSync(
+      path,
+      '{"type":"event_msg","payload":{"turn_id":"turn-retain-race","type":"task_complete"}}\n'
+    );
+    await new Promise<void>((resolveDelay) => setTimeout(resolveDelay, 300));
+
+    expect(received).toHaveLength(0);
+    reconciler.dispose();
+  });
+
+  it("同一 transcript 的多个面板独立持有，释放其一不关闭另一方", async () => {
+    const received: AgentHookEventPayload[] = [];
+    const reconciler = createCodexTranscriptReconciler({
+      onTerminalEvent: (event) => received.push(event),
+      transcriptRoot,
+    });
+    await Promise.all([
+      reconciler.observe({
+        ...hookEvent(path, "turn-a"),
+        panelId: "panel-a",
+      }),
+      reconciler.observe({
+        ...hookEvent(path, "turn-b"),
+        panelId: "panel-b",
+      }),
+    ]);
+
+    reconciler.releasePanel("panel-b", "1");
+    appendFileSync(
+      path,
+      '{"type":"event_msg","payload":{"turn_id":"turn-a","type":"task_complete"}}\n'
+    );
+    await vi.waitFor(() => expect(received).toHaveLength(1));
+
+    expect(received[0]).toMatchObject({
+      event: "TurnCompleted",
+      panelId: "panel-a",
+    });
+    reconciler.dispose();
+  });
+
+  it("跳过超过 1 MiB 的 transcript 单行后仍能读取终态", async () => {
+    const received: AgentHookEventPayload[] = [];
+    const reconciler = createCodexTranscriptReconciler({
+      onTerminalEvent: (event) => received.push(event),
+      transcriptRoot,
+    });
+    await reconciler.observe(hookEvent(path, "turn-large"));
+
+    appendFileSync(
+      path,
+      `${JSON.stringify({ payload: "x".repeat(1024 * 1024 + 100) })}\n${JSON.stringify(
+        {
+          payload: { turn_id: "turn-large", type: "task_complete" },
+          type: "event_msg",
+        }
+      )}\n`
+    );
+    await vi.waitFor(() => expect(received).toHaveLength(1));
+
+    expect(received[0]?.event).toBe("TurnCompleted");
+    reconciler.dispose();
+  });
+
+  it("同一面板切换大量 transcript 时淘汰旧 watcher，不触发 32 项上限", async () => {
+    const received: AgentHookEventPayload[] = [];
+    const reconciler = createCodexTranscriptReconciler({
+      onTerminalEvent: (event) => received.push(event),
+      transcriptRoot,
+    });
+    let latestPath = path;
+    for (let index = 0; index < 40; index += 1) {
+      latestPath = join(transcriptRoot, `rollout-${index}.jsonl`);
+      writeFileSync(latestPath, '{"type":"session_meta"}\n');
+      await reconciler.observe(hookEvent(latestPath, `turn-${index}`));
+    }
+
+    appendFileSync(
+      latestPath,
+      '{"type":"event_msg","payload":{"turn_id":"turn-39","type":"task_complete"}}\n'
+    );
+    await vi.waitFor(() => expect(received).toHaveLength(1));
+
+    expect(received[0]).toMatchObject({
+      event: "TurnCompleted",
+      turnId: "turn-39",
+    });
+    reconciler.dispose();
+  });
+});

--- a/tests/unit/main/codex-transcript-reconciler.test.ts
+++ b/tests/unit/main/codex-transcript-reconciler.test.ts
@@ -92,6 +92,30 @@ describe("codex transcript reconciler", () => {
     reconciler.dispose();
   });
 
+  it("终态先于对应 hook 到达时暂存，注册 turn 上下文后补派发", async () => {
+    const received: AgentHookEventPayload[] = [];
+    const reconciler = createCodexTranscriptReconciler({
+      onTerminalEvent: (event) => received.push(event),
+      transcriptRoot,
+    });
+    await reconciler.observe(hookEvent(path, "turn-existing"));
+    appendFileSync(
+      path,
+      '{"type":"event_msg","payload":{"reason":"interrupted","turn_id":"turn-late-hook","type":"turn_aborted"}}\n'
+    );
+    await new Promise<void>((resolveDelay) => setTimeout(resolveDelay, 300));
+    expect(received).toHaveLength(0);
+
+    await reconciler.observe(hookEvent(path, "turn-late-hook"));
+
+    expect(received).toHaveLength(1);
+    expect(received[0]).toMatchObject({
+      event: "TurnInterrupted",
+      turnId: "turn-late-hook",
+    });
+    reconciler.dispose();
+  });
+
   it("缺少 turn_id 的多个终态不会跨回合误去重", async () => {
     const received: AgentHookEventPayload[] = [];
     const reconciler = createCodexTranscriptReconciler({

--- a/tests/unit/main/foreground-activity-aggregator.test.ts
+++ b/tests/unit/main/foreground-activity-aggregator.test.ts
@@ -130,15 +130,44 @@ describe("ForegroundActivityAggregator", () => {
     agg.dispose();
   });
 
-  it("ToolStart / ToolComplete → status=tool", () => {
+  it("ToolStart → tool，最后一个 ToolComplete → processing", () => {
     const agg = createForegroundActivityAggregator({ now });
     agg.ingestAgentEvent(hookEvent("PromptSubmit"));
-    agg.ingestAgentEvent(hookEvent("ToolStart"));
+    agg.ingestAgentEvent(
+      agentHookEvent({ event: "ToolStart", toolUseId: "tool-1" })
+    );
     let a = agg.snapshot().activities[0] as AgentActivity;
     expect(a.status).toBe("tool");
-    agg.ingestAgentEvent(hookEvent("ToolComplete"));
+    agg.ingestAgentEvent(
+      agentHookEvent({ event: "ToolComplete", toolUseId: "tool-1" })
+    );
     a = agg.snapshot().activities[0] as AgentActivity;
-    expect(a.status).toBe("tool");
+    expect(a.status).toBe("processing");
+    agg.dispose();
+  });
+
+  it("并发工具按 toolUseId 幂等记账，全部完成后才离开 tool", () => {
+    const agg = createForegroundActivityAggregator({ now });
+    agg.ingestAgentEvent(hookEvent("PromptSubmit"));
+    agg.ingestAgentEvent(
+      agentHookEvent({ event: "ToolStart", toolUseId: "a" })
+    );
+    agg.ingestAgentEvent(
+      agentHookEvent({ event: "ToolStart", toolUseId: "b" })
+    );
+    agg.ingestAgentEvent(
+      agentHookEvent({ event: "ToolStart", toolUseId: "a" })
+    );
+    agg.ingestAgentEvent(
+      agentHookEvent({ event: "ToolComplete", toolUseId: "a" })
+    );
+    expect((agg.snapshot().activities[0] as AgentActivity).status).toBe("tool");
+    agg.ingestAgentEvent(
+      agentHookEvent({ event: "ToolComplete", toolUseId: "b" })
+    );
+    expect((agg.snapshot().activities[0] as AgentActivity).status).toBe(
+      "processing"
+    );
     agg.dispose();
   });
 
@@ -151,6 +180,63 @@ describe("ForegroundActivityAggregator", () => {
     agg.ingestAgentEvent(hookEvent("ToolStart"));
     a = agg.snapshot().activities[0] as AgentActivity;
     expect(a.status).toBe("tool");
+    agg.dispose();
+  });
+
+  it("TurnInterrupted → ready，并吸收迟到的工具完成事件", () => {
+    const agg = createForegroundActivityAggregator({ now });
+    agg.ingestAgentEvent(hookEvent("PromptSubmit"));
+    agg.ingestAgentEvent(hookEvent("ToolStart"));
+    agg.ingestAgentEvent(hookEvent("TurnInterrupted"));
+    let activity = agg.snapshot().activities[0] as AgentActivity;
+    expect(activity.status).toBe("ready");
+    agg.ingestAgentEvent(hookEvent("ToolComplete"));
+    activity = agg.snapshot().activities[0] as AgentActivity;
+    expect(activity.status).toBe("ready");
+    agg.dispose();
+  });
+
+  it("TurnCompleted → ready，并吸收迟到的工具事件", () => {
+    const agg = createForegroundActivityAggregator({ now });
+    agg.ingestAgentEvent(
+      agentHookEvent({ event: "PromptSubmit", turnId: "turn-complete" })
+    );
+    agg.ingestAgentEvent(
+      agentHookEvent({ event: "TurnCompleted", turnId: "turn-complete" })
+    );
+    agg.ingestAgentEvent(
+      agentHookEvent({ event: "ToolStart", toolUseId: "late-tool" })
+    );
+    expect((agg.snapshot().activities[0] as AgentActivity).status).toBe(
+      "ready"
+    );
+    agg.dispose();
+  });
+
+  it("旧 turn 的迟到 TurnInterrupted 不会冻结当前回合", () => {
+    const agg = createForegroundActivityAggregator({ now });
+    agg.ingestAgentEvent(
+      agentHookEvent({ event: "PromptSubmit", turnId: "turn-1" })
+    );
+    agg.ingestAgentEvent(
+      agentHookEvent({ event: "PromptSubmit", turnId: "turn-2" })
+    );
+    expect(
+      agg.ingestAgentEvent(
+        agentHookEvent({ event: "TurnInterrupted", turnId: "turn-1" })
+      )
+    ).toBe(false);
+    let activity = agg.snapshot().activities[0] as AgentActivity;
+    expect(activity.status).toBe("processing");
+    agg.ingestAgentEvent(
+      agentHookEvent({
+        event: "ToolStart",
+        toolUseId: "tool-2",
+        turnId: "turn-2",
+      })
+    );
+    activity = agg.snapshot().activities[0] as AgentActivity;
+    expect(activity.status).toBe("tool");
     agg.dispose();
   });
 
@@ -232,6 +318,30 @@ describe("ForegroundActivityAggregator", () => {
       agentHookEvent({ event: "SessionEnd", pid: 1002, sessionId: "s2" })
     );
     expect(agg.snapshot().activities).toHaveLength(0);
+    agg.dispose();
+  });
+
+  it("旧 session 的重复 SessionEnd 不会被当作当前会话终态", () => {
+    const agg = createForegroundActivityAggregator({ now });
+    agg.ingestAgentEvent(
+      agentHookEvent({ event: "PromptSubmit", sessionId: "old" })
+    );
+    expect(
+      agg.ingestAgentEvent(
+        agentHookEvent({ event: "SessionEnd", sessionId: "old" })
+      )
+    ).toBe(true);
+    advance(1501);
+    agg.ingestAgentEvent(
+      agentHookEvent({ event: "PromptSubmit", sessionId: "current" })
+    );
+    expect(
+      agg.ingestAgentEvent(
+        agentHookEvent({ event: "SessionEnd", sessionId: "old" })
+      )
+    ).toBe(false);
+    const activity = agg.snapshot().activities[0] as AgentActivity;
+    expect(activity.status).toBe("processing");
     agg.dispose();
   });
 
@@ -348,6 +458,36 @@ describe("ForegroundActivityAggregator", () => {
     // panel 关闭才清
     agg.panelClosed("p1");
     expect(agg.snapshot().activities).toHaveLength(0);
+    agg.dispose();
+  });
+
+  it("跨窗口同 panelId 的 taskFinished 只更新目标窗口", () => {
+    const agg = createForegroundActivityAggregator({ now });
+    agg.taskLaunched("same-panel", "w-1", {
+      label: "one",
+      runId: "run-1",
+      taskId: "task-1",
+    });
+    agg.taskLaunched("same-panel", "w-2", {
+      label: "two",
+      runId: "run-2",
+      taskId: "task-2",
+    });
+
+    agg.taskFinished(
+      "same-panel",
+      { runId: "run-1", status: "success" },
+      "w-1"
+    );
+
+    expect(agg.snapshot("w-1").activities[0]).toMatchObject({
+      status: "success",
+      windowId: "w-1",
+    });
+    expect(agg.snapshot("w-2").activities[0]).toMatchObject({
+      status: "running",
+      windowId: "w-2",
+    });
     agg.dispose();
   });
 
@@ -491,6 +631,28 @@ describe("ForegroundActivityAggregator", () => {
     agg.dispose();
   });
 
+  it("子代理按 agentInstanceId 幂等记账，重复事件不漂移", () => {
+    const agg = createForegroundActivityAggregator({ now });
+    agg.ingestAgentEvent(hookEvent("PromptSubmit"));
+    agg.ingestAgentEvent(
+      agentHookEvent({ event: "SubagentStart", agentInstanceId: "worker-1" })
+    );
+    agg.ingestAgentEvent(
+      agentHookEvent({ event: "SubagentStart", agentInstanceId: "worker-1" })
+    );
+    let activity = agg.snapshot().activities[0] as AgentActivity;
+    expect(activity.subagentCount).toBe(1);
+    agg.ingestAgentEvent(
+      agentHookEvent({ event: "SubagentStop", agentInstanceId: "worker-1" })
+    );
+    agg.ingestAgentEvent(
+      agentHookEvent({ event: "SubagentStop", agentInstanceId: "worker-1" })
+    );
+    activity = agg.snapshot().activities[0] as AgentActivity;
+    expect(activity.subagentCount).toBe(0);
+    agg.dispose();
+  });
+
   it("snapshot(windowId) 过滤只返回该窗口 activity", () => {
     const agg = createForegroundActivityAggregator({ now });
     agg.ingestAgentEvent(hookEvent("PromptSubmit", "p1", "1"));
@@ -498,6 +660,20 @@ describe("ForegroundActivityAggregator", () => {
     expect(agg.snapshot("1").activities).toHaveLength(1);
     expect(agg.snapshot("1").activities[0]?.windowId).toBe("1");
     expect(agg.snapshot("2").activities).toHaveLength(1);
+    agg.dispose();
+  });
+
+  it("相同 panelId 在不同窗口使用独立 slot", () => {
+    const agg = createForegroundActivityAggregator({ now });
+    agg.ingestAgentEvent(hookEvent("PromptSubmit", "shared", "1"));
+    agg.ingestAgentEvent(hookEvent("PromptSubmit", "shared", "2"));
+    expect(agg.snapshot().activities).toHaveLength(2);
+
+    agg.panelClosed("shared", "1");
+    const remaining = agg.snapshot().activities;
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0]?.panelId).toBe("shared");
+    expect(remaining[0]?.windowId).toBe("2");
     agg.dispose();
   });
 

--- a/tests/unit/main/jsonl-observer.test.ts
+++ b/tests/unit/main/jsonl-observer.test.ts
@@ -1,5 +1,5 @@
 import { appendFileSync, writeFileSync } from "node:fs";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { AgentHookEventPayload } from "@shared/contracts/agent-session.ts";
@@ -67,7 +67,31 @@ describe("jsonl-observer", () => {
     observer.dispose();
   }, 20_000);
 
-  it("rotate：超 10MB 后截断保留 tail 1000 行", async () => {
+  it("drain：处理期间追加最终事件并再次唤醒，不会永久漏读", async () => {
+    writeFileSync(jsonlPath, "");
+    const received: AgentHookEventPayload[] = [];
+    let observer: ReturnType<typeof createJsonlObserver>;
+    observer = createJsonlObserver({
+      filePath: jsonlPath,
+      onAgentEvent(event) {
+        received.push(event);
+        if (event.event === "evt-1") {
+          appendFileSync(jsonlPath, `${eventLine(2)}\n`);
+          observer.pollNow().catch(() => undefined);
+        }
+      },
+      onCommandFinished() {},
+      onCommandStart() {},
+    });
+
+    appendFileSync(jsonlPath, `${eventLine(1)}\n`);
+    await observer.pollNow();
+
+    expect(received.map((event) => event.event)).toEqual(["evt-1", "evt-2"]);
+    observer.dispose();
+  });
+
+  it("rotate：超 10MB 时先派发未读事件，再原子切换到新日志", async () => {
     // 写 100000 行（每行约 90 字节 → ~9MB，不够。加大内容让它超 10MB）
     const lines: string[] = [];
     for (let i = 0; i < 100_000; i++) {
@@ -85,10 +109,11 @@ describe("jsonl-observer", () => {
       );
     }
     writeFileSync(jsonlPath, `${lines.join("\n")}\n`);
+    const received: AgentHookEventPayload[] = [];
     const observer = createJsonlObserver({
       filePath: jsonlPath,
-      onAgentEvent() {
-        // rotate 后不该有历史事件回放
+      onAgentEvent(event) {
+        received.push(event);
       },
       onCommandFinished() {
         // 未消费——本 case 只测 agentEvent 路径。
@@ -105,16 +130,8 @@ describe("jsonl-observer", () => {
     appendFileSync(jsonlPath, `${eventLine(999_999)}\n`);
     await observer.pollNow();
 
-    const finalContent = await readFile(jsonlPath, "utf8");
-    const finalLines = finalContent.split("\n").filter((l) => l.trim());
-    expect(finalLines).toHaveLength(1000);
-    // 最后一行应是追加的那行
-    const last = finalLines.at(-1);
-    if (!last) {
-      throw new Error("empty finalLines after rotate");
-    }
-    const lastParsed = JSON.parse(last);
-    expect(lastParsed.event).toBe("evt-999999");
+    expect(received.map((event) => event.event)).toEqual(["evt-999999"]);
+    expect(await readFile(jsonlPath, "utf8")).toBe("");
 
     observer.dispose();
   }, 20_000);
@@ -155,6 +172,101 @@ describe("jsonl-observer", () => {
 
     observer.dispose();
   }, 20_000);
+
+  it("启动时恢复中断的轮转文件，按旧 offset 继续且不漏新日志", async () => {
+    const oldProcessed = `${eventLine(0)}\n`;
+    writeFileSync(`${jsonlPath}.rotating`, `${oldProcessed}${eventLine(1)}\n`);
+    writeFileSync(jsonlPath, `${eventLine(2)}\n`);
+    writeFileSync(offsetPath, String(Buffer.byteLength(oldProcessed)));
+    const received: AgentHookEventPayload[] = [];
+    const observer = createJsonlObserver({
+      filePath: jsonlPath,
+      onAgentEvent: (event) => received.push(event),
+      onCommandFinished() {},
+      onCommandStart() {},
+    });
+
+    await observer.pollNow();
+
+    expect(received.map((event) => event.event)).toEqual(["evt-1", "evt-2"]);
+    observer.dispose();
+  });
+
+  it("轮转在创建新日志前崩溃：只有 rotating 文件也能恢复", async () => {
+    const processed = `${eventLine(0)}\n`;
+    writeFileSync(`${jsonlPath}.rotating`, `${processed}${eventLine(1)}\n`);
+    writeFileSync(
+      `${jsonlPath}.rotating.offset`,
+      String(Buffer.byteLength(processed))
+    );
+    const received: AgentHookEventPayload[] = [];
+    const observer = createJsonlObserver({
+      filePath: jsonlPath,
+      onAgentEvent: (event) => received.push(event),
+      onCommandFinished() {},
+      onCommandStart() {},
+    });
+
+    await observer.pollNow();
+
+    expect(received.map((event) => event.event)).toEqual(["evt-1"]);
+    expect(await readFile(jsonlPath, "utf8")).toBe(
+      `${processed}${eventLine(1)}\n`
+    );
+    observer.dispose();
+  });
+
+  it("中断轮转恢复可重入：恢复完成后重启不会重复派发", async () => {
+    const processed = `${eventLine(0)}\n`;
+    writeFileSync(`${jsonlPath}.rotating`, `${processed}${eventLine(1)}\n`);
+    writeFileSync(jsonlPath, `${eventLine(2)}\n`);
+    writeFileSync(
+      `${jsonlPath}.rotating.offset`,
+      String(Buffer.byteLength(processed))
+    );
+    const received: AgentHookEventPayload[] = [];
+    const createObserver = () =>
+      createJsonlObserver({
+        filePath: jsonlPath,
+        onAgentEvent: (event) => received.push(event),
+        onCommandFinished() {},
+        onCommandStart() {},
+      });
+
+    const first = createObserver();
+    await first.pollNow();
+    first.dispose();
+    const second = createObserver();
+    await second.pollNow();
+
+    expect(received.map((event) => event.event)).toEqual(["evt-1", "evt-2"]);
+    second.dispose();
+  });
+
+  it("中断轮转旧文件以半行结尾时报告错误并继续消费新日志", async () => {
+    const processed = `${eventLine(0)}\n`;
+    writeFileSync(`${jsonlPath}.rotating`, `${processed}{half-json`);
+    writeFileSync(jsonlPath, `${eventLine(2)}\n`);
+    writeFileSync(
+      `${jsonlPath}.rotating.offset`,
+      String(Buffer.byteLength(processed))
+    );
+    const received: AgentHookEventPayload[] = [];
+    const errors: unknown[] = [];
+    const observer = createJsonlObserver({
+      filePath: jsonlPath,
+      onAgentEvent: (event) => received.push(event),
+      onCommandFinished() {},
+      onCommandStart() {},
+      onError: (error) => errors.push(error),
+    });
+
+    await observer.pollNow();
+
+    expect(received.map((event) => event.event)).toEqual(["evt-2"]);
+    expect(errors).toHaveLength(1);
+    observer.dispose();
+  });
 
   it("半行不丢：无换行尾部半行不派发不报错, 补齐后完整派发", async () => {
     writeFileSync(jsonlPath, "");
@@ -269,4 +381,91 @@ describe("jsonl-observer", () => {
 
     observer.dispose();
   }, 20_000);
+
+  it("超过 1 MiB 的单行不会造成大分配或阻塞后续事件", async () => {
+    writeFileSync(jsonlPath, "");
+    const received: AgentHookEventPayload[] = [];
+    const errors: unknown[] = [];
+    const observer = createJsonlObserver({
+      filePath: jsonlPath,
+      onAgentEvent: (event) => received.push(event),
+      onCommandFinished() {},
+      onCommandStart() {},
+      onError: (error) => errors.push(error),
+    });
+
+    appendFileSync(
+      jsonlPath,
+      `${"x".repeat(1024 * 1024 + 100)}\n${eventLine(9)}\n`
+    );
+    await observer.pollNow();
+
+    expect(received.map((event) => event.event)).toEqual(["evt-9"]);
+    expect(errors.length).toBeGreaterThan(0);
+    observer.dispose();
+  });
+
+  it("writer 在 append 前崩溃留下死亡锁时，周期回收无需主日志变化", async () => {
+    writeFileSync(jsonlPath, "");
+    const lockPath = `${jsonlPath}.lock`;
+    writeFileSync(lockPath, "99999999.crashed-writer");
+    const observer = createJsonlObserver({
+      filePath: jsonlPath,
+      onAgentEvent() {},
+      onCommandFinished() {},
+      onCommandStart() {},
+    });
+
+    await vi.waitFor(
+      async () => {
+        await expect(stat(lockPath)).rejects.toMatchObject({ code: "ENOENT" });
+      },
+      { timeout: 2500 }
+    );
+
+    observer.dispose();
+  });
+
+  it("原始 hook payload 只读取顶层身份字段，不受 tool_input 同名字段污染", async () => {
+    writeFileSync(jsonlPath, "");
+    const received: AgentHookEventPayload[] = [];
+    const observer = createJsonlObserver({
+      filePath: jsonlPath,
+      onAgentEvent: (event) => received.push(event),
+      onCommandFinished() {},
+      onCommandStart() {},
+    });
+    const rawPayload = {
+      agent_id: "worker-top",
+      session_id: "session-top",
+      tool_input: {
+        agent_id: "worker-nested",
+        session_id: "session-nested",
+      },
+      tool_use_id: "tool-top",
+      turn_id: "turn-top",
+    };
+    const line = JSON.stringify({
+      agent: "codex",
+      event: "ToolStart",
+      kind: "agentEvent",
+      panelId: "panel-1",
+      metadataBase64: Buffer.from(JSON.stringify(rawPayload)).toString(
+        "base64"
+      ),
+      sessionId: "session-nested",
+      v: 1,
+      windowId: "1",
+    });
+    appendFileSync(jsonlPath, `${line}\n`);
+    await observer.pollNow();
+
+    expect(received[0]).toMatchObject({
+      agentInstanceId: "worker-top",
+      sessionId: "session-top",
+      toolUseId: "tool-top",
+      turnId: "turn-top",
+    });
+    observer.dispose();
+  });
 });

--- a/tests/unit/main/tasks/task-service-activity.test.ts
+++ b/tests/unit/main/tasks/task-service-activity.test.ts
@@ -66,7 +66,7 @@ describe("task-service cancelRun onTaskActivity gating", () => {
 
     // build 完成 → coordinator 记 status=succeeded；schedule test；activity fire success。
     await service.completePanel("panel-build", 0, "main");
-    expect(onFinished).toHaveBeenNthCalledWith(1, "panel-build", {
+    expect(onFinished).toHaveBeenNthCalledWith(1, "panel-build", "main", {
       exitCode: 0,
       runId: opened.runId,
       status: "success",
@@ -80,7 +80,7 @@ describe("task-service cancelRun onTaskActivity gating", () => {
     service.cancelRun(opened.runId);
 
     expect(onFinished).toHaveBeenCalledTimes(1);
-    expect(onFinished).toHaveBeenCalledWith("panel-test", {
+    expect(onFinished).toHaveBeenCalledWith("panel-test", "main", {
       runId: opened.runId,
       status: "cancelled",
     });

--- a/tests/unit/main/terminal-close-reason.test.ts
+++ b/tests/unit/main/terminal-close-reason.test.ts
@@ -271,7 +271,7 @@ describe("terminal close IPC reason semantics", () => {
       }),
     ]);
 
-    foregroundActivityService.taskFinished("terminal-1", {
+    foregroundActivityService.taskFinished("terminal-1", "window-main", {
       exitCode: 0,
       runId: "run-1",
       status: "success",


### PR DESCRIPTION
## 背景

修复 Agent 前台状态在 Esc 中断、正常完成以及工具/子 Agent 并发执行后仍停留在“思考中”的问题，并补齐不同 Agent 集成的会话与工具身份识别。

## 主要改动

- 使用 window + panel 复合身份隔离活动状态，补齐 task 完成链的窗口路由
- 按 turn、toolUseId 和 agentInstanceId 维护回合、工具与子 Agent 状态
- 增加 Codex transcript 终态对账，覆盖 TurnInterrupted / TurnCompleted 及终态先于 hook 的竞态
- 强化 JSONL 分块读取、轮转、崩溃恢复和跨 shell/JavaScript/Python 写端锁协议
- 补齐 Codex、OpenCode、Kilo、Mimo 等集成的 session/tool/subagent 身份字段
- 增加路径、资源上限、多 owner watcher、跨窗口和迟到事件回归测试

## 验证

- `pnpm check`
- 单元测试：384 个文件，3504 项通过
- 组件测试：33 个文件，409 项通过
- 集成测试：3 个文件，19 项通过
- 推送前 typecheck、lint、文件大小和插件打包检查通过
