### PR TITLE
ci(plugins): release every changed plugin package serially

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -141,9 +141,9 @@ Pier 安装官方插件时依次执行：
 
 1. 更新 `packages/plugin-<id>/package.json` 和 `plugin.json` 中的版本。
 2. 在本地运行对应构建、打包和测试。
-3. 每次只把一个 `packages/plugin-*/package.json` 版本变更合入 `main`，保持发布原子性。
-4. `.github/workflows/release-plugin.yml` 构建插件，并创建 `plugin-<id>-v<version>` GitHub Release。
-5. 同一工作流重新生成、签名并提交 `plugins/index.v1.json`。
+3. 可在同一合入中变更多个 `packages/plugin-*/package.json`；release workflow 会按插件 id tail 排序串行发布。
+4. `.github/workflows/release-plugin.yml` 为每个变更插件构建并创建/校验 `plugin-<id>-v<version>` GitHub Release。
+5. 全部插件发布成功后，同一工作流只重新生成、签名并提交一次 `plugins/index.v1.json`。
 6. 索引提交触发 `.github/workflows/publish-index.yml` 发布官方索引。
 
 `workflow_dispatch` 只用于指定官方插件和版本的恢复发布，不是常规发布入口。

--- a/docs/superpowers/plans/2026-07-15-multi-plugin-release.md
+++ b/docs/superpowers/plans/2026-07-15-multi-plugin-release.md
@@ -1,39 +1,113 @@
-name: Release Plugin
+# Multi-plugin Serial Release Implementation Plan
 
-on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'packages/plugin-*/package.json'
-  workflow_dispatch:
-    inputs:
-      plugin:
-        description: 'Plugin id tail (e.g. codex for pier.codex)'
-        required: true
-      version:
-        description: 'Version to release'
-        required: true
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
+**Goal:** Let one `main` push that changes multiple `packages/plugin-*/package.json` files release every changed plugin serially in one job, then regenerate the official index once.
+
+**Architecture:** Keep a single `release` job on `macos-latest`. Resolve a JSON array of targets (push: all changed package.json files; dispatch: one input). Loop pack → immutable check / create release with `gh`. After all targets succeed, run `pnpm plugins:index` once and commit if needed.
+
+**Tech Stack:** GitHub Actions, `gh`, pnpm, vitest governance string assertions.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-15-multi-plugin-release-design.md`
+- No matrix / parallel release jobs
+- Preserve same-version sha256 immutability
+- Preserve Ed25519 required signing for index regeneration
+- `workflow_dispatch` remains single-plugin recovery
+- Work only under `/Users/xyz/ABC/pier.worktree/multi-plugin-release`
+
+## File map
+
+| File | Responsibility |
+|---|---|
+| `.github/workflows/release-plugin.yml` | Multi-target resolve + serial release + single index commit |
+| `tests/unit/main/managed-plugin-packaging-governance.test.ts` | Lock workflow contract in source |
+| `docs/plugins.md` | Maintainer release procedure |
+
+---
+
+### Task 1: Governance test contract
+
+**Files:**
+- Modify: `tests/unit/main/managed-plugin-packaging-governance.test.ts:80-93`
+- Test: same file
+
+**Interfaces:**
+- Consumes: workflow file text as string
+- Produces: assertions that require multi-target markers and forbid the old single-change hard fail
+
+- [ ] **Step 1: Rewrite the automatic-publish governance test**
+
+Replace the test body for `automatically publishes an immutable plugin release after one version change lands on main` with multi-plugin contract checks:
+
+```ts
+  it("automatically publishes immutable plugin releases for every package.json change on main", () => {
+    expect(releaseWorkflow).toMatch(
+      /push:\s+branches:\s+- main\s+paths:\s+- 'packages\/plugin-\*\/package\.json'/
+    );
+    expect(releaseWorkflow).toContain(
+      "expected at least one changed plugin package.json"
+    );
+    expect(releaseWorkflow).not.toContain(
+      "expected exactly one changed plugin package.json"
+    );
+    expect(releaseWorkflow).toContain("release_targets");
+    expect(releaseWorkflow).toContain("sorted by tail");
+    expect(releaseWorkflow).toContain("same-version hash drift");
+    expect(releaseWorkflow).toContain("Check existing release");
+    expect(releaseWorkflow).toContain("Verify existing release asset is immutable");
+    // single index regeneration after the serial loop
+    expect(releaseWorkflow).toContain("pnpm plugins:index");
+    expect(releaseWorkflow).toContain(
+      "chore(plugins): update index for"
+    );
+  });
+```
+
+Also keep the Ed25519 signing test unchanged.
+
+- [ ] **Step 2: Run test to verify it fails against current workflow**
+
+Run:
+
+```bash
+pnpm exec vitest run tests/unit/main/managed-plugin-packaging-governance.test.ts
+```
+
+Expected: FAIL on missing multi-target markers / still containing exactly-one string.
+
+- [ ] **Step 3: Commit test**
+
+```bash
+git add tests/unit/main/managed-plugin-packaging-governance.test.ts
+git commit -m "test(plugins): require multi-plugin serial release workflow"
+```
+
+---
+
+### Task 2: Rewrite release-plugin.yml
+
+**Files:**
+- Modify: `.github/workflows/release-plugin.yml`
+
+**Interfaces:**
+- Consumes: `github.event.before`, `github.sha`, dispatch inputs, GH token, signing secrets
+- Produces: zero or more `plugin-<tail>-v<version>` releases + optional index commit
+
+- [ ] **Step 1: Replace header comment**
+
+```yaml
 # Plugin package version changes merged to `main` automatically build every
 # changed `packages/plugin-<tail>`, publish each tgz under
 # `plugin-<tail>-v<version>` (serially, sorted by tail), then regenerate
 # `plugins/index.v1.json` once. `workflow_dispatch` remains available for
 # single-plugin recovery.
