### PR TITLE
fix(plugins): skip non-releasable packages in release workflow

### DIFF
--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -16,9 +16,10 @@ on:
         required: true
 
 # Plugin package version changes merged to `main` automatically build every
-# changed `packages/plugin-<tail>`, publish each tgz under
-# `plugin-<tail>-v<version>` (serially, sorted by tail), then regenerate
-# `plugins/index.v1.json` once. `workflow_dispatch` remains available for
+# changed releasable `packages/plugin-<tail>` (must have `plugin.json`),
+# publish each tgz under `plugin-<tail>-v<version>` (serially, sorted by
+# tail), then regenerate `plugins/index.v1.json` once. Shared packages such
+# as `plugin-api` are ignored. `workflow_dispatch` remains available for
 # single-plugin recovery.
 
 permissions:
@@ -43,6 +44,11 @@ jobs:
             TAIL="${{ github.event.inputs.plugin }}"
             VERSION="${{ github.event.inputs.version }}"
             PACKAGE_JSON="packages/plugin-${TAIL}/package.json"
+            PLUGIN_JSON="packages/plugin-${TAIL}/plugin.json"
+            if [ ! -f "$PLUGIN_JSON" ]; then
+              echo "packages/plugin-${TAIL} is not a releasable plugin (missing plugin.json)" >&2
+              exit 1
+            fi
             ACTUAL_VERSION=$(node -p "require('./${PACKAGE_JSON}').version")
             if [ "$ACTUAL_VERSION" != "$VERSION" ]; then
               echo "requested ${TAIL}@${VERSION}, but ${PACKAGE_JSON} declares ${ACTUAL_VERSION}" >&2
@@ -67,11 +73,13 @@ jobs:
               printf '%s\n' "$CHANGED" >&2
               exit 1
             fi
-            # Resolve every changed package.json into release targets, sorted by tail.
+            # Resolve releasable targets only (must have plugin.json), sorted by tail.
+            # Shared packages like plugin-api change package.json but are not released.
             TARGETS=$(printf '%s\n' "$CHANGED" | node -e '
               const fs = require("node:fs");
               const paths = fs.readFileSync(0, "utf8").split(/\r?\n/).filter(Boolean);
-              const targets = paths.map((packageJson) => {
+              const targets = [];
+              for (const packageJson of paths) {
                 if (!/^packages\/plugin-[^/]+\/package\.json$/.test(packageJson)) {
                   throw new Error(`unexpected package path: ${packageJson}`);
                 }
@@ -79,23 +87,39 @@ jobs:
                   "packages/plugin-".length,
                   -"/package.json".length
                 );
+                const pluginJson = `packages/plugin-${tail}/plugin.json`;
+                if (!fs.existsSync(pluginJson)) {
+                  console.error(`skipping non-releasable package (no plugin.json): ${packageJson}`);
+                  continue;
+                }
                 const version = JSON.parse(fs.readFileSync(packageJson, "utf8")).version;
                 if (typeof version !== "string" || version.length === 0) {
                   throw new Error(`missing version in ${packageJson}`);
                 }
-                return {
+                targets.push({
                   tail,
                   version,
                   tag: `plugin-${tail}-v${version}`,
                   package: `@pier/plugin-${tail}`,
                   packageJson,
-                };
-              });
+                });
+              }
               targets.sort((a, b) => a.tail.localeCompare(b.tail));
               console.log(JSON.stringify(targets));
             ')
           fi
+          TARGET_COUNT=$(echo "$TARGETS" | node -e 'const t=JSON.parse(require("fs").readFileSync(0,"utf8")); process.stdout.write(String(t.length));')
+          if [ "$TARGET_COUNT" -eq 0 ]; then
+            echo "no releasable plugin package.json changes (plugin.json required); skipping release"
+            {
+              echo "should_release=false"
+              echo "release_targets=[]"
+              echo "release_tags="
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           {
+            echo "should_release=true"
             echo "release_targets<<EOF"
             echo "$TARGETS"
             echo "EOF"
@@ -106,15 +130,19 @@ jobs:
           echo "release_tags=$TAGS" >> "$GITHUB_OUTPUT"
 
       - uses: pnpm/action-setup@v4
+        if: steps.parse.outputs.should_release == 'true'
 
       - uses: actions/setup-node@v4
+        if: steps.parse.outputs.should_release == 'true'
         with:
           node-version: 24
           cache: 'pnpm'
 
-      - run: pnpm install --frozen-lockfile
+      - if: steps.parse.outputs.should_release == 'true'
+        run: pnpm install --frozen-lockfile
 
       - name: Build, verify, and publish each plugin release
+        if: steps.parse.outputs.should_release == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TARGETS: ${{ steps.parse.outputs.release_targets }}
@@ -176,6 +204,7 @@ jobs:
           ')
 
       - name: Regenerate plugin index
+        if: steps.parse.outputs.should_release == 'true'
         env:
           PIER_PLUGIN_INDEX_REQUIRE_SIGNATURE: "1"
           PIER_PLUGIN_INDEX_SIGNING_KEY_ID: ${{ secrets.PIER_PLUGIN_INDEX_SIGNING_KEY_ID }}
@@ -183,6 +212,7 @@ jobs:
         run: pnpm plugins:index
 
       - name: Commit index update
+        if: steps.parse.outputs.should_release == 'true'
         env:
           RELEASE_TAGS: ${{ steps.parse.outputs.release_tags }}
         run: |

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -142,9 +142,10 @@ Pier 安装官方插件时依次执行：
 1. 更新 `packages/plugin-<id>/package.json` 和 `plugin.json` 中的版本。
 2. 在本地运行对应构建、打包和测试。
 3. 可在同一合入中变更多个 `packages/plugin-*/package.json`；release workflow 会按插件 id tail 排序串行发布。
-4. `.github/workflows/release-plugin.yml` 为每个变更插件构建并创建/校验 `plugin-<id>-v<version>` GitHub Release。
-5. 全部插件发布成功后，同一工作流只重新生成、签名并提交一次 `plugins/index.v1.json`。
-6. 索引提交触发 `.github/workflows/publish-index.yml` 发布官方索引。
+4. 只有带有 `plugin.json` 的包会进入发布队列；像 `packages/plugin-api` 这类共享包即使改了 `package.json` 也会被跳过。
+5. `.github/workflows/release-plugin.yml` 为每个可发布变更插件构建并创建/校验 `plugin-<id>-v<version>` GitHub Release。
+6. 全部插件发布成功后，同一工作流只重新生成、签名并提交一次 `plugins/index.v1.json`。
+7. 索引提交触发 `.github/workflows/publish-index.yml` 发布官方索引。
 
 `workflow_dispatch` 只用于指定官方插件和版本的恢复发布，不是常规发布入口。
 

--- a/tests/unit/main/managed-plugin-packaging-governance.test.ts
+++ b/tests/unit/main/managed-plugin-packaging-governance.test.ts
@@ -89,6 +89,14 @@ describe("managed plugin packaging governance", () => {
     );
     expect(releaseWorkflow).toContain("release_targets");
     expect(releaseWorkflow).toContain("sorted by tail");
+    expect(releaseWorkflow).toContain("must have plugin.json");
+    expect(releaseWorkflow).toContain(
+      "skipping non-releasable package (no plugin.json)"
+    );
+    expect(releaseWorkflow).toContain("should_release");
+    expect(releaseWorkflow).toContain(
+      "no releasable plugin package.json changes (plugin.json required)"
+    );
     expect(releaseWorkflow).toContain("same-version hash drift");
     expect(releaseWorkflow).toContain("Check existing release");
     expect(releaseWorkflow).toContain(


### PR DESCRIPTION
## Summary
- Release Plugin failed on [run 29459474693](https://github.com/runloom/pier/actions/runs/29459474693/job/87499744108) because `packages/plugin-api` matched `packages/plugin-*/package.json` and was treated as a publishable plugin (`build:package` missing).
- Only enqueue packages that have `plugin.json`; skip shared packages like `plugin-api`.
- If a push only changes non-releasable manifests, the job succeeds without publishing.
- Docs + governance tests updated to lock the contract.

## Follow-up after merge
`plugin-grok@1.0.1` never published (release stopped on `plugin-api`). After this lands on `main`, recover with:

```bash
gh workflow run release-plugin.yml -f plugin=grok -f version=1.0.1
```

## Test plan
- [x] `pnpm exec vitest run tests/unit/main/managed-plugin-packaging-governance.test.ts`
- [x] Local resolve simulation: `plugin-api` skipped, `plugin-grok` kept
- [x] Merge, then `workflow_dispatch` release for `grok@1.0.1`
- [x] Confirm Release Plugin no longer tries to build `@pier/plugin-api`