+```
 
-permissions:
-  contents: write
+- [ ] **Step 2: Replace Resolve step**
 
-jobs:
-  release:
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          # We need write access to commit the regenerated index back to main.
-          token: ${{ secrets.GITHUB_TOKEN }}
-
+```yaml
       - name: Resolve plugin release targets
         id: parse
         run: |
@@ -48,17 +122,17 @@ jobs:
               echo "requested ${TAIL}@${VERSION}, but ${PACKAGE_JSON} declares ${ACTUAL_VERSION}" >&2
               exit 1
             fi
-            TARGETS=$(node -e '
+            TARGETS=$(node -e "
               const t = process.argv[1];
               const v = process.argv[2];
               console.log(JSON.stringify([{
                 tail: t,
                 version: v,
-                tag: `plugin-${t}-v${v}`,
-                package: `@pier/plugin-${t}`,
-                packageJson: `packages/plugin-${t}/package.json`,
+                tag: \`plugin-\${t}-v\${v}\`,
+                package: \`@pier/plugin-\${t}\`,
+                packageJson: \`packages/plugin-\${t}/package.json\`,
               }]));
-            ' "$TAIL" "$VERSION")
+            " "$TAIL" "$VERSION")
           else
             CHANGED=$(git diff --name-only "${{ github.event.before }}" "${{ github.sha }}" -- 'packages/plugin-*/package.json' || true)
             COUNT=$(printf '%s\n' "$CHANGED" | awk 'NF { count++ } END { print count + 0 }')
@@ -67,7 +141,6 @@ jobs:
               printf '%s\n' "$CHANGED" >&2
               exit 1
             fi
-            # Resolve every changed package.json into release targets, sorted by tail.
             TARGETS=$(printf '%s\n' "$CHANGED" | node -e '
               const fs = require("node:fs");
               const paths = fs.readFileSync(0, "utf8").split(/\r?\n/).filter(Boolean);
@@ -75,10 +148,7 @@ jobs:
                 if (!/^packages\/plugin-[^/]+\/package\.json$/.test(packageJson)) {
                   throw new Error(`unexpected package path: ${packageJson}`);
                 }
-                const tail = packageJson.slice(
-                  "packages/plugin-".length,
-                  -"/package.json".length
-                );
+                const tail = packageJson.slice("packages/plugin-".length, -"/package.json".length);
                 const version = JSON.parse(fs.readFileSync(packageJson, "utf8")).version;
                 if (typeof version !== "string" || version.length === 0) {
                   throw new Error(`missing version in ${packageJson}`);
@@ -95,25 +165,18 @@ jobs:
               console.log(JSON.stringify(targets));
             ')
           fi
-          {
-            echo "release_targets<<EOF"
-            echo "$TARGETS"
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
+          echo "release_targets=$TARGETS" >> "$GITHUB_OUTPUT"
           echo "Resolved release targets (sorted by tail):"
           echo "$TARGETS" | node -e 'const t=JSON.parse(require("fs").readFileSync(0,"utf8")); for (const x of t) console.log(`- ${x.tag}`);'
           TAGS=$(echo "$TARGETS" | node -e 'const t=JSON.parse(require("fs").readFileSync(0,"utf8")); process.stdout.write(t.map((x)=>x.tag).join(", "));')
           echo "release_tags=$TAGS" >> "$GITHUB_OUTPUT"
+```
 
-      - uses: pnpm/action-setup@v4
+- [ ] **Step 3: Replace single-plugin build/publish steps with serial loop**
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 24
-          cache: 'pnpm'
+After `pnpm install --frozen-lockfile`, replace Build/Locate/Check/Verify/Publish with one step:
 
-      - run: pnpm install --frozen-lockfile
-
+```yaml
       - name: Build, verify, and publish each plugin release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -131,6 +194,7 @@ jobs:
 
           while IFS= read -r target; do
             TAIL=$(printf '%s' "$target" | node -e 'const t=JSON.parse(require("fs").readFileSync(0,"utf8")); process.stdout.write(t.tail)')
+            VERSION=$(printf '%s' "$target" | node -e 'const t=JSON.parse(require("fs").readFileSync(0,"utf8")); process.stdout.write(t.version)')
             TAG=$(printf '%s' "$target" | node -e 'const t=JSON.parse(require("fs").readFileSync(0,"utf8")); process.stdout.write(t.tag)')
             PACKAGE=$(printf '%s' "$target" | node -e 'const t=JSON.parse(require("fs").readFileSync(0,"utf8")); process.stdout.write(t.package)')
 
@@ -143,9 +207,7 @@ jobs:
             SIZE=$(stat -f%z "$TGZ")
             BASENAME=$(basename "$TGZ")
 
-            # Check existing release
             if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-              # Verify existing release asset is immutable
               echo "Release $TAG already exists; verifying immutable asset"
               WORK="$RUNNER_TEMP/existing-plugin-release-$TAIL"
               rm -rf "$WORK"
@@ -174,7 +236,15 @@ jobs:
             const targets = JSON.parse(require("node:fs").readFileSync("release-targets.json", "utf8"));
             for (const t of targets) process.stdout.write(JSON.stringify(t) + "\n");
           ')
+```
 
+Notes:
+- Prefer `gh release create` over `softprops/action-gh-release` so the loop stays in one shell step.
+- Keep failure fail-fast (`set -euo pipefail`).
+
+- [ ] **Step 4: Keep one index regenerate + multi-tag commit message**
+
+```yaml
       - name: Regenerate plugin index
         env:
           PIER_PLUGIN_INDEX_REQUIRE_SIGNATURE: "1"
@@ -198,3 +268,66 @@ jobs:
           git add plugins/index.v1.json
           git commit -m "chore(plugins): update index for ${RELEASE_TAGS}"
           git push origin main
+```
+
+- [ ] **Step 5: Run governance test**
+
+```bash
+pnpm exec vitest run tests/unit/main/managed-plugin-packaging-governance.test.ts
+```
+
+Expected: PASS
+
+- [ ] **Step 6: Commit workflow**
+
+```bash
+git add .github/workflows/release-plugin.yml
+git commit -m "ci(plugins): release every changed plugin package serially"
+```
+
+---
+
+### Task 3: Docs + final verification
+
+**Files:**
+- Modify: `docs/plugins.md` section “发布官方插件”
+
+- [ ] **Step 1: Update release procedure**
+
+Replace steps 3–6 with:
+
+```markdown
+3. 可在同一合入中变更多个 `packages/plugin-*/package.json`；release workflow 会按插件 id tail 排序串行发布。
+4. `.github/workflows/release-plugin.yml` 为每个变更插件构建并创建/校验 `plugin-<id>-v<version>` GitHub Release。
+5. 全部插件发布成功后，同一工作流只重新生成、签名并提交一次 `plugins/index.v1.json`。
+6. 索引提交触发 `.github/workflows/publish-index.yml` 发布官方索引。
+```
+
+Keep:
+
+```markdown
+`workflow_dispatch` 只用于指定官方插件和版本的恢复发布，不是常规发布入口。
+```
+
+- [ ] **Step 2: Final test**
+
+```bash
+pnpm exec vitest run tests/unit/main/managed-plugin-packaging-governance.test.ts
+```
+
+Expected: PASS all 6 tests.
+
+- [ ] **Step 3: Commit docs**
+
+```bash
+git add docs/plugins.md
+git commit -m "docs(plugins): document multi-plugin serial release"
+```
+
+---
+
+## Self-review
+
+1. Spec coverage: multi-target resolve, serial loop, immutability, single index, dispatch recovery, tests, docs — covered.
+2. No placeholders.
+3. Naming: `release_targets`, `release_tags`, `sorted by tail` markers match governance assertions.

--- a/docs/superpowers/specs/2026-07-15-multi-plugin-release-design.md
+++ b/docs/superpowers/specs/2026-07-15-multi-plugin-release-design.md
@@ -1,0 +1,134 @@
+# Multi-plugin release workflow design
+
+Date: 2026-07-15
+
+## Problem
+
+`.github/workflows/release-plugin.yml` refuses any push to `main` that changes
+more than one `packages/plugin-*/package.json`:
+
+```text
+expected exactly one changed plugin package.json, found 2
+```
+
+PR #88 merged `plugin-codex@1.3.1` and `plugin-grok@1.0.0` in one commit and
+tripped this guard. Release assets already existed, so product impact was low,
+but the automated release job still failed and the process blocks legitimate
+multi-plugin merges.
+
+Current docs and governance tests encode the same "exactly one" rule:
+
+- `docs/plugins.md` requires one package.json change per main merge
+- `tests/unit/main/managed-plugin-packaging-governance.test.ts` asserts the
+  failure string exists in the workflow
+
+## Goal
+
+When a push to `main` changes one or more official plugin package manifests,
+the release workflow must:
+
+1. release every changed plugin in one job
+2. preserve immutable same-version asset checks
+3. regenerate and commit the official index once at the end
+
+`workflow_dispatch` remains a single-plugin recovery path.
+
+## Non-goals
+
+- Parallel matrix jobs
+- Changing release tag or asset naming
+- Changing Ed25519 signing keys / key rotation
+- Auto-splitting PRs
+- Releasing plugins whose `package.json` did not change
+
+## Decision
+
+Use one job, serial per-plugin release, single index regeneration.
+
+Why not matrix:
+
+- multiple jobs would race on `plugins/index.v1.json` commits
+- plugin count is tiny; serial pack/publish cost is acceptable
+- immutability checks stay simple in one runner
+
+## Behavior
+
+### Trigger
+
+Unchanged:
+
+- `push` to `main` with path filter `packages/plugin-*/package.json`
+- `workflow_dispatch` with `plugin` + `version`
+
+### Resolve
+
+For `push`:
+
+1. `git diff --name-only $BEFORE $SHA -- 'packages/plugin-*/package.json'`
+2. require `COUNT >= 1` (fail if zero after path filter noise)
+3. for each changed file:
+   - derive `tail` from `packages/plugin-<tail>/package.json`
+   - read `version` from that package.json
+   - build `tag = plugin-<tail>-v<version>`
+   - build `package = @pier/plugin-<tail>`
+4. emit a JSON array of release targets to `$GITHUB_OUTPUT`
+
+For `workflow_dispatch`:
+
+- emit a one-element array from the provided inputs
+- still verify `package.json` declares the requested version
+
+### Release loop
+
+For each target, in deterministic order (sorted by `tail`):
+
+1. `pnpm --filter <package> run build:package`
+2. locate the produced `.tgz`, `.sha256`, and size
+3. if GitHub Release `tag` is missing: create it with tgz + sha256 sidecar
+4. if GitHub Release `tag` exists: download the published tgz and require
+   local sha256 == published sha256; hash drift fails the job
+
+Failure policy:
+
+- stop on first failure
+- already-published immutable releases remain published
+- re-run / dispatch can recover remaining plugins
+
+### Index once
+
+After every target succeeds:
+
+1. run `pnpm plugins:index` with:
+   - `PIER_PLUGIN_INDEX_REQUIRE_SIGNATURE=1`
+   - existing signing key id / private key secrets
+2. if `plugins/index.v1.json` changed, commit once and push to `main`
+3. commit message lists every released tag, e.g.
+   `chore(plugins): update index for plugin-codex-v1.3.1, plugin-grok-v1.0.0`
+
+Do not regenerate the index between individual plugin releases.
+
+## Files to change
+
+- `.github/workflows/release-plugin.yml`
+  - replace single-target resolve with multi-target list
+  - loop pack / immutability / publish
+  - keep one index commit at the end
+- `tests/unit/main/managed-plugin-packaging-governance.test.ts`
+  - drop assertion on `expected exactly one changed plugin package.json`
+  - assert multi-target resolve + serial loop + single index commit markers
+- `docs/plugins.md`
+  - replace "one package.json per merge" with multi-plugin serial release rules
+
+## Success criteria
+
+- push changing only `plugin-codex/package.json` still releases codex
+- push changing both codex + grok package.json releases both, then one index commit
+- existing release with matching sha256 is treated as success, not republished
+- existing release with different sha256 fails as hash drift
+- `workflow_dispatch` still releases exactly one requested plugin
+- governance tests and docs match the new contract
+
+## Out of scope follow-ups
+
+- optional matrix later with distributed lock for index commits
+- PR bot that warns when multiple plugin versions change without release notes

--- a/tests/unit/main/managed-plugin-packaging-governance.test.ts
+++ b/tests/unit/main/managed-plugin-packaging-governance.test.ts
@@ -77,19 +77,25 @@ describe("managed plugin packaging governance", () => {
     expect(releaseWorkflow).toContain("PIER_PLUGIN_INDEX_SIGNING_KEY_ID");
   });
 
-  it("automatically publishes an immutable plugin release after one version change lands on main", () => {
+  it("automatically publishes immutable plugin releases for every package.json change on main", () => {
     expect(releaseWorkflow).toMatch(
       /push:\s+branches:\s+- main\s+paths:\s+- 'packages\/plugin-\*\/package\.json'/
     );
     expect(releaseWorkflow).toContain(
+      "expected at least one changed plugin package.json"
+    );
+    expect(releaseWorkflow).not.toContain(
       "expected exactly one changed plugin package.json"
     );
-    expect(releaseWorkflow).toContain('if [ "$ACTUAL_VERSION" != "$VERSION" ]');
+    expect(releaseWorkflow).toContain("release_targets");
+    expect(releaseWorkflow).toContain("sorted by tail");
+    expect(releaseWorkflow).toContain("same-version hash drift");
     expect(releaseWorkflow).toContain("Check existing release");
     expect(releaseWorkflow).toContain(
       "Verify existing release asset is immutable"
     );
-    expect(releaseWorkflow).toContain("same-version hash drift");
+    expect(releaseWorkflow).toContain("pnpm plugins:index");
+    expect(releaseWorkflow).toContain("chore(plugins): update index for");
   });
 
   it("does not commit an unsigned official index", () => {


### PR DESCRIPTION
## Summary
- Allow one `main` push that changes multiple `packages/plugin-*/package.json` files to release every plugin in one job.
- Pack/publish serially (sorted by plugin id tail), keep same-version sha256 immutability checks, then regenerate the signed official index once.
- Update packaging governance tests and release docs so the old "exactly one package.json" guard is gone.

## Why
PR #88 failed Release Plugin with:
`expected exactly one changed plugin package.json, found 2`

## Test plan
- [x] `pnpm exec vitest run tests/unit/main/managed-plugin-packaging-governance.test.ts`
- [ ] Merge a multi-plugin package.json change and confirm Release Plugin resolves both targets, releases/verifies each, and commits one index update
- [ ] Confirm single-plugin push and `workflow_dispatch` still work