### PR TITLE
feat(agent-attention): persist attention settings, add notifications section, soft-fail hook install

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,6 +150,21 @@ Pier 桌面端的单行交互控件统一使用 28px 高度：
 检查点在 `tests/unit/renderer/shadcn-governance.test.ts`；新增例外必须写明组件边界和
 无法使用现有 shadcn 原语的原因。
 
+### 设置页状态提示布局
+
+宿主设置页（`src/renderer/pages/settings/**`）里用于权限、错误、模式说明的
+`@pier/ui/Alert` **必须放在 `Card` / `CardContent` 内**，不得与 `Card` 并列作为
+section 根节点下的裸子节点。
+
+- 设置页一级标题（`h1`）仍在卡片外（见上节 shadcn 规范）。
+- 多卡片分段时：健康/错误提示**并入内容 Card 顶部**（与表单/列表同卡）；禁止
+  `h1 → 裸 Alert → Card`，也禁止「仅包一层 Alert 的空壳 Card」（Alert 已自带
+  边框，套 Card 会双重描边）。
+- 参考：`plugins-section.tsx`（错误 Alert 在内容 Card 内）、
+  `notifications-section.tsx`（权限/hooks Alert 在策略 Card 顶部）。
+- 一次性动作失败的详情仍走 `showAppAlert`（与本条不冲突）。
+- 检查点在 `tests/unit/renderer/settings-section-alert-layout-governance.test.ts`（仅扫描 `settings-dialog` 直接挂载的 `*-section.tsx`；嵌套在父 Card 内的子块不扫）。
+
 ### 前台活动模块 `src/main/services/foreground-activity/`
 
 统一 agent / task / shell / idle 四态活动聚合器：

--- a/docs/superpowers/plans/2026-07-16-agent-attention-settings-and-status-accuracy.md
+++ b/docs/superpowers/plans/2026-07-16-agent-attention-settings-and-status-accuracy.md
@@ -1,0 +1,364 @@
+# Agent 注意力设置与状态准确性 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans`. Checkbox steps. Do **not** expand into completion notifications, sounds, terminal bell, history, Canvas, or plugin `agents.list/subscribe`.
+
+**Goal:** 落地修订后的 [设计](../specs/2026-07-16-agent-attention-settings-and-status-accuracy-design.md)：可持久化 Attention 策略（含 `PATCHABLE_KEYS`）、可恢复权限探针、设置「通知」分区、触发矩阵、B 档映射收敛、Top 四家真实证据链门禁。
+
+**Architecture:**
+
+```text
+preferences.update({ agentAttention })
+  → preferences-service PATCHABLE_KEYS（必须含 agentAttention）
+  → disk + preferences.changed
+  → main Attention settings 同步缓存
+  → observe(FA): 触发矩阵 → enabled/suppress/cooldown → show
+system-notification: stickyDenied + forceProbe(test) → permission status 广播
+```
+
+**Tech Stack:** Electron IPC + zod preferences + 现有 Attention / system-notification + 设置 SwitchRow/SelectRow + vitest。
+
+**Spec:** 修订版 2026-07-16 design（Codex 审查 P0/P1 已吸收）  
+**Branch:** `feat/agent-attention-settings-status-accuracy`
+
+## Global Constraints
+
+- FA 唯一语义；Index 不自算 status；禁 OCR waiting。
+- 默认：`enabled=true`，`enableErrorAttention=false`，`suppressWhenFocused=true`，`cooldownMs=180_000`。
+- **嵌套 patch 整对象替换**；白名单遗漏 = 功能不存在。
+- 保存/测试失败必须用户可见；禁止 silent `catch`。
+- 触发 = **非触发集 → 触发集**（非 `previous !== next`）。
+- B 档未审完不得宣称状态准确性完成。
+- Git：显式 stage；commit 前展示 diff+message 等用户确认。
+
+---
+
+## 文件地图
+
+| 路径 | 职责 |
+| --- | --- |
+| `src/shared/contracts/agent-attention.ts` | settings schema、默认值、cooldown 枚举、permission status 类型 |
+| `src/shared/contracts/preferences.ts` | `agentAttention` 字段 |
+| `src/main/state/preferences.ts` | DEFAULTS |
+| **`src/main/services/preferences-service.ts`** | **`PATCHABLE_KEYS` + `agentAttention`** |
+| `src/main/services/agent-attention/attention-service.ts` | 触发矩阵 + enabled/suppress + 同步 settings |
+| `src/main/ipc/agent-attention.ts` | 缓存 settings；订阅 preferences.changed |
+| `src/main/services/system-notification.ts` | sticky + forceProbe + getPermissionSnapshot |
+| `src/shared/ipc-channels.ts` + preload | permission/test/openSettings |
+| `src/renderer/stores/agent-attention-preferences.store.ts` | 整对象 update + 失败可见 |
+| `src/renderer/pages/settings/components/notifications-section.tsx` | UI |
+| integrations B 档文件 | 映射收敛 |
+| tests | 见各 Task |
+
+---
+
+## Phase map
+
+| Phase | Tasks |
+| --- | --- |
+| 契约+白名单持久化 | 1 |
+| Attention 矩阵+设置 | 2 |
+| 探针 forceProbe | 3 |
+| 设置 UI + store | 4–5 |
+| B 收敛 + S1–S3 门禁 | 6 |
+| 验收 | 7 |
+
+---
+
+### Task 1: 契约 + preferences 字段 + **PATCHABLE_KEYS**
+
+**Files:**
+
+- Modify: `src/shared/contracts/agent-attention.ts`
+- Modify: `src/shared/contracts/preferences.ts`
+- Modify: `src/main/state/preferences.ts`
+- Modify: **`src/main/services/preferences-service.ts`**（`PATCHABLE_KEYS` 增加 `"agentAttention"`）
+- Test: `tests/unit/shared/agent-attention-settings.test.ts`
+- Test: `tests/unit/main/preferences-service-agent-attention.test.ts`（新建；或扩展现有 preferences-service 测）
+
+**Interfaces:**
+
+```ts
+// agent-attention.ts — full AgentAttentionSettings + zod + defaults
+// preferences: agentAttention: agentAttentionSettingsSchema.default(...)
+```
+
+**Produces for later tasks:** 持久化后的 `ProjectPreferences.agentAttention`；`preferences.changed` 含该 key。
+
+- [ ] **Step 1: 失败测 — schema 默认 + 非法 cooldown**
+
+```ts
+// tests/unit/shared/agent-attention-settings.test.ts
+// 见设计 §4.1 默认值；cooldown 123 应 fail
+```
+
+- [ ] **Step 2: 失败测 — service 白名单（关键 P0）**
+
+```ts
+import { createPreferencesService } from "@main/services/preferences-service.ts";
+// mock updatePreferencesState / read
+// update({ agentAttention: { enabled: false, enableErrorAttention: false, suppressWhenFocused: true, cooldownMs: 60_000 } })
+// expect underlying mutate 收到 agentAttention
+// expect changedKeys 包含 "agentAttention"
+// 对照：若忘记 PATCHABLE_KEYS，normalizedPatch 为空 → 本测必须红
+```
+
+- [ ] **Step 3: 实现契约 + DEFAULTS + PATCHABLE_KEYS**
+
+- [ ] **Step 4:**
+
+```bash
+pnpm test:unit -- agent-attention-settings
+pnpm test:unit -- preferences-service
+```
+
+Expected: PASS
+
+- [ ] **Step 5: 提交（用户确认后）** `feat(attention): add agentAttention prefs and patch whitelist`
+
+---
+
+### Task 2: Attention 触发矩阵 + 完整 settings 消费 + 同步缓存
+
+**Files:**
+
+- Modify: `src/main/services/agent-attention/attention-service.ts`
+- Modify: `src/main/ipc/agent-attention.ts`
+- Modify: `tests/unit/main/agent-attention.test.ts`
+
+**触发矩阵实现（替换 `previous !== next`）：**
+
+```ts
+function inTriggerSet(
+  status: ActivityStatus | undefined,
+  settings: AgentAttentionSettings
+): boolean {
+  if (status === "waiting") return true;
+  return settings.enableErrorAttention && status === "error";
+}
+
+function enteredAttention(
+  previous: ActivityStatus | undefined,
+  next: ActivityStatus | undefined,
+  settings: AgentAttentionSettings
+): boolean {
+  return !inTriggerSet(previous, settings) && inTriggerSet(next, settings);
+}
+```
+
+**settings 缓存（ipc）：**
+
+```ts
+let cached = DEFAULT_AGENT_ATTENTION_SETTINGS;
+// boot: readPreferences().then(p => { cached = p.agentAttention })
+// on preferences.changed / eventBus: if changedKeys includes agentAttention → cached = snapshot.agentAttention
+// createAgentAttentionService({ settings: () => cached, ... })
+```
+
+`settings()` 保持 **同步** `() => AgentAttentionSettings`。
+
+- [ ] **Step 1: 单测矩阵**
+
+```ts
+it("does not re-notify waiting→error when both in trigger set", ...);
+it("does not re-notify error→waiting when both in trigger set", ...);
+it("notifies ∅→waiting", ...);
+it("notifies ∅→error only if enableErrorAttention", ...);
+it("skips when enabled false", ...);
+it("notifies when focused if suppressWhenFocused false", ...);
+// 保留 cooldown / shown:false 不记冷却
+```
+
+- [ ] **Step 2–4: 红 → 实现 → 绿**
+
+```bash
+pnpm test:unit -- agent-attention
+```
+
+- [ ] **Step 5: 提交** `fix(attention): enter trigger-set semantics and live settings cache`
+
+---
+
+### Task 3: 权限探针 + forceProbe 测试通知 + 打开系统设置
+
+**Files:**
+
+- Modify: `src/main/services/system-notification.ts`
+- Modify: `src/shared/contracts/notification.ts`（probe 快照类型优先放此，避免污染 agent domain）
+- Modify: `src/shared/ipc-channels.ts`
+- Modify: `src/main/ipc/notification.ts` / host 注册
+- Modify: preload + `window.pier` 类型
+- Test: `tests/unit/main/system-notification.test.ts`
+
+**Interfaces:**
+
+```ts
+type SystemNotificationPermissionStatus =
+  | "unsupported" | "denied" | "unknown" | "authorized";
+
+interface SystemNotificationPermissionSnapshot {
+  status: SystemNotificationPermissionStatus;
+  observedAt: number;
+  source: "cached" | "forced-probe" | "attention-delivery" | "boot";
+}
+
+// showSystemNotification(req, { forceProbe?: boolean, onClick?, onUnavailable? })
+// forceProbe===true → 忽略 stickyDenied 一次，真正 show
+// shown:true → stickyDenied=false, status=authorized
+// getSystemNotificationPermissionSnapshot(): snapshot
+// openSystemNotificationSettings(): Promise<{ opened: boolean; reason?: string }>
+// showTestSystemNotification(): uses forceProbe, kind agent.attention.test, no agentRef
+```
+
+广播：权限 status 变化时 `broadcast`（新 channel 如 `pier://notification:permission-changed`），设置页订阅。
+
+- [ ] **Step 1: 测 sticky 阻断普通路径；forceProbe 可 show；shown:true 清 sticky**
+
+- [ ] **Step 2: 实现 + IPC + preload**
+
+- [ ] **Step 3:**
+
+```bash
+pnpm test:unit -- system-notification
+pnpm test:unit -- notification-ipc
+```
+
+- [ ] **Step 4: 提交** `feat(notification): recoverable permission probe and test notification`
+
+---
+
+### Task 4: Renderer store + 通知设置 UI
+
+**Files:**
+
+- Create: `src/renderer/stores/agent-attention-preferences.store.ts`
+- Create: `src/renderer/pages/settings/components/notifications-section.tsx`
+- Modify: `appearance-nav.ts`（`notifications` after `agents`，Bell 图标）
+- Modify: `settings-dialog.tsx`
+- Modify: i18n en/zh-CN `settings.ts`
+- Wire store init 与现有 preferences boot
+
+**Store 纪律：**
+
+```ts
+async setAgentAttention(next: AgentAttentionSettings): Promise<void> {
+  const prev = get().agentAttention;
+  set({ agentAttention: next }); // 可选乐观
+  try {
+    const merged = await window.pier.preferences.update({ agentAttention: next });
+    set({ agentAttention: merged.agentAttention });
+  } catch (err) {
+    set({ agentAttention: prev });
+    showAppAlert({ title: t("...Failed"), body: ... }); // 或 toast.error 短失败
+    throw err;
+  }
+}
+```
+
+**UI：** banner（订阅 permission snapshot）+ switches + cooldown select + 测试通知（forceProbe）+ 打开系统设置。无空「重新检查」。
+
+- [ ] **Step 1–3: 实现 + typecheck**
+
+```bash
+pnpm typecheck
+```
+
+- [ ] **Step 4: 提交** `feat(settings): notifications section for agent attention`
+
+---
+
+### Task 5: S3 文案 + hooks 门闸（优先 FA 入口）
+
+**Files:**
+
+- Modify: `agents-section.tsx` + i18n（hooks 关闭说明 = 设计 §5.4）
+- Modify: notifications-section 在 `agentStatusHooks===false` 时 Alert
+- **推荐：** Modify FA/jsonl 摄入（`foreground-activity` ipc 或 observer 回调前）—— `agentStatusHooks===false` 时丢弃 **新** agent hook 事件  
+- Test: 门闸单测（mock prefs false → ingest 忽略 PermissionRequest）
+
+若本迭代不做门闸：文案必须含「已运行会话可能仍上报；重开 Agent 后完全生效」，且不得在验收表声称即时全局安静。
+
+- [ ] **Step 1–3: 文案 +（门闸|诚实文案）+ 测**
+
+- [ ] **Step 4: 提交** `fix(agents): honest status-hooks-off semantics for attention`
+
+---
+
+### Task 6: B 档收敛 + S1/S2 证据门禁
+
+**Files:**
+
+- Review/modify as needed: `grok.ts` / `gemini.ts` / `droid.ts` / `cursor.ts`
+- Update: design 附录 A（同分支）
+- Create: `tests/unit/main/agent-waiting-evidence-gates.test.ts`
+- Export pure mappers if needed（OpenCode `permission.updated` 分支）
+
+**S1 每家必须：**
+
+```ts
+// 1) 从集成导出的 events 表或 mapNativeToPier(native) 断言 → PermissionRequest
+// 2) activityStatusForHookEvent("PermissionRequest") === "waiting"
+// 3) projectAgentActivities([...waiting agent...]) → needsYou >= 1
+// 4) Attention observe 在 enabled+unfocused 时调用 showNotification
+// Claude, Codex, Copilot, OpenCode 四条 it() 或 table-driven 四行，禁止注释代替
+```
+
+**S2：** launch-only 列表 + 无 status 的 needsYou===0 + Attention 不调用。
+
+**B：** 每文件审完：保留则测锁定；删除映射则测「不再 PermissionRequest」+ 更新附录。
+
+- [ ] **Step 1: 写门禁测（映射源先红则先改导出）**
+
+- [ ] **Step 2: B 审落地**
+
+- [ ] **Step 3:**
+
+```bash
+pnpm test:unit -- agent-waiting-evidence-gates
+pnpm test:unit -- agent-hook-runtime-semantics
+pnpm test:unit -- agent-attention
+pnpm test:unit -- agent-runtime-index
+```
+
+- [ ] **Step 4: 提交** `fix(agents): converge B waiting maps and lock evidence gates`
+
+---
+
+### Task 7: 总验收
+
+```bash
+pnpm test:unit -- agent-attention
+pnpm test:unit -- agent-attention-settings
+pnpm test:unit -- preferences-service
+pnpm test:unit -- system-notification
+pnpm test:unit -- agent-waiting-evidence-gates
+pnpm test:unit -- agent-runtime-index
+pnpm typecheck
+pnpm lint
+```
+
+手工：N1 关开关、N6 系统设置允许后测试通知、N7、真 waiting click、四家之一真机 permission（若环境允许）。
+
+更新 design 状态 → 已实现（仅门禁全绿）。
+
+`pnpm check` 发 PR 前。
+
+---
+
+## Spec 覆盖
+
+| Spec | Task |
+| --- | --- |
+| PATCHABLE_KEYS / N8 | 1 |
+| 触发矩阵 / enabled / suppress | 2 |
+| forceProbe / 测试 / 打开设置 | 3 |
+| 设置 UI / 失败可见 | 4 |
+| S3 诚实 + 门闸 | 5 |
+| S1 真链 / S2 / B | 6 |
+| 总门禁 | 7 |
+
+## 完成定义
+
+- Codex P0 两条在测试中不可再发（白名单、sticky 恢复）  
+- N1–N9、S1–S3 按修订 design 可证  
+- B 附录与代码一致  
+- 无完成通知/响铃/历史范围膨胀  

--- a/docs/superpowers/specs/2026-07-16-agent-attention-settings-and-status-accuracy-design.md
+++ b/docs/superpowers/specs/2026-07-16-agent-attention-settings-and-status-accuracy-design.md
@@ -1,0 +1,454 @@
+# Agent 注意力设置与状态准确性产品设计
+
+> 日期：2026-07-16  
+> 状态：**实施中**（Task 1–6 代码已落地，待 commit / 手工验收）；[实施计划](../plans/2026-07-16-agent-attention-settings-and-status-accuracy.md)  
+> 审查：Codex CLI 架构审查（2026-07-16）→ **fail → 本修订吸收 P0/P1**  
+> 前置：[`2026-07-15-agent-runtime-index-and-attention-design.md`](./2026-07-15-agent-runtime-index-and-attention-design.md)（P1 / P1.5 已实现）  
+> 状态基线：[`2026-07-13-agent-status-adapter-contract-audit.md`](./2026-07-13-agent-status-adapter-contract-audit.md)  
+> 范围：Phase A（通知可管理闭环）+ 状态准确性治理；**不含**完成通知 / 声音库 / 终端响铃 / 通知历史 / Canvas
+
+## 1. 目标与完成标准
+
+### 1.1 一句话定位
+
+在 **ForegroundActivity（FA）仍为活动语义唯一源**、Index / Attention 主链路已落地的前提下：
+
+1. **注意力可管理**：设置可持久化策略、可恢复的权限探针、测试通知、打开系统设置。  
+2. **状态可诚实验收**：Top A 档用**真实映射证据**锁门；launch-only 负向；B 档映射本迭代**重审并收敛**，禁止「只写文档却默认弹通知」。
+
+### 1.2 要解决的问题
+
+1. Attention 策略硬编码，用户无法管理；权限失败不可恢复自检。  
+2. 易被误判为「通知没做完」（缺设置表面）。  
+3. waiting 证据不全量等价；若门禁只测共享契约、不测 provider 映射，会假绿。  
+4. 审查发现：preferences **白名单**会静默丢弃未列字段；sticky denied **阻断**「成功 show 清拒绝」——必须在设计中钉死，否则 N1–N8 全假。
+
+### 1.3 完成标准（闭环）
+
+| 闭环 | 名称 | 通过标准摘要 | 证明方式 |
+| --- | --- | --- | --- |
+| N1 | 总开关 | 关后 waiting 不发 OS 通知；Index/标题栏仍更新 | 单测 + 手工 |
+| N2 | 出错通知 | 默认关；开后仅进入 `error` 可通知 | 单测 |
+| N3 | 专注抑制 | 默认聚焦目标 panel 不弹；可关 | 单测 |
+| N4 | 冷却 | 同 agentRef 冷却内不重复；tag replace | 单测（既有+扩展） |
+| N5 | 权限健康 | denied/unsupported 可理解；不谎报 | 单测 + 手工 |
+| N6 | 权限可恢复 | **强制探测**可在用户允许后变为 authorized | 单测 sticky bypass + 手工 |
+| N7 | 测试通知 | 只验通道；不记 agent 冷却 | 单测 |
+| N8 | 策略即时生效 | patch 经白名单持久化+广播；下一次 FA 变迁用新策略 | **preferences-service 集成测** + Attention 测 |
+| N9 | 真通知回跳 | agent.attention click → Index.focus | 既有路径回归 |
+| S1 | Top A 链 | Claude/Codex/Copilot/OpenCode：原生 permission 映射 → FA waiting → needsYou → Attention 候选 | **每家真实 mapper/事件表** + 聚合链测 |
+| S2 | launch-only | 无 status 不进 Needs you、不通知 | 单测 |
+| S3 | hooks 关闭 | 文案与运行时语义**一致**（见 §6.4）；失败可感知 | 文案 + 可选 FA 门闸测 |
+
+### 1.4 边界
+
+- FA 唯一语义源；Index 投影；Attention 只投递。  
+- 不做：侧栏、完成通知、历史、OCR waiting、Canvas、插件 list/subscribe。  
+- 金标准 = Pier 可行动注意力，**不是** Orca 功能对等。
+
+### 1.5 审查抬档（相对初稿）
+
+| # | 问题 | 本修订锁定 |
+| --- | --- | --- |
+| P0 | `PATCHABLE_KEYS` 丢弃 `agentAttention` | 白名单 + 整对象替换测必须进 Task 1 |
+| P0 | sticky denied 使「show 成功清拒绝」不可达 | 用户强制探测可 bypass 一次 sticky；仅 shown:true 清 denied |
+| P1 | hooks 关承诺过强 | 诚实语义：停装+异步卸；在跑 CLI 可能仍发事件；可选 FA 入口门闸 |
+| P1 | S1 假绿 | 禁止只测 `PermissionRequest→waiting`；必须锁四家映射源 |
+| P1 | B 档默认仍吵 | 本迭代重审 B 映射；无授权证据则停止映到 PermissionRequest |
+| P1 | 触发语义 | 冻结「非触发集 → 触发集」矩阵，修正 `previous !== next` |
+| P1 | 保存失败吞掉 | store 必须用户可见失败；禁止 silent catch |
+| P2 | settings/探针所有权 | main 同步缓存 + 权限状态广播或设置页确定性 refetch |
+
+---
+
+## 2. 分层架构
+
+```mermaid
+flowchart TB
+  Settings["设置 · 通知"]
+  Prefs["preferences.agentAttention\n+ PATCHABLE_KEYS"]
+  Cache["main Attention settings 缓存"]
+  Probe["权限探针状态机"]
+  Attention["Attention 策略"]
+  SysN["系统通知通道"]
+  FA["ForegroundActivity"]
+  Index["Agent Runtime Index"]
+  Chrome["标题栏 / 命令面板 / 快捷键"]
+
+  Settings --> Prefs
+  Prefs --> Cache
+  Cache --> Attention
+  Settings --> Probe
+  Probe --> Settings
+  FA --> Attention
+  Attention --> SysN
+  SysN --> Probe
+  SysN -->|"click agent.attention"| Index
+  FA --> Index
+  Index --> Chrome
+```
+
+| 层 | 做 | 不做 |
+| --- | --- | --- |
+| preferences-service | 白名单 patch、广播 `changedKeys` | 静默丢未知业务字段却返回「成功」 |
+| Attention settings 缓存 | `preferences.changed` 同步更新；`settings()` **同步** | observe 内每次异步 read 当唯一路径（可作启动兜底） |
+| 权限探针 | main 独占状态机；强制探测；广播或 invoke 快照 | renderer 猜 OS 权限 |
+| Attention | 投递决策 | 读 provider 名、证据等级、hooks 开关（hooks 由安装/可选 FA 门闸处理） |
+
+---
+
+## 3. 设置信息架构
+
+### 3.1 导航
+
+- 独立分区 `notifications`（通知），顺序：`agents` → `notifications` → `plugins`。
+
+### 3.2 页面
+
+1. **权限健康**（`unsupported` / `denied` / `unknown` / `authorized`）  
+   - denied：banner + 打开系统设置 + **发送测试通知**（强制探测）  
+   - **不提供**无真实探测的「重新检查」空按钮；若保留文案，必须等同强制探测  
+   - unsupported：降级说明，无无效深链  
+
+2. **策略**：`enabled`、说明「需要确认时」、`enableErrorAttention`、`suppressWhenFocused`、`cooldownMs`（1/3/10 分）
+
+3. **自检**：发送测试通知；打开系统设置  
+
+4. **诚实说明**：仅 hook 报告的需要确认（及可选 error）；部分 CLI 无法报告；**状态钩子关闭**见 §6.4 原文承诺  
+
+### 3.3 不做的设置项
+
+完成通知、响铃、声音、历史、按项目规则、独立「需要确认」开关。
+
+---
+
+## 4. 数据契约与运行时
+
+### 4.1 设置
+
+```ts
+{
+  enabled: boolean;                 // default true
+  enableErrorAttention: boolean;    // default false
+  suppressWhenFocused: boolean;     // default true
+  cooldownMs: 60_000 | 180_000 | 600_000; // default 180_000
+}
+```
+
+- `src/shared/contracts/agent-attention.ts` + `preferences.agentAttention`  
+- **`src/main/services/preferences-service.ts` 的 `PATCHABLE_KEYS` 必须含 `"agentAttention"`**  
+- 更新方式：renderer 提交**完整** `agentAttention` 对象（四字段齐全）；main 整键替换，禁止只 patch 子字段导致 zod/合并丢键  
+- 广播：`preferences.changed` 含 `changedKeys: ["agentAttention"]`；Attention 缓存订阅后同步  
+
+### 4.2 权限探针状态机（强制）
+
+状态：`unsupported` | `denied` | `unknown` | `authorized`。
+
+| 事件 | 转移 |
+| --- | --- |
+| `!Notification.isSupported()` | → `unsupported`（终态类） |
+| 普通 show 权限失败 / sticky 学习 | → `denied`，`stickyDenied=true` |
+| 尚无证实 show | `unknown`（初值） |
+| 任意路径 `shown:true` | → `authorized`，**清除** `stickyDenied` |
+| 用户**强制探测**（测试通知） | 允许 **bypass sticky 一次** 真正调用 `Notification.show`；结果按上表更新 |
+| 只读 getStatus | 返回 last 状态 + `observedAt` + `source`（`cached` \| `forced-probe` \| `attention-delivery`）；**不得**假装实时问 OS |
+
+设置页打开：拉快照。  
+设置页可见且窗口 focus：可再拉快照（仍只是缓存，除非用户点测试）。  
+真实 Attention 投递结果回写探针。  
+权限状态变化：main → renderer 广播（建议 `PIER_BROADCAST` 新通道或复用 degraded 扩展为 full status）；设置页订阅，避免只依赖一次性 toast。
+
+### 4.3 打开系统设置
+
+macOS best-effort URL；失败 `opened:false` + `showAppAlert` 手动路径；禁止假成功 toast。
+
+### 4.4 测试通知
+
+- `kind: "agent.attention.test"`（或等价）；**无**业务 `agentRef`  
+- **不**写 Attention `lastNotified`  
+- 走强制探测路径（可 bypass sticky）  
+- click：激活 Pier 窗口即可  
+- 失败：toast/alert；成功：以 OS 通知为主  
+
+### 4.5 触发矩阵（冻结，替换 `previous !== next`）
+
+触发集 T：
+
+- 恒含 `waiting`  
+- 当 `enableErrorAttention` 时含 `error`  
+
+**仅当** `previous ∉ T` 且 `next ∈ T` 时进入 Attention 候选（「进入触发集」）。
+
+| previous → next | enableErrorAttention | 是否候选 |
+| --- | --- | --- |
+| ready/processing/tool/∅ → waiting | * | 是 |
+| ready/… → error | true | 是 |
+| ready/… → error | false | 否 |
+| waiting → waiting | * | 否 |
+| error → error | true | 否 |
+| waiting → error | true | **否**（同属 T，不重复吵） |
+| error → waiting | true | **否** |
+| waiting → processing | * | 否 |
+| error → ready | * | 否 |
+
+冷却与 focused/disabled 在进入候选之后仍可 skip。
+
+### 4.6 Attention 决策序
+
+```text
+1. !settings.enabled → skip (disabled)
+2. 未满足触发矩阵 → skip (filtered-status)
+3. suppressWhenFocused && focused → skip (focused)
+4. cooldown active → skip (cooldown)
+5. show(kind=agent.attention, tag, agentRef)  // 普通路径遵守 sticky
+6. shown:true → lastNotified + probe authorized
+   shown:false → 不记冷却；更新 probe
+```
+
+`settings()`：**同步**读 main 缓存；缓存由 preferences 广播更新；启动时 readPreferences 填初值。
+
+### 4.7 诊断原因码
+
+日志/单测：`disabled` | `focused` | `cooldown` | `filtered-status` | `unsupported` | `denied` | `shown`。用户面板非本迭代必达。
+
+### 4.8 操作反馈（摘要）
+
+设置保存 / 测试通知 / focus 的细则见 **§5 反馈通道总表**。Renderer store：update 失败须 revert 乐观态；不得「catch 后 swallow」。
+
+---
+
+## 5. 反馈通道总表（分级，非全系统通知）
+
+### 5.1 两类反馈（禁止混用）
+
+| 类型 | 回答的问题 | 合法通道 |
+| --- | --- | --- |
+| **注意力投递** | 有智能体需要你去处理吗？ | 系统通知（OS）· 标题栏 Needs you · Index / 命令面板 / `Mod+Shift+Y` · 终端 tab/状态栏 |
+| **操作反馈** | 我刚点的动作成功了吗？ | 强自然 UI · `toast` · `showAppAlert` |
+
+硬纪律（对齐 [AGENTS.md](../../../AGENTS.md) 与 2026-07-15 设计）：
+
+1. **不是**所有消息都走系统通知。  
+2. 系统通知 **不当** 操作成功/失败的主通道（`kind: agent.attention` 只服务可行动注意力）。  
+3. toast **不当** Agent 等待确认的主通道。  
+4. 成功 focus / 成功启动面板：**禁止** success toast。  
+5. 关系统通知或 OS 拒权后：标题栏 / Index / 快捷键 **仍是真相面**。
+
+### 5.2 通道强度（由强到弱）
+
+| 通道 | 强度 | 用途 |
+| --- | --- | --- |
+| 系统通知（OS） | 打断 | 仅：进入触发集 + 策略允许 + 未专注抑制 + 通道可用 |
+| 标题栏 Needs you / running | 常驻 | 本机全局计数；不依赖 OS 权限 |
+| Index 列表 / 命令面板 / focusWaiting | 主动 | 发现与回跳 |
+| 终端 tab / 状态栏 | 现场 | 本窗 FA（按窗隔离） |
+| `showAppAlert` | 操作失败·有详情 | 技术错误、打开系统设置失败等 |
+| `toast.error` / 短 toast | 操作失败·短 | 面板已关、无 Needs you、测试失败短因 |
+| 强自然 UI | 操作成功默认 | 开关态、面板激活、列表变化 |
+
+### 5.3 注意力类：哪些状态变化有反馈
+
+| 事件 | 系统通知 | 标题栏 / Index | toast / alert |
+| --- | --- | --- | --- |
+| 进入 `waiting`，未聚焦目标 panel，`enabled`，权限允许 | **是** | Needs you 计入 | **否** |
+| 进入 `waiting`，已聚焦且 `suppressWhenFocused` | **否** | 仍可计入 Needs you | **否**（现场足够） |
+| 进入 `error`，默认（`enableErrorAttention=false`） | **否** | Needs you 计入（error 属需要你） | **否** |
+| 进入 `error`，用户打开出错通知且未聚焦 | **是** | 同上 | **否** |
+| 持续 waiting / 触发集内 waiting↔error | **否**（不刷屏） | 保持 | **否** |
+| processing / tool / ready | **否** | running 或 ready 规则；**不**进 Needs you KPI 的 ready 默认不强调 | **否** |
+| 仅 launch、无 `status` | **否** | running 可计；**永不** Needs you | **否** |
+| 任务完成 → idle/ready | **否**（非目标） | 离开 Needs you | **否** |
+| `enabled=false` 时进入 waiting | **否** | **仍**更新 Needs you | **否** |
+| OS denied / unsupported 时进入 waiting | **否** | **仍**更新 Needs you | 设置 banner；可选一次性 degraded 提示（不刷屏） |
+| 冷却期内同 agentRef 再入触发集 | **否** | 不变 | **否** |
+| 用户划掉系统通知未点击 | — | 可继续强调至离开 Needs you | **否**；不强制清冷却 |
+
+### 5.4 操作类：用户动作的成败信号
+
+| 用户动作 | 成功 | 失败 |
+| --- | --- | --- |
+| Index / 标题栏列表 / 真 Attention 通知 → `focus` | 窗+面板激活（强自然 UI）；**禁止** success toast | 短：`toast.error`（面板/窗没了）；有技术详情：`showAppAlert` |
+| `pier.agents.focusWaiting` 且无 Needs you | — | 短 toast：「没有需要处理的智能体」 |
+| 设置：改 enabled / error / 抑制 / 冷却并保存 | 控件态即时更新；跨窗 `preferences.changed` | **必须** toast.error 或 showAppAlert；**禁止**仅 console |
+| 发送测试通知 | 以 OS 通知出现为主；可选极短 toast（可省略） | toast.error 或 showAppAlert |
+| 打开系统设置 | 系统界面出现 | showAppAlert 手动路径；**禁止**假「已打开」 |
+| 权限 denied / unsupported | — | 设置页常驻 banner；bridge 可一次 toast 引导 |
+| 启动 Agent（L3） | 新面板打开 = 成功 | 既有 agent 启动规范（toast / alert） |
+| 关闭状态钩子（S3） | 开关态 + 文案；uninstall 异步 | 卸载失败 showAppAlert |
+
+### 5.5 明确无用户消息的情况
+
+- Agent 正常 processing/tool 心跳  
+- Attention 内部 skip（disabled / focused / cooldown / filtered-status）——仅日志/诊断码  
+- focus **成功**、启动面板 **成功**  
+- 完成/空闲（本设计不做完成通知）
+
+### 5.6 实施检查（防回归）
+
+| 反模式 | 处理 |
+| --- | --- |
+| 凡 FA 变化都 `Notification.show` | 禁止；仅触发矩阵 + 决策序 |
+| 凡失败都打系统通知 | 禁止；操作失败走 toast/alert |
+| focus 成功再 toast.success | 禁止 |
+| `toast.*(…, { description })` 塞长详情 | 禁止；详情走 showAppAlert |
+| 系统通知文案冒充「已保存设置」 | 禁止 |
+| 关 OS 通道后清空 Needs you | 禁止 |
+
+### 5.7 与业界的对齐（说明，非新范围）
+
+桌面端常见分层：未聚焦可行动 → OS 打断；已聚焦 → 不扰；角标/计数常驻；操作成败 in-app。本表即该模型在 Pier 的落地；**不**追求移动端 push 粒度，**不**做通知历史 inbox。
+
+---
+
+## 6. 状态准确性治理
+
+### 6.1 原则
+
+1. waiting 唯一规范入口：`PermissionRequest`。  
+2. 有证据才断言；无信号不进 Needs you。  
+3. 禁 OCR/标题猜状态。  
+4. 设置开关不提高无证据准确率。  
+5. **门禁必须证明 provider → 规范事件 → FA → Index → Attention 候选**，禁止契约孤岛假绿。
+
+### 6.2 证据等级
+
+| 级 | 定义 | 承诺 |
+| --- | --- | --- |
+| A | 明确 permission/approval 原生事件 | waiting 可通知 |
+| B | 近似映射 | **本迭代重审**；留下的须有注释+测；否则删除映射 |
+| C | 有 hook 无 permission | 不承诺 waiting |
+| D | 仅 launch | 永不 Needs you |
+
+### 6.3 S1 Top 链（四家全锁）
+
+| Agent | 映射源（实施时以代码为准） | 链 |
+| --- | --- | --- |
+| Claude | nested `events`：`PermissionRequest`→`PermissionRequest` | 规范事件 → aggregator → `projectAgentActivities` → `needsYou` → Attention entered |
+| Codex | 同上 hooks 表 | 同上（对账不负责 permission） |
+| Copilot | `COPILOT_EVENTS`：`permissionRequest` | 同上 |
+| OpenCode | 运行时 `permission.updated`→`PermissionRequest`（导出纯函数或从安装产物/源码可测点断言） | 同上 |
+
+**禁止**：用 Mimo「同构注释」代替 OpenCode；禁止只 assert `activityStatusForHookEvent("PermissionRequest")`。
+
+### 6.4 S2 / S3
+
+**S2：** launch-only 无 hook 集成；无 status 条目 `needsYou===0` 且 Attention 不通知。
+
+**S3 hooks 关闭 — 诚实语义（修订）：**
+
+| 承诺 | 不承诺 |
+| --- | --- |
+| 偏好 `agentStatusHooks=false` 后触发 uninstall（异步）且启动时不安装 | 已在跑的 CLI 进程立即停止发 hook |
+| 卸载失败：`showAppAlert` / 用户可见错误，不得只 console | uninstall 完成前已排队的 JSONL 行 0 丢失 |
+| 设置双处文案与上表一致 | 「一点开关全世界立刻安静」 |
+
+**推荐工程加固（本迭代应做其一，优先 A）：**
+
+- **A.** FA/jsonl 摄入路径读取 `agentStatusHooks`：为 false 时**丢弃新 agent hook 事件**（仍允许 command lifecycle 等非 agent-hook）  
+- **B.** 若不做 A，文案必须写「需重开 Agent 会话后完全生效」，且 S3 测只锁文案+uninstall 调用，不声称即时无 waiting  
+
+既有 `waiting` 条目：hooks 关闭后**不**由 Attention 清除 FA；用户处理或会话结束后自然离开。关闭 hooks **不**自动发「已解决」通知。
+
+### 6.5 B 档（本迭代必做，非 backlog）
+
+对 Grok / Gemini / Droid 的 `Notification→PermissionRequest`、Cursor `beforeShellExecution`/`beforeMCPExecution`：
+
+1. 读集成注释与上游文档。  
+2. **保留**当且仅当可辩护为用户授权/确认信号；单测锁映射。  
+3. **删除或改映**若为一般通知/噪声；改映不得映到 PermissionRequest。  
+4. 附录 A 与代码同步；变更写进本设计附录。  
+
+未完成 B 审前，**不得**将本设计标为「状态准确性已实现」。
+
+### 6.6 展示纪律
+
+Needs you = `waiting|error`；launch 无 status 只算 running；Index 无证据等级字段。
+
+---
+
+## 7. 关键闭环补注
+
+### N8 持久化
+
+```text
+UI → preferences.update({ agentAttention })
+  → preferences-service.stripUndefinedPatch（白名单含 agentAttention）
+  → disk + preferences.changed
+  → Attention 缓存更新
+  → 下一次 observe 用新 settings
+```
+
+缺白名单 = **功能不存在**；Task 1 必须先测 service 层。
+
+### N6 恢复
+
+```text
+denied + sticky
+  → 用户「测试通知」forceProbe
+  → 真正 Notification.show
+  → shown:true → authorized, clear sticky
+  → shown:false 权限失败 → 保持 denied
+```
+
+---
+
+## 8. 分期
+
+| 阶段 | 交付 |
+| --- | --- |
+| 本设计实施 | §1.3 全闭环 + B 审 + 白名单 + 探针状态机 + 触发矩阵 |
+| 后续 | 完成通知（默认关）、声音、响铃独立页、插件 subscribe、agentRef 升级 |
+
+---
+
+## 9. 非目标
+
+完成/空闲默认通知、响铃、声音库、历史、侧栏、OCR waiting、Canvas attach、用开关伪造 waiting。
+
+---
+
+## 10. 总验收门禁
+
+| # | 门禁 | 通过 |
+| --- | --- | --- |
+| 1 | 语义单源 | 设置/探针不写 status |
+| 2 | 双通道 | 关通知或权限失败 Index 仍可用 |
+| 3 | 持久化真 | patch 白名单 + 重启后策略仍在 + Attention 行为变 |
+| 4 | 权限可恢复 | forceProbe 路径测绿 |
+| 5 | 触发矩阵 | waiting/error 全组合单测 |
+| 6 | S1 真链 | 四家映射+投影+Attention |
+| 7 | S2/S3 诚实 | 负向测 + 文案与门闸/语义一致 |
+| 8 | B 收敛 | 附录与代码一致；无未审噪声默认通知 |
+| 9 | 反馈分级 | 符合 §5 总表：注意力≠操作反馈；保存/测试失败用户可见；focus 无 success toast |
+
+---
+
+## 11. 风险与纪律
+
+1. Electron 无完美权限 API：强制探测是恢复关键。  
+2. 嵌套 preferences 必须整对象 + 白名单。  
+3. 禁止观察路径 `await readPreferences` 作为唯一 settings 源导致卡顿/竞态（缓存优先）。  
+4. B 映射宁缺毋吵。  
+5. 500 行文件拆分设置 UI。  
+
+---
+
+## 12. 附录 A · 证据等级（实施 Task 6 必须 diff 代码后定稿）
+
+| 级 | 初值代表 | 备注 |
+| --- | --- | --- |
+| A 候选 | Claude、Codex、Copilot、OpenCode、Qwen、… | S1 四家硬门禁 |
+| B 已审保留 | Grok/Gemini/Droid Notification；Cursor shell/MCP before | 2026-07-16 审查：均为授权/确认邻接信号，保留并单测锁定 |
+| C | Kiro 等 | 无 waiting |
+| D | ante、codebuff、continue、rovo、openclaw | 仅 launch |
+
+---
+
+## 13. 参考
+
+- [2026-07-15 Index / Attention](./2026-07-15-agent-runtime-index-and-attention-design.md)  
+- [2026-07-13 状态审计](./2026-07-13-agent-status-adapter-contract-audit.md)  
+- `src/main/services/preferences-service.ts`（`PATCHABLE_KEYS`）  
+- `src/main/services/system-notification.ts`（`stickyDenied`）  
+- `src/main/services/agent-attention/attention-service.ts`（`enteredAttention`）  
+- [AGENTS.md](../../../AGENTS.md)  

--- a/src/main/app-core/command-router.ts
+++ b/src/main/app-core/command-router.ts
@@ -161,11 +161,13 @@ async function executeAppStateCommand(
     case "preferences.update": {
       const merged = await services.preferences.update(command.patch);
       if (command.patch.agentStatusHooks !== undefined) {
-        applyAgentStatusHooksPreference(merged.agentStatusHooks).catch(
-          (err) => {
-            console.error("[preferences] agent hook install failed:", err);
-          }
-        );
+        // 偏好与摄入门闸以落盘值为准；hook 安装/卸载 best-effort，
+        // 单家失败只记日志，不让 preferences.update 失败回滚 UI。
+        try {
+          await applyAgentStatusHooksPreference(merged.agentStatusHooks);
+        } catch (err) {
+          console.error("[preferences] agent hook install failed:", err);
+        }
       }
       return success(requestId, merged);
     }

--- a/src/main/app-core/window-broadcasts.ts
+++ b/src/main/app-core/window-broadcasts.ts
@@ -5,7 +5,10 @@ import type {
 import type { AppUpdateSnapshot } from "@shared/contracts/app-update.ts";
 import type { MruState } from "@shared/contracts/command-palette-mru.ts";
 import type { LocalEnvironmentState } from "@shared/contracts/environment.ts";
-import type { SystemNotificationUnavailableReason } from "@shared/contracts/notification.ts";
+import type {
+  SystemNotificationPermissionSnapshot,
+  SystemNotificationUnavailableReason,
+} from "@shared/contracts/notification.ts";
 import type { PluginRegistryListResult } from "@shared/contracts/plugin.ts";
 import type { TaskRunsSnapshot } from "@shared/contracts/tasks.ts";
 import type { TerminalStatusBarPrefs } from "@shared/contracts/terminal-status-bar.ts";
@@ -97,4 +100,13 @@ export function broadcastAgentAttentionDegraded(payload: {
   reason: SystemNotificationUnavailableReason;
 }): void {
   broadcastToAllWindows(PIER_BROADCAST.AGENT_ATTENTION_DEGRADED, payload);
+}
+
+export function broadcastSystemNotificationPermissionChanged(
+  snapshot: SystemNotificationPermissionSnapshot
+): void {
+  broadcastToAllWindows(
+    PIER_BROADCAST.SYSTEM_NOTIFICATION_PERMISSION_CHANGED,
+    snapshot
+  );
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -385,7 +385,10 @@ if (gotTheLock) {
       registerMenuIpc(ipcMain);
       registerAgentsIpc(ipcMain);
       registerForegroundActivityIpc(ipcMain);
-      registerAgentRuntimeHostIpc(ipcMain, appCore.services.agentRuntimeIndex);
+      registerAgentRuntimeHostIpc(ipcMain, {
+        eventBus: appCore.eventBus,
+        index: appCore.services.agentRuntimeIndex,
+      });
       registerSystemStatsIpc(ipcMain);
       registerUsageDataIpc(ipcMain, appCore.services.usageData);
       ipcMain.handle(PIER.APP_QUIT_DECISION, (_event, payload: unknown) => {

--- a/src/main/ipc/agent-attention.ts
+++ b/src/main/ipc/agent-attention.ts
@@ -1,12 +1,20 @@
+import type { PierEventBus } from "@main/app-core/event-bus.ts";
 import type { AgentAttentionService } from "@main/services/agent-attention/attention-service.ts";
 import { createAgentAttentionService } from "@main/services/agent-attention/attention-service.ts";
 import { focusAgentFromNotificationClick } from "@main/services/agent-attention/notification-click-focus.ts";
 import type { AttentionUiLocale } from "@main/services/agent-attention/notification-copy.ts";
 import type { AgentRuntimeIndexService } from "@main/services/agent-runtime-index/index.ts";
+import {
+  type AgentAttentionSettings,
+  DEFAULT_AGENT_ATTENTION_SETTINGS,
+} from "@shared/contracts/agent-attention.ts";
 import type { ForegroundActivityBroadcast } from "@shared/contracts/foreground-activity.ts";
 import { createLogger } from "@shared/logger.ts";
 import { app } from "electron";
-import { broadcastAgentAttentionDegraded } from "../app-core/window-broadcasts.ts";
+import {
+  broadcastAgentAttentionDegraded,
+  broadcastSystemNotificationPermissionChanged,
+} from "../app-core/window-broadcasts.ts";
 import { showSystemNotification } from "../services/system-notification.ts";
 import { readPreferences } from "../state/preferences.ts";
 import { windowManager } from "../windows/window-manager.ts";
@@ -16,6 +24,7 @@ import { terminalFocusCoordinator } from "./terminal-focus-coordinator.ts";
 const log = createLogger("agent-attention.ipc");
 
 export interface RegisterAgentAttentionArgs {
+  eventBus?: PierEventBus;
   index: AgentRuntimeIndexService;
 }
 
@@ -54,19 +63,57 @@ async function resolveAttentionLocale(): Promise<AttentionUiLocale> {
 
 /**
  * 挂 FA 发布钩子：Attention 消费本机 status 变迁并发系统通知。
- * 通知 click 与 notification IPC 共用 `focusAgentFromNotificationClick`。
+ * settings 同步缓存：boot read + preferences.changed。
+ * boot 完成前 enabled 强制 false，避免用默认值误弹通知。
  */
 export function registerAgentAttention(
   args: RegisterAgentAttentionArgs
 ): AgentAttentionService {
   let degradedBroadcasted = false;
+  let settingsReady = false;
+  let cachedSettings: AgentAttentionSettings = {
+    ...DEFAULT_AGENT_ATTENTION_SETTINGS,
+    // 偏好读完前保守：不发系统通知（标题栏 Index 仍可更新）。
+    enabled: false,
+  };
+
+  readPreferences()
+    .then((prefs) => {
+      cachedSettings = { ...prefs.agentAttention };
+      settingsReady = true;
+    })
+    .catch((err: unknown) => {
+      log.debug("boot attention settings read failed; using product defaults", {
+        err,
+      });
+      cachedSettings = { ...DEFAULT_AGENT_ATTENTION_SETTINGS };
+      settingsReady = true;
+    });
+
+  args.eventBus?.subscribe((event) => {
+    if (event.type !== "preferences.changed") {
+      return;
+    }
+    if (!event.changedKeys.includes("agentAttention")) {
+      return;
+    }
+    cachedSettings = { ...event.snapshot.agentAttention };
+    settingsReady = true;
+  });
 
   const attention = createAgentAttentionService({
     isTargetPanelFocused,
     resolveLocale: resolveAttentionLocale,
+    settings: () => {
+      if (!settingsReady) {
+        return { ...cachedSettings, enabled: false };
+      }
+      return cachedSettings;
+    },
     showNotification: (request) =>
       showSystemNotification(request, {
         onClick: (shown) => focusAgentFromNotificationClick(args.index, shown),
+        onPermissionChanged: broadcastSystemNotificationPermissionChanged,
         onUnavailable: (reason) => {
           if (reason !== "denied" && reason !== "unsupported") {
             return;

--- a/src/main/ipc/agent-runtime-host.ts
+++ b/src/main/ipc/agent-runtime-host.ts
@@ -1,3 +1,4 @@
+import type { PierEventBus } from "@main/app-core/event-bus.ts";
 import type { AgentRuntimeIndexService } from "@main/services/agent-runtime-index/index.ts";
 import type { IpcMain } from "electron";
 import { registerAgentAttention } from "./agent-attention.ts";
@@ -7,12 +8,20 @@ import {
   registerNotificationIpc,
 } from "./notification.ts";
 
+export interface RegisterAgentRuntimeHostIpcArgs {
+  eventBus?: PierEventBus;
+  index: AgentRuntimeIndexService;
+}
+
 /** Agent Runtime Index + Attention + system notification click→focus wiring. */
 export function registerAgentRuntimeHostIpc(
   ipcMain: IpcMain,
-  index: AgentRuntimeIndexService
+  args: RegisterAgentRuntimeHostIpcArgs
 ): void {
-  registerAgentRuntimeIndexIpc(ipcMain, index);
-  registerAgentAttention({ index });
-  registerNotificationIpc(ipcMain, bindNotificationFocus(index));
+  registerAgentRuntimeIndexIpc(ipcMain, args.index);
+  registerAgentAttention({
+    index: args.index,
+    ...(args.eventBus ? { eventBus: args.eventBus } : {}),
+  });
+  registerNotificationIpc(ipcMain, bindNotificationFocus(args.index));
 }

--- a/src/main/ipc/foreground-activity.ts
+++ b/src/main/ipc/foreground-activity.ts
@@ -10,6 +10,10 @@ import {
   installAgentHooksEmitScript,
 } from "../services/agents/agent-hooks-install.ts";
 import {
+  isAgentStatusHooksIngestEnabled,
+  setAgentStatusHooksIngestEnabled,
+} from "../services/agents/agent-status-hooks-gate.ts";
+import {
   getAgentHookIntegration,
   installAllAgentHooks,
   uninstallAllAgentHooks,
@@ -269,6 +273,9 @@ export function registerForegroundActivityIpc(ipcMain: IpcMain): void {
   jsonlObserver = createJsonlObserver({
     filePath: eventsJsonlPath(app.getPath("userData")),
     onAgentEvent: (event) => {
+      if (!isAgentStatusHooksIngestEnabled()) {
+        return;
+      }
       const accepted = foregroundActivityAggregator.ingestAgentEvent(event, {
         stopAuthority:
           getAgentHookIntegration(event.agent)?.runtime.stopAuthority ?? "none",
@@ -322,9 +329,12 @@ export function registerForegroundActivityIpc(ipcMain: IpcMain): void {
   // 启动时按偏好双向对齐 hook 安装状态（幂等）：开→装, 关→卸。
   // 关闭态必须主动卸载, 防止旧版本/外部同步写回的 hook 静默复活。
   readPreferences()
-    .then((prefs) =>
-      prefs.agentStatusHooks ? installAllAgentHooks() : uninstallAllAgentHooks()
-    )
+    .then((prefs) => {
+      setAgentStatusHooksIngestEnabled(prefs.agentStatusHooks);
+      return prefs.agentStatusHooks
+        ? installAllAgentHooks()
+        : uninstallAllAgentHooks();
+    })
     .catch((err) => {
       log.error("startup hook install failed", { err });
     });

--- a/src/main/ipc/notification.ts
+++ b/src/main/ipc/notification.ts
@@ -1,14 +1,29 @@
 import type { AgentRuntimeIndexService } from "@main/services/agent-runtime-index/index.ts";
 import type {
+  SystemNotificationPermissionSnapshot,
   SystemNotificationRequest,
   SystemNotificationResult,
 } from "@shared/contracts/notification.ts";
-import type { IpcMain } from "electron";
+import { PIER } from "@shared/ipc-channels.ts";
+import { app, type IpcMain } from "electron";
+import { broadcastSystemNotificationPermissionChanged } from "../app-core/window-broadcasts.ts";
 import { focusAgentFromNotificationClick } from "../services/agent-attention/notification-click-focus.ts";
-import { showSystemNotification } from "../services/system-notification.ts";
+import {
+  getSystemNotificationPermissionSnapshot,
+  openSystemNotificationSettings,
+  showSystemNotification,
+  showTestSystemNotification,
+} from "../services/system-notification.ts";
+import { windowManager } from "../windows/window-manager.ts";
 
 export interface NotificationIpcDeps {
   index?: AgentRuntimeIndexService;
+}
+
+function onPermissionChanged(
+  snapshot: SystemNotificationPermissionSnapshot
+): void {
+  broadcastSystemNotificationPermissionChanged(snapshot);
 }
 
 /**
@@ -32,7 +47,37 @@ export function registerNotificationIpc(
           }
           await focusAgentFromNotificationClick(deps.index, shown);
         },
+        onPermissionChanged,
       })
+  );
+
+  ipcMain.handle(PIER.SYSTEM_NOTIFICATION_PERMISSION, () =>
+    getSystemNotificationPermissionSnapshot()
+  );
+
+  ipcMain.handle(PIER.SYSTEM_NOTIFICATION_TEST, () =>
+    showTestSystemNotification({
+      onClick: () => {
+        // 测试通知：激活任一 Pier 窗口，不 focus 业务 agent。
+        const target =
+          windowManager.getFocused() ?? windowManager.getAll()[0] ?? null;
+        if (!target || target.isDestroyed()) {
+          return;
+        }
+        if (target.isMinimized()) {
+          target.restore();
+        }
+        if (process.platform === "darwin") {
+          app.focus({ steal: true });
+        }
+        target.focus();
+      },
+      onPermissionChanged,
+    })
+  );
+
+  ipcMain.handle(PIER.SYSTEM_NOTIFICATION_OPEN_SETTINGS, () =>
+    openSystemNotificationSettings()
   );
 }
 

--- a/src/main/services/agent-attention/attention-service.ts
+++ b/src/main/services/agent-attention/attention-service.ts
@@ -34,6 +34,7 @@ export interface CreateAgentAttentionServiceArgs {
   isTargetPanelFocused(electronWindowId: string, panelId: string): boolean;
   now?(): number;
   resolveLocale?(): AttentionUiLocale | Promise<AttentionUiLocale>;
+  /** 同步读取当前策略（main 缓存）；禁止在此做异步 IO。 */
   settings?(): AgentAttentionSettings;
   showNotification(
     request: SystemNotificationRequest
@@ -55,7 +56,8 @@ function agentStatusMap(
   return map;
 }
 
-function shouldTriggerForStatus(
+/** 触发集 T：waiting 恒在；error 仅当 enableErrorAttention。 */
+function inTriggerSet(
   status: ActivityStatus | undefined,
   settings: AgentAttentionSettings
 ): boolean {
@@ -65,15 +67,16 @@ function shouldTriggerForStatus(
   return settings.enableErrorAttention && status === "error";
 }
 
+/**
+ * 仅当 previous ∉ T 且 next ∈ T 时进入候选（非 previous !== next）。
+ * waiting↔error 同属 T 时不重复通知。
+ */
 function enteredAttention(
   previous: ActivityStatus | undefined,
   next: ActivityStatus | undefined,
   settings: AgentAttentionSettings
 ): boolean {
-  if (!shouldTriggerForStatus(next, settings)) {
-    return false;
-  }
-  return previous !== next;
+  return !inTriggerSet(previous, settings) && inTriggerSet(next, settings);
 }
 
 export function createAgentAttentionService({
@@ -91,6 +94,10 @@ export function createAgentAttentionService({
     },
     async observe(previous, next) {
       const prefs = settings();
+      if (!prefs.enabled) {
+        return;
+      }
+
       const prevMap = previous
         ? agentStatusMap(previous.activities)
         : new Map<string, ActivityStatus | undefined>();
@@ -106,7 +113,10 @@ export function createAgentAttentionService({
           continue;
         }
 
-        if (isTargetPanelFocused(activity.windowId, activity.panelId)) {
+        if (
+          prefs.suppressWhenFocused &&
+          isTargetPanelFocused(activity.windowId, activity.panelId)
+        ) {
           log.debug("skip notify: target panel focused", { agentRef });
           continue;
         }

--- a/src/main/services/agents/agent-status-hooks-gate.ts
+++ b/src/main/services/agents/agent-status-hooks-gate.ts
@@ -1,0 +1,13 @@
+/**
+ * agentStatusHooks 偏好的摄入门闸（与 install/uninstall 同步）。
+ * 独立小模块，避免 registry ↔ foreground-activity IPC 循环依赖。
+ */
+let agentStatusHooksIngestEnabled = true;
+
+export function setAgentStatusHooksIngestEnabled(enabled: boolean): void {
+  agentStatusHooksIngestEnabled = enabled;
+}
+
+export function isAgentStatusHooksIngestEnabled(): boolean {
+  return agentStatusHooksIngestEnabled;
+}

--- a/src/main/services/agents/integrations/claude.ts
+++ b/src/main/services/agents/integrations/claude.ts
@@ -43,6 +43,8 @@ const CLAUDE_SPEC: NestedJsonIntegrationSpec = {
   ],
 };
 
+export const CLAUDE_HOOK_EVENTS = CLAUDE_SPEC.events;
+
 export const claudeIntegration = createNestedJsonIntegration(CLAUDE_SPEC);
 
 /** 兼容导出（既有测试/调用方使用；语义与工厂一致）。 */

--- a/src/main/services/agents/integrations/codex.ts
+++ b/src/main/services/agents/integrations/codex.ts
@@ -84,6 +84,8 @@ const CODEX_SPEC: NestedJsonIntegrationSpec = {
   ],
 };
 
+export const CODEX_HOOK_EVENTS = CODEX_SPEC.events;
+
 export const codexIntegration = createNestedJsonIntegration(CODEX_SPEC);
 
 /** 兼容导出（与 claude.ts 一致的模式；语义与工厂一致）。 */

--- a/src/main/services/agents/integrations/copilot.ts
+++ b/src/main/services/agents/integrations/copilot.ts
@@ -17,7 +17,7 @@ const TIMEOUT_SECONDS = 5;
 const configPath = () => join(homedir(), ".copilot", "hooks", "pier.json");
 
 /** Copilot CLI hook 事件 → pier 事件名。 */
-const COPILOT_EVENTS: ReadonlyArray<{
+export const COPILOT_EVENTS: ReadonlyArray<{
   nativeEvent: string;
   pierEvent: string;
 }> = [

--- a/src/main/services/agents/integrations/cursor.ts
+++ b/src/main/services/agents/integrations/cursor.ts
@@ -21,23 +21,25 @@ const configPath = () => join(homedir(), ".cursor", "hooks.json");
  * → PermissionRequest；afterAgentResponse 近似"仍在处理" → processing
  * （loomdesk running≈processing 的映射）。
  */
-const CURSOR_EVENTS: ReadonlyArray<{ nativeEvent: string; pierEvent: string }> =
-  [
-    { nativeEvent: "sessionStart", pierEvent: "SessionStart" },
-    { nativeEvent: "beforeSubmitPrompt", pierEvent: "PromptSubmit" },
-    { nativeEvent: "preToolUse", pierEvent: "ToolStart" },
-    { nativeEvent: "postToolUse", pierEvent: "ToolComplete" },
-    { nativeEvent: "postToolUseFailure", pierEvent: "ToolComplete" },
-    { nativeEvent: "beforeShellExecution", pierEvent: "PermissionRequest" },
-    { nativeEvent: "beforeMCPExecution", pierEvent: "PermissionRequest" },
-    { nativeEvent: "afterShellExecution", pierEvent: "ToolComplete" },
-    { nativeEvent: "afterMCPExecution", pierEvent: "ToolComplete" },
-    { nativeEvent: "afterAgentResponse", pierEvent: "processing" },
-    { nativeEvent: "subagentStart", pierEvent: "SubagentStart" },
-    { nativeEvent: "subagentStop", pierEvent: "SubagentStop" },
-    { nativeEvent: "stop", pierEvent: "Stop" },
-    { nativeEvent: "sessionEnd", pierEvent: "SessionEnd" },
-  ];
+export const CURSOR_EVENTS: ReadonlyArray<{
+  nativeEvent: string;
+  pierEvent: string;
+}> = [
+  { nativeEvent: "sessionStart", pierEvent: "SessionStart" },
+  { nativeEvent: "beforeSubmitPrompt", pierEvent: "PromptSubmit" },
+  { nativeEvent: "preToolUse", pierEvent: "ToolStart" },
+  { nativeEvent: "postToolUse", pierEvent: "ToolComplete" },
+  { nativeEvent: "postToolUseFailure", pierEvent: "ToolComplete" },
+  { nativeEvent: "beforeShellExecution", pierEvent: "PermissionRequest" },
+  { nativeEvent: "beforeMCPExecution", pierEvent: "PermissionRequest" },
+  { nativeEvent: "afterShellExecution", pierEvent: "ToolComplete" },
+  { nativeEvent: "afterMCPExecution", pierEvent: "ToolComplete" },
+  { nativeEvent: "afterAgentResponse", pierEvent: "processing" },
+  { nativeEvent: "subagentStart", pierEvent: "SubagentStart" },
+  { nativeEvent: "subagentStop", pierEvent: "SubagentStop" },
+  { nativeEvent: "stop", pierEvent: "Stop" },
+  { nativeEvent: "sessionEnd", pierEvent: "SessionEnd" },
+];
 
 interface CursorHookEntry {
   command: string;

--- a/src/main/services/agents/integrations/droid.ts
+++ b/src/main/services/agents/integrations/droid.ts
@@ -71,6 +71,8 @@ const DROID_SPEC: NestedJsonIntegrationSpec = {
   ],
 };
 
+export const DROID_HOOK_EVENTS = DROID_SPEC.events;
+
 const droidBase = createNestedJsonIntegration(DROID_SPEC);
 
 export const droidIntegration: typeof droidBase = {

--- a/src/main/services/agents/integrations/gemini.ts
+++ b/src/main/services/agents/integrations/gemini.ts
@@ -51,6 +51,8 @@ const GEMINI_SPEC: NestedJsonIntegrationSpec = {
   timeoutSeconds: 10_000,
 };
 
+export const GEMINI_HOOK_EVENTS = GEMINI_SPEC.events;
+
 export const geminiIntegration = createNestedJsonIntegration(GEMINI_SPEC);
 
 /** 兼容导出（沿袭 claude 集成的既有纪律；语义与工厂一致）。 */

--- a/src/main/services/agents/integrations/grok.ts
+++ b/src/main/services/agents/integrations/grok.ts
@@ -70,4 +70,6 @@ const GROK_SPEC: NestedJsonIntegrationSpec = {
   ],
 };
 
+export const GROK_HOOK_EVENTS = GROK_SPEC.events;
+
 export const grokIntegration = createNestedJsonIntegration(GROK_SPEC);

--- a/src/main/services/agents/integrations/opencode.ts
+++ b/src/main/services/agents/integrations/opencode.ts
@@ -9,6 +9,19 @@ import { JAVASCRIPT_LOCKED_APPEND_SOURCE } from "./writer-lock-source.ts";
 
 const AGENT_ID: AgentKind = "opencode";
 
+/** Host-side evidence table for S1 gates (mirrors plugin mapPierEvent). */
+export const OPENCODE_PERMISSION_NATIVE_EVENTS = [
+  "permission.updated",
+] as const;
+
+export function mapOpenCodeNativeEventToPier(
+  nativeType: string
+): string | null {
+  if (nativeType === "permission.updated") return "PermissionRequest";
+  if (nativeType === "permission.replied") return "processing";
+  return null;
+}
+
 /**
  * 插件文件名。部署进 opencode 的**自动发现目录**（<configRoot>/plugins/）——
  * 实证发现 config `plugin` 数组的绝对路径注册在当前 opencode 版本不生效

--- a/src/main/services/agents/integrations/registry.ts
+++ b/src/main/services/agents/integrations/registry.ts
@@ -1,4 +1,5 @@
 import type { AgentKind } from "@shared/contracts/agent.ts";
+import { setAgentStatusHooksIngestEnabled } from "../agent-status-hooks-gate.ts";
 import { aiderIntegration } from "./aider.ts";
 import { ampIntegration } from "./amp.ts";
 import { antigravityIntegration } from "./antigravity.ts";
@@ -80,7 +81,7 @@ export function getAgentHookIntegration(
 
 /**
  * 幂等安装全部已检测到的集成。单个失败不影响其他（逐个隔离告警）——
- * 一家 agent 的配置异常不应拖垮整个状态功能。
+ * 一家 agent 的配置异常不应拖垮整个状态功能 / 偏好切换。
  */
 export async function installAllAgentHooks(): Promise<void> {
   await Promise.allSettled(
@@ -100,6 +101,7 @@ export async function installAllAgentHooks(): Promise<void> {
 /**
  * 卸载全部集成。不设 detect 门控——二进制已卸但配置残留时也要能清干净；
  * 对从未安装过的目标, 变换无变化不落盘, 零副作用。
+ * 单个失败不影响其他，也不回滚偏好 / 摄入门闸。
  */
 export async function uninstallAllAgentHooks(): Promise<void> {
   await Promise.allSettled(
@@ -116,5 +118,6 @@ export async function uninstallAllAgentHooks(): Promise<void> {
 export async function applyAgentStatusHooksPreference(
   enabled: boolean
 ): Promise<void> {
+  setAgentStatusHooksIngestEnabled(enabled);
   await (enabled ? installAllAgentHooks() : uninstallAllAgentHooks());
 }

--- a/src/main/services/preferences-service.ts
+++ b/src/main/services/preferences-service.ts
@@ -28,6 +28,7 @@ export interface CreatePreferencesServiceArgs {
 
 /** 白名单键——patch 里 undefined 的字段不下传 (zod 会替代为默认值)。 */
 const PATCHABLE_KEYS = [
+  "agentAttention",
   "agentCommandOverrides",
   "agentDefaultArgs",
   "agentDefaultEnv",

--- a/src/main/services/system-notification.ts
+++ b/src/main/services/system-notification.ts
@@ -1,36 +1,88 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { AGENT_ATTENTION_TEST_KIND } from "@shared/contracts/agent-attention.ts";
 import type {
+  OpenSystemNotificationSettingsResult,
+  SystemNotificationPermissionSnapshot,
+  SystemNotificationPermissionSource,
+  SystemNotificationPermissionStatus,
   SystemNotificationRequest,
   SystemNotificationResult,
   SystemNotificationUnavailableReason,
 } from "@shared/contracts/notification.ts";
 import { systemNotificationRequestSchema } from "@shared/contracts/notification.ts";
 import { createLogger } from "@shared/logger.ts";
-import { Notification } from "electron";
+import { Notification, shell } from "electron";
 
 const log = createLogger("system-notification");
+const execFileAsync = promisify(execFile);
 
 /** Keep instances alive so click handlers remain reachable (esp. Windows). */
 const liveByTag = new Map<string, Notification>();
 const untitledLive = new Set<Notification>();
 
 /**
- * 权限类失败后粘性降级：后续调用直接 shown:false，避免假成功记冷却。
- * Electron 无稳定同步查权限 API；依赖 `failed` 事件学习。
+ * 权限类失败后粘性降级：普通路径直接 shown:false。
+ * 用户强制探测（测试通知）可 bypass 一次真正 show。
  */
 let stickyDenied = false;
+let permissionStatus: SystemNotificationPermissionStatus = "unknown";
+let permissionObservedAt = 0;
+let permissionSource: SystemNotificationPermissionSource = "boot";
 
+/** 普通 Attention 投递：短超时，避免误记冷却。 */
 const SHOW_SETTLE_MS = 250;
+/** 用户强制探测：macOS 常不发 show 事件或较晚；无 failed 则视为已投递。 */
+const FORCE_PROBE_SETTLE_MS = 2000;
 
 export interface ShowSystemNotificationOptions {
+  /**
+   * 用户发起的强制探测：忽略 stickyDenied 一次，真正调用 Notification.show。
+   * 仅测试通知等自检路径使用；Attention 业务路径不得传 true。
+   */
+  forceProbe?: boolean;
   onClick?: (request: SystemNotificationRequest) => void | Promise<void>;
+  /** 权限快照更新后回调（设置页订阅）。 */
+  onPermissionChanged?: (
+    snapshot: SystemNotificationPermissionSnapshot
+  ) => void;
   /** 通知未能展示（含粘性拒绝）时回调，供 Attention 提示用户看标题栏。 */
   onUnavailable?: (reason: SystemNotificationUnavailableReason) => void;
 }
 
 export function resetSystemNotificationPermissionStateForTests(): void {
   stickyDenied = false;
+  permissionStatus = "unknown";
+  permissionObservedAt = 0;
+  permissionSource = "boot";
   liveByTag.clear();
   untitledLive.clear();
+}
+
+export function getSystemNotificationPermissionSnapshot(): SystemNotificationPermissionSnapshot {
+  if (!Notification.isSupported()) {
+    return {
+      observedAt: Date.now(),
+      source: "cached",
+      status: "unsupported",
+    };
+  }
+  return {
+    observedAt: permissionObservedAt || Date.now(),
+    source: permissionSource,
+    status: permissionStatus,
+  };
+}
+
+function recordPermission(
+  status: SystemNotificationPermissionStatus,
+  source: SystemNotificationPermissionSource,
+  onPermissionChanged?: (snapshot: SystemNotificationPermissionSnapshot) => void
+): void {
+  permissionStatus = status;
+  permissionSource = source;
+  permissionObservedAt = Date.now();
+  onPermissionChanged?.(getSystemNotificationPermissionSnapshot());
 }
 
 function isPermissionFailure(error: string): boolean {
@@ -48,12 +100,16 @@ function isPermissionFailure(error: string): boolean {
 
 /**
  * 展示系统通知。异步等待 `show` / `failed`（短超时兜底），
- * 权限拒绝记 sticky，后续不再谎报 shown:true。
+ * 权限拒绝记 sticky；forceProbe 可 bypass sticky 一次。
  */
 export async function showSystemNotification(
   raw: SystemNotificationRequest,
   options: ShowSystemNotificationOptions = {}
 ): Promise<SystemNotificationResult> {
+  const deliverySource: SystemNotificationPermissionSource = options.forceProbe
+    ? "forced-probe"
+    : "attention-delivery";
+
   const parsed = systemNotificationRequestSchema.safeParse(raw);
   if (!parsed.success) {
     log.warn("invalid system notification request", {
@@ -69,6 +125,11 @@ export async function showSystemNotification(
   const request = parsed.data;
 
   if (!Notification.isSupported()) {
+    recordPermission(
+      "unsupported",
+      deliverySource,
+      options.onPermissionChanged
+    );
     const result = {
       reason: "unsupported" as const,
       shown: false,
@@ -77,7 +138,8 @@ export async function showSystemNotification(
     return result;
   }
 
-  if (stickyDenied) {
+  if (stickyDenied && !options.forceProbe) {
+    recordPermission("denied", "cached", options.onPermissionChanged);
     const result = {
       reason: "denied" as const,
       shown: false,
@@ -98,9 +160,14 @@ export async function showSystemNotification(
     }
   }
 
+  const isTestKind = request.kind === AGENT_ATTENTION_TEST_KIND;
   const notification = new Notification({
     title: request.title,
+    silent: false,
     ...(request.body ? { body: request.body } : {}),
+    ...(isTestKind && process.platform === "darwin"
+      ? { subtitle: "Pier" }
+      : {}),
   });
 
   if (request.tag) {
@@ -148,11 +215,19 @@ export async function showSystemNotification(
       finish({ shown: true });
     });
 
-    const timer = setTimeout(() => {
-      // 部分平台不保证 show 事件。超时不得乐观 shown:true（会误记 Attention
-      // 冷却并跳过权限降级）；未证实展示则 shown:false，不记冷却。
-      finish({ reason: "failed", shown: false });
-    }, SHOW_SETTLE_MS);
+    const timer = setTimeout(
+      () => {
+        // 部分平台（尤其 macOS）不保证 show 事件。
+        // 业务 Attention：超时 = 未证实展示，不记冷却。
+        // 用户 forceProbe：show() 未抛错且未 failed → 视为已投递给系统。
+        if (options.forceProbe) {
+          finish({ shown: true });
+          return;
+        }
+        finish({ reason: "failed", shown: false });
+      },
+      options.forceProbe ? FORCE_PROBE_SETTLE_MS : SHOW_SETTLE_MS
+    );
 
     try {
       notification.show();
@@ -173,13 +248,84 @@ export async function showSystemNotification(
       return;
     }
     stickyDenied = true;
+    recordPermission("denied", deliverySource, options.onPermissionChanged);
     options.onUnavailable?.("denied");
   });
 
+  if (outcome.shown) {
+    stickyDenied = false;
+    recordPermission("authorized", deliverySource, options.onPermissionChanged);
+  } else if (outcome.reason === "denied") {
+    recordPermission("denied", deliverySource, options.onPermissionChanged);
+  }
+
   if (!outcome.shown && outcome.reason && outcome.reason !== "failed") {
-    // 超时/瞬时 failed 不弹降级 toast；denied / unsupported / invalid 才提示。
     options.onUnavailable?.(outcome.reason);
   }
 
   return outcome;
+}
+
+/** 设置页「发送测试通知」：forceProbe，不携带业务 agentRef。 */
+export async function showTestSystemNotification(
+  options: Omit<ShowSystemNotificationOptions, "forceProbe"> = {}
+): Promise<SystemNotificationResult> {
+  return showSystemNotification(
+    {
+      body: "If you see this banner or Notification Center item, delivery works.",
+      kind: AGENT_ATTENTION_TEST_KIND,
+      tag: `${AGENT_ATTENTION_TEST_KIND}:${Date.now()}`,
+      title: "Pier test notification",
+    },
+    {
+      ...options,
+      forceProbe: true,
+    }
+  );
+}
+
+/**
+ * 尽力打开系统通知偏好。失败返回 opened:false，由 UI 展示手动路径。
+ */
+export async function openSystemNotificationSettings(): Promise<OpenSystemNotificationSettingsResult> {
+  try {
+    if (process.platform === "darwin") {
+      // 不要用 shell.openExternal 打开 x-apple.systempreferences：
+      // Electron/dev 壳下可能落到 Electron 默认页（空壳），而不是系统设置。
+      // 用系统 open(1) 交给 LaunchServices 更稳。
+      const candidates = [
+        [
+          "x-apple.systempreferences:com.apple.Notifications-Settings.extension",
+        ],
+        ["x-apple.systempreferences:com.apple.preference.notifications"],
+        ["-b", "com.apple.systempreferences"],
+      ];
+      for (const args of candidates) {
+        try {
+          await execFileAsync("open", args);
+          return { opened: true };
+        } catch (err) {
+          log.debug("open notification settings candidate failed", {
+            args,
+            err,
+          });
+        }
+      }
+      return { opened: false, reason: "open-failed" };
+    }
+    if (process.platform === "win32") {
+      await shell.openExternal("ms-settings:notifications");
+      return { opened: true };
+    }
+    return {
+      opened: false,
+      reason: "unsupported-platform",
+    };
+  } catch (err) {
+    log.warn("open system notification settings failed", { err });
+    return {
+      opened: false,
+      reason: err instanceof Error ? err.message : String(err),
+    };
+  }
 }

--- a/src/main/state/preferences.ts
+++ b/src/main/state/preferences.ts
@@ -1,5 +1,6 @@
 import { join } from "node:path";
 import { resolvePermissionMode } from "@shared/contracts/agent.ts";
+import { DEFAULT_AGENT_ATTENTION_SETTINGS } from "@shared/contracts/agent-attention.ts";
 import {
   DEFAULT_APP_QUIT_CONFIRMATION_MODE,
   DEFAULT_GIT_AUTO_FETCH_ENABLED,
@@ -48,6 +49,7 @@ const DEFAULTS: ProjectPreferences = {
   agentCommandOverrides: {},
   worktreeRootPath: "",
   agentStatusHooks: true,
+  agentAttention: { ...DEFAULT_AGENT_ATTENTION_SETTINGS },
   gitAutoFetchEnabled: DEFAULT_GIT_AUTO_FETCH_ENABLED,
   gitAutoFetchIntervalMinutes: DEFAULT_GIT_AUTO_FETCH_INTERVAL_MINUTES,
 };

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -12,6 +12,8 @@ import type {
   MenuTemplate,
 } from "@shared/contracts/menu.ts";
 import type {
+  OpenSystemNotificationSettingsResult,
+  SystemNotificationPermissionSnapshot,
   SystemNotificationRequest,
   SystemNotificationResult,
 } from "@shared/contracts/notification.ts";
@@ -110,6 +112,12 @@ export interface PierAgentsAPI {
 }
 
 export interface PierNotificationsAPI {
+  getPermissionStatus: () => Promise<SystemNotificationPermissionSnapshot>;
+  onPermissionChanged: (
+    cb: (snapshot: SystemNotificationPermissionSnapshot) => void
+  ) => () => void;
+  openSystemSettings: () => Promise<OpenSystemNotificationSettingsResult>;
+  sendTest: () => Promise<SystemNotificationResult>;
   system: (
     request: SystemNotificationRequest
   ) => Promise<SystemNotificationResult>;
@@ -277,6 +285,29 @@ const preferencesApi: PierPreferencesAPI = {
 };
 
 const notificationsApi: PierNotificationsAPI = {
+  getPermissionStatus: () =>
+    ipcRenderer.invoke(PIER.SYSTEM_NOTIFICATION_PERMISSION),
+  onPermissionChanged: (cb) => {
+    const listener = (
+      _event: unknown,
+      payload: SystemNotificationPermissionSnapshot
+    ): void => {
+      cb(payload);
+    };
+    ipcRenderer.on(
+      PIER_BROADCAST.SYSTEM_NOTIFICATION_PERMISSION_CHANGED,
+      listener
+    );
+    return () => {
+      ipcRenderer.off(
+        PIER_BROADCAST.SYSTEM_NOTIFICATION_PERMISSION_CHANGED,
+        listener
+      );
+    };
+  },
+  openSystemSettings: () =>
+    ipcRenderer.invoke(PIER.SYSTEM_NOTIFICATION_OPEN_SETTINGS),
+  sendTest: () => ipcRenderer.invoke(PIER.SYSTEM_NOTIFICATION_TEST),
   system: (request) => ipcRenderer.invoke("pier:notification:system", request),
 };
 

--- a/src/renderer/i18n/locales/en/settings.ts
+++ b/src/renderer/i18n/locales/en/settings.ts
@@ -12,6 +12,7 @@ export const settings = {
     updates: "Updates",
     workspace: "Workspace",
     agents: "Agents",
+    notifications: "Notifications",
     pluginGroup: "Plugin Settings",
   },
   section: {
@@ -24,6 +25,7 @@ export const settings = {
     updates: "Updates",
     workspace: "Workspace",
     agents: "Agents",
+    notifications: "Notifications",
   },
   environment: {
     addEnvironment: "Add environment setting",
@@ -408,7 +410,56 @@ export const settings = {
     statusHooks: {
       label: "Agent status awareness",
       description:
-        "Panels show live Claude Code running/waiting state via status hooks in ~/.claude/settings.json. Turn off to remove Pier-managed hooks and stop reinstalling them",
+        "Show live agent run/wait status in panels via status hooks. Turning off uninstalls Pier hooks and stops reinstall; Needs-you system notifications will not appear. Running sessions may still report until reopened.",
+      failed: "Could not update agent status hooks",
+    },
+  },
+  notifications: {
+    enabled: "Enable system notifications",
+    enabledDesc:
+      "Deliver OS notifications when an agent needs you (title bar counts still update when off).",
+    waitingHint:
+      "Needs confirmation (waiting): follows the master switch above.",
+    error: "Notify on agent errors",
+    errorDesc:
+      "Also notify when an agent enters an error state. Off by default.",
+    suppress: "Suppress when focused",
+    suppressDesc:
+      "Skip OS notifications when the target agent panel is already focused.",
+    cooldownLabel: "Cooldown per agent",
+    cooldownDesc:
+      "Minimum time between OS notifications for the same agent panel.",
+    cooldown: {
+      "60000": "1 minute",
+      "180000": "3 minutes",
+      "600000": "10 minutes",
+    },
+    sendTest: "Send test notification",
+    openSystemSettings: "Open system settings",
+    testSent: "Test notification sent",
+    testFailed: "Test notification failed",
+    testFailedShort: "Could not show test notification",
+    testFailedDetail:
+      "Could not deliver a system notification ({{reason}}). Allow this app in System Settings → Notifications, then try again.",
+    testHint:
+      "Success means delivered to the OS. Frontmost banners may be hidden — check Notification Center.",
+    openSettingsFailed: "Could not open system settings",
+    openSettingsManual:
+      "Open your OS notification settings manually and allow Pier, then send a test notification.",
+    saveFailed: "Could not save notification settings",
+    hooksOffTitle: "Agent status hooks are off",
+    hooksOffBody:
+      "Needs-you system notifications will not appear until status hooks are enabled. Running agent sessions may still report until reopened.",
+    permission: {
+      deniedTitle: "System notifications are blocked",
+      deniedBody:
+        "Allow notifications for Pier in system settings, then send a test notification to verify.",
+      unsupportedTitle: "System notifications are unavailable",
+      unsupportedBody:
+        "This environment cannot show OS notifications. Use the title bar Needs you count and agent list instead.",
+      unknownTitle: "Notification permission not verified yet",
+      unknownBody:
+        "Send a test notification to check whether Pier can deliver OS alerts.",
     },
   },
 } as const;

--- a/src/renderer/i18n/locales/zh-CN/settings.ts
+++ b/src/renderer/i18n/locales/zh-CN/settings.ts
@@ -12,6 +12,7 @@ export const settings = {
     updates: "更新",
     workspace: "工作区",
     agents: "智能体",
+    notifications: "通知",
     pluginGroup: "插件设置",
   },
   section: {
@@ -24,6 +25,7 @@ export const settings = {
     updates: "更新",
     workspace: "工作区",
     agents: "智能体",
+    notifications: "通知",
   },
   environment: {
     addEnvironment: "添加环境设置",
@@ -400,7 +402,49 @@ export const settings = {
     statusHooks: {
       label: "Agent 状态感知",
       description:
-        "面板实时显示 Claude Code 运行/等待状态（经 ~/.claude/settings.json 状态上报 hook）。关闭将移除 Pier 安装的 hook 并停止重装",
+        "面板实时显示 agent 运行/等待状态（经状态上报 hook）。关闭将卸载 Pier hook 并停止重装；不会出现 Needs you 系统通知。已在运行的会话可能仍上报，重开后完全生效",
+      failed: "无法更新 Agent 状态感知",
+    },
+  },
+  notifications: {
+    enabled: "启用系统通知",
+    enabledDesc:
+      "智能体需要你时通过本机系统通知提醒（关闭后标题栏计数仍更新）。",
+    waitingHint: "需要确认（waiting）：跟随上方总开关。",
+    error: "出错时通知",
+    errorDesc: "智能体进入错误状态时也发送系统通知。默认关闭。",
+    suppress: "专注时抑制",
+    suppressDesc: "目标智能体面板已聚焦时不发送系统通知。",
+    cooldownLabel: "同一智能体冷却",
+    cooldownDesc: "同一智能体面板两次系统通知之间的最短间隔。",
+    cooldown: {
+      "60000": "1 分钟",
+      "180000": "3 分钟",
+      "600000": "10 分钟",
+    },
+    sendTest: "发送测试通知",
+    openSystemSettings: "打开系统设置",
+    testSent: "已发送测试通知",
+    testFailed: "测试通知失败",
+    testFailedShort: "无法展示测试通知",
+    testFailedDetail:
+      "无法投递系统通知（{{reason}}）。请到「系统设置 → 通知」允许本应用，然后重试。",
+    testHint: "成功表示已交给系统。前台可能看不到横幅，可到通知中心确认。",
+    openSettingsFailed: "无法打开系统设置",
+    openSettingsManual:
+      "请手动打开系统通知设置并为 Pier 开启允许，然后发送测试通知验证。",
+    saveFailed: "无法保存通知设置",
+    hooksOffTitle: "Agent 状态感知已关闭",
+    hooksOffBody:
+      "关闭后不会出现 Needs you 系统通知。已在运行的智能体会话可能仍会上报，重开会话后完全生效。",
+    permission: {
+      deniedTitle: "系统通知未授权",
+      deniedBody: "请在系统设置中为 Pier 开启通知，然后发送测试通知验证。",
+      unsupportedTitle: "系统不支持通知",
+      unsupportedBody:
+        "当前环境无法展示系统通知。请使用标题栏 Needs you 计数与智能体列表。",
+      unknownTitle: "尚未确认通知权限",
+      unknownBody: "发送测试通知以检查 Pier 能否投递系统提醒。",
     },
   },
 } as const;

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -36,6 +36,7 @@ import { keybindingRegistry } from "./lib/keybindings/registry.ts";
 import { bootstrapBuiltinPlugins } from "./lib/plugins/bootstrap.ts";
 import { registerTerminalActions } from "./panel-kits/terminal/register-actions.ts";
 import { registerTerminalPanelCloseGuard } from "./panel-kits/terminal/register-close-guard.ts";
+import { initAgentAttentionPreferences } from "./stores/agent-attention-preferences.store.ts";
 import { initAgentDetection } from "./stores/agent-detect.store.ts";
 import { initAgentPreferences } from "./stores/agent-preferences.store.ts";
 import { initAppQuitPreferences } from "./stores/app-quit-preferences.store.ts";
@@ -118,6 +119,7 @@ async function bootstrap() {
       initTerminalPreferences(),
       initAppQuitPreferences(),
       initAgentPreferences(),
+      initAgentAttentionPreferences(),
       initTerminalStatusBarPrefs(),
       initTaskRunsStore(),
       initWorktreePreferences(),

--- a/src/renderer/pages/settings/components/agents-section.tsx
+++ b/src/renderer/pages/settings/components/agents-section.tsx
@@ -153,7 +153,12 @@ function AgentStatusHooksRow() {
       id="agent-status-hooks"
       label={t("settings.agents.statusHooks.label")}
       onCheckedChange={(next) => {
-        setEnabled(next).catch(() => undefined);
+        setEnabled(next).catch((err: unknown) => {
+          showAppAlert({
+            body: err instanceof Error ? err.message : String(err),
+            title: t("settings.agents.statusHooks.failed"),
+          }).catch(() => undefined);
+        });
       }}
     />
   );

--- a/src/renderer/pages/settings/components/notifications-section.tsx
+++ b/src/renderer/pages/settings/components/notifications-section.tsx
@@ -1,0 +1,345 @@
+import { Alert, AlertDescription, AlertTitle } from "@pier/ui/alert.tsx";
+import { Button } from "@pier/ui/button.tsx";
+import { Card, CardContent } from "@pier/ui/card.tsx";
+import { FieldSet } from "@pier/ui/field.tsx";
+import {
+  AGENT_ATTENTION_COOLDOWN_MS,
+  type AgentAttentionCooldownMs,
+  type AgentAttentionSettings,
+} from "@shared/contracts/agent-attention.ts";
+import type { SystemNotificationPermissionSnapshot } from "@shared/contracts/notification.ts";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import { useT } from "@/i18n/use-t.ts";
+import { SelectRow } from "@/pages/settings/components/rows/select-row.tsx";
+import { SwitchRow } from "@/pages/settings/components/rows/switch-row.tsx";
+import { useAgentAttentionPreferencesStore } from "@/stores/agent-attention-preferences.store.ts";
+import { useAgentPreferencesStore } from "@/stores/agent-preferences.store.ts";
+import { showAppAlert } from "@/stores/app-dialog.store.ts";
+
+function usePermissionSnapshot(): SystemNotificationPermissionSnapshot | null {
+  const [snapshot, setSnapshot] =
+    useState<SystemNotificationPermissionSnapshot | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    window.pier.notifications
+      .getPermissionStatus()
+      .then((next) => {
+        if (!cancelled) {
+          setSnapshot(next);
+        }
+      })
+      .catch(() => undefined);
+
+    const off = window.pier.notifications.onPermissionChanged((next) => {
+      setSnapshot(next);
+    });
+
+    const onFocus = () => {
+      window.pier.notifications
+        .getPermissionStatus()
+        .then((next) => {
+          if (!cancelled) {
+            setSnapshot(next);
+          }
+        })
+        .catch(() => undefined);
+    };
+    window.addEventListener("focus", onFocus);
+
+    return () => {
+      cancelled = true;
+      off();
+      window.removeEventListener("focus", onFocus);
+    };
+  }, []);
+
+  return snapshot;
+}
+
+async function patchAttention(
+  patch: Partial<AgentAttentionSettings>,
+  setAgentAttention: (
+    next:
+      | AgentAttentionSettings
+      | ((current: AgentAttentionSettings) => AgentAttentionSettings)
+  ) => Promise<void>,
+  failedTitle: string
+): Promise<void> {
+  try {
+    await setAgentAttention((current) => ({ ...current, ...patch }));
+  } catch (err) {
+    await showAppAlert({
+      body: err instanceof Error ? err.message : String(err),
+      title: failedTitle,
+    });
+  }
+}
+
+function PermissionBanner({
+  snapshot,
+}: {
+  snapshot: SystemNotificationPermissionSnapshot | null;
+}) {
+  const t = useT();
+  if (!snapshot || snapshot.status === "authorized") {
+    return null;
+  }
+
+  if (snapshot.status === "unsupported") {
+    return (
+      <Alert variant="warning">
+        <AlertTitle>
+          {t("settings.notifications.permission.unsupportedTitle")}
+        </AlertTitle>
+        <AlertDescription>
+          {t("settings.notifications.permission.unsupportedBody")}
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
+  if (snapshot.status === "denied") {
+    return (
+      <Alert variant="warning">
+        <AlertTitle>
+          {t("settings.notifications.permission.deniedTitle")}
+        </AlertTitle>
+        <AlertDescription>
+          {t("settings.notifications.permission.deniedBody")}
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
+  return (
+    <Alert variant="info">
+      <AlertTitle>
+        {t("settings.notifications.permission.unknownTitle")}
+      </AlertTitle>
+      <AlertDescription>
+        {t("settings.notifications.permission.unknownBody")}
+      </AlertDescription>
+    </Alert>
+  );
+}
+
+function PolicyCard({
+  snapshot,
+}: {
+  snapshot: SystemNotificationPermissionSnapshot | null;
+}) {
+  const t = useT();
+  const agentAttention = useAgentAttentionPreferencesStore(
+    (s) => s.agentAttention
+  );
+  const setAgentAttention = useAgentAttentionPreferencesStore(
+    (s) => s.setAgentAttention
+  );
+  const agentStatusHooks = useAgentPreferencesStore((s) => s.agentStatusHooks);
+  const failedTitle = t("settings.notifications.saveFailed");
+  const showPermission = snapshot !== null && snapshot.status !== "authorized";
+  const showHooksOff = !agentStatusHooks;
+
+  const cooldownOptions = AGENT_ATTENTION_COOLDOWN_MS.map((ms) => ({
+    label: t(`settings.notifications.cooldown.${ms}`),
+    value: String(ms),
+  }));
+
+  return (
+    <Card>
+      <CardContent className="flex flex-col gap-4">
+        {showPermission || showHooksOff ? (
+          <div className="flex flex-col gap-3">
+            {showPermission ? <PermissionBanner snapshot={snapshot} /> : null}
+            {showHooksOff ? <StatusHooksHint /> : null}
+          </div>
+        ) : null}
+        <FieldSet>
+          <SwitchRow
+            checked={agentAttention.enabled}
+            description={t("settings.notifications.enabledDesc")}
+            id="settings-attention-enabled"
+            label={t("settings.notifications.enabled")}
+            onCheckedChange={(checked) => {
+              patchAttention(
+                { enabled: checked },
+                setAgentAttention,
+                failedTitle
+              ).catch(() => undefined);
+            }}
+          />
+          <div className="text-muted-foreground text-sm">
+            {t("settings.notifications.waitingHint")}
+          </div>
+          <SwitchRow
+            checked={agentAttention.enableErrorAttention}
+            description={t("settings.notifications.errorDesc")}
+            id="settings-attention-error"
+            label={t("settings.notifications.error")}
+            onCheckedChange={(checked) => {
+              patchAttention(
+                { enableErrorAttention: checked },
+                setAgentAttention,
+                failedTitle
+              ).catch(() => undefined);
+            }}
+          />
+          <SwitchRow
+            checked={agentAttention.suppressWhenFocused}
+            description={t("settings.notifications.suppressDesc")}
+            id="settings-attention-suppress"
+            label={t("settings.notifications.suppress")}
+            onCheckedChange={(checked) => {
+              patchAttention(
+                { suppressWhenFocused: checked },
+                setAgentAttention,
+                failedTitle
+              ).catch(() => undefined);
+            }}
+          />
+          <SelectRow<string>
+            description={t("settings.notifications.cooldownDesc")}
+            id="settings-attention-cooldown"
+            label={t("settings.notifications.cooldownLabel")}
+            onChange={(value) => {
+              const cooldownMs = Number(value) as AgentAttentionCooldownMs;
+              patchAttention(
+                { cooldownMs },
+                setAgentAttention,
+                failedTitle
+              ).catch(() => undefined);
+            }}
+            options={cooldownOptions}
+            triggerWidth="w-[160px]"
+            value={String(agentAttention.cooldownMs)}
+          />
+        </FieldSet>
+      </CardContent>
+    </Card>
+  );
+}
+
+function DiagnosticsCard() {
+  const t = useT();
+  const [busy, setBusy] = useState(false);
+
+  const runSendTest = () => {
+    setBusy(true);
+    window.pier.notifications
+      .sendTest()
+      .then((result) => {
+        if (result.shown) {
+          toast.success(t("settings.notifications.testSent"));
+          return;
+        }
+        return showAppAlert({
+          body: t("settings.notifications.testFailedDetail", {
+            reason: result.reason ?? "failed",
+          }),
+          title: t("settings.notifications.testFailed"),
+        });
+      })
+      .catch((err: unknown) =>
+        showAppAlert({
+          body: err instanceof Error ? err.message : String(err),
+          title: t("settings.notifications.testFailed"),
+        })
+      )
+      .finally(() => {
+        setBusy(false);
+      });
+  };
+
+  const openSystemSettings = () => {
+    setBusy(true);
+    window.pier.notifications
+      .openSystemSettings()
+      .then((result) => {
+        if (result.opened) {
+          return;
+        }
+        return showAppAlert({
+          body: t("settings.notifications.openSettingsManual"),
+          title: t("settings.notifications.openSettingsFailed"),
+        });
+      })
+      .catch((err: unknown) =>
+        showAppAlert({
+          body: err instanceof Error ? err.message : String(err),
+          title: t("settings.notifications.openSettingsFailed"),
+        })
+      )
+      .finally(() => {
+        setBusy(false);
+      });
+  };
+
+  return (
+    <Card>
+      <CardContent className="flex flex-col gap-3">
+        <div className="flex flex-wrap gap-2">
+          <Button
+            disabled={busy}
+            onClick={() => {
+              runSendTest();
+            }}
+            size="sm"
+            type="button"
+            variant="outline"
+          >
+            {t("settings.notifications.sendTest")}
+          </Button>
+          <Button
+            disabled={busy}
+            onClick={() => {
+              openSystemSettings();
+            }}
+            size="sm"
+            type="button"
+            variant="outline"
+          >
+            {t("settings.notifications.openSystemSettings")}
+          </Button>
+        </div>
+        <p className="text-muted-foreground text-sm">
+          {t("settings.notifications.testHint")}
+        </p>
+      </CardContent>
+    </Card>
+  );
+}
+
+function StatusHooksHint() {
+  const t = useT();
+  const agentStatusHooks = useAgentPreferencesStore((s) => s.agentStatusHooks);
+  if (agentStatusHooks) {
+    return null;
+  }
+  return (
+    <Alert variant="warning">
+      <AlertTitle>{t("settings.notifications.hooksOffTitle")}</AlertTitle>
+      <AlertDescription>
+        {t("settings.notifications.hooksOffBody")}
+      </AlertDescription>
+    </Alert>
+  );
+}
+
+/**
+ * 通知设置：Attention 策略 + 系统通知通道健康。
+ * 权限/hooks Alert 并入策略 Card 顶部（与插件页「Card 内 Alert」一致，避免卡套卡）。
+ */
+export function NotificationsSection() {
+  const t = useT();
+  const snapshot = usePermissionSnapshot();
+
+  return (
+    <div className="flex flex-col gap-4 px-4 pb-4" id="notifications">
+      <h1 className="text-xl">{t("settings.section.notifications")}</h1>
+      <PolicyCard snapshot={snapshot} />
+      <DiagnosticsCard />
+    </div>
+  );
+}

--- a/src/renderer/pages/settings/data/appearance-nav.ts
+++ b/src/renderer/pages/settings/data/appearance-nav.ts
@@ -1,5 +1,6 @@
 import type { PluginRegistryEntry } from "@shared/contracts/plugin.ts";
 import {
+  Bell,
   Bot,
   Box,
   Download,
@@ -38,6 +39,7 @@ export const NAV_ITEMS: readonly StaticNavItem[] = [
   { id: "environment", icon: Box, variant: "static" },
   { id: "keybindings", icon: Keyboard, variant: "static" },
   { id: "agents", icon: Bot, variant: "static" },
+  { id: "notifications", icon: Bell, variant: "static" },
   { id: "plugins", icon: Plug, variant: "static" },
   { id: "updates", icon: Download, variant: "static" },
 ] as const;

--- a/src/renderer/pages/settings/settings-dialog.tsx
+++ b/src/renderer/pages/settings/settings-dialog.tsx
@@ -30,6 +30,7 @@ import { AppUpdateSection } from "@/pages/settings/components/app-update-section
 import { AppearanceSection } from "@/pages/settings/components/appearance-section.tsx";
 import { EnvironmentSection } from "@/pages/settings/components/environment-section.tsx";
 import { KeybindingsSection } from "@/pages/settings/components/keybindings-section.tsx";
+import { NotificationsSection } from "@/pages/settings/components/notifications-section.tsx";
 import { PluginConfigurationSection } from "@/pages/settings/components/plugin-configuration-section.tsx";
 import { PluginsSection } from "@/pages/settings/components/plugins-section.tsx";
 import { TerminalSection } from "@/pages/settings/components/terminal-section.tsx";
@@ -205,6 +206,9 @@ export function SettingsDialog() {
             {activeSection === "plugins" ? <PluginsSection /> : null}
             {activeSection === "environment" ? <EnvironmentSection /> : null}
             {activeSection === "agents" ? <AgentsSection /> : null}
+            {activeSection === "notifications" ? (
+              <NotificationsSection />
+            ) : null}
             {activePluginId ? (
               <PluginSettingsSection pluginId={activePluginId} />
             ) : null}

--- a/src/renderer/stores/agent-attention-preferences.store.ts
+++ b/src/renderer/stores/agent-attention-preferences.store.ts
@@ -1,0 +1,100 @@
+import {
+  type AgentAttentionSettings,
+  DEFAULT_AGENT_ATTENTION_SETTINGS,
+} from "@shared/contracts/agent-attention.ts";
+import type { ProjectPreferences } from "@shared/contracts/preferences.ts";
+import { create } from "zustand";
+
+interface AgentAttentionPreferencesState {
+  _hydrate: (next: AgentAttentionSettings) => void;
+  agentAttention: AgentAttentionSettings;
+  /**
+   * 接受完整对象或基于最新 state 的 patch 函数，避免连点用过期 current 覆盖。
+   */
+  setAgentAttention: (
+    next:
+      | AgentAttentionSettings
+      | ((current: AgentAttentionSettings) => AgentAttentionSettings)
+  ) => Promise<void>;
+}
+
+function snapshotFrom(prefs: ProjectPreferences): AgentAttentionSettings {
+  return { ...prefs.agentAttention };
+}
+
+/** 串行化写，避免并发 update 乱序。 */
+let writeChain: Promise<void> = Promise.resolve();
+
+export const useAgentAttentionPreferencesStore =
+  create<AgentAttentionPreferencesState>((set, get) => ({
+    agentAttention: { ...DEFAULT_AGENT_ATTENTION_SETTINGS },
+
+    _hydrate(next) {
+      set({ agentAttention: { ...next } });
+    },
+
+    async setAgentAttention(nextOrUpdater) {
+      const run = async (): Promise<void> => {
+        const prev = get().agentAttention;
+        const next =
+          typeof nextOrUpdater === "function"
+            ? nextOrUpdater(prev)
+            : nextOrUpdater;
+        set({ agentAttention: { ...next } });
+        try {
+          const merged = await window.pier.preferences.update({
+            agentAttention: next,
+          });
+          set({ agentAttention: snapshotFrom(merged) });
+        } catch (err) {
+          set({ agentAttention: prev });
+          throw err;
+        }
+      };
+
+      const queued = writeChain.then(run, run);
+      writeChain = queued.then(
+        () => undefined,
+        () => undefined
+      );
+      await queued;
+    },
+  }));
+
+let listenerAttached = false;
+let detachFn: (() => void) | null = null;
+
+function attachListener(): void {
+  if (listenerAttached || typeof window === "undefined") {
+    return;
+  }
+  const detach = window.pier?.preferences?.onChanged?.((next) => {
+    useAgentAttentionPreferencesStore.getState()._hydrate(snapshotFrom(next));
+  });
+  if (!detach) {
+    return;
+  }
+  detachFn = detach;
+  listenerAttached = true;
+}
+
+export function detachAgentAttentionPreferencesListener(): void {
+  detachFn?.();
+  detachFn = null;
+  listenerAttached = false;
+}
+
+export async function initAgentAttentionPreferences(): Promise<void> {
+  attachListener();
+  try {
+    const snapshot = await window.pier.preferences.read();
+    useAgentAttentionPreferencesStore
+      .getState()
+      ._hydrate(snapshotFrom(snapshot));
+  } catch (err) {
+    console.error(
+      "[agent-attention-preferences.store] init failed; keeping defaults:",
+      err
+    );
+  }
+}

--- a/src/renderer/stores/agent-preferences.store.ts
+++ b/src/renderer/stores/agent-preferences.store.ts
@@ -67,7 +67,7 @@ interface AgentPreferencesState extends AgentPreferenceSnapshot {
 }
 
 export const useAgentPreferencesStore = create<AgentPreferencesState>(
-  (set) => ({
+  (set, get) => ({
     agentCommandOverrides: {},
     agentDefaultArgs: {},
     agentDefaultEnv: {},
@@ -169,16 +169,20 @@ export const useAgentPreferencesStore = create<AgentPreferencesState>(
     },
 
     async setAgentStatusHooks(next) {
+      const prev = get().agentStatusHooks;
+      set({ agentStatusHooks: next });
       try {
         const merged = await window.pier.preferences.update({
           agentStatusHooks: next,
         });
         useAgentPreferencesStore.getState()._hydrate(snapshotFrom(merged));
       } catch (err) {
+        set({ agentStatusHooks: prev });
         console.error(
           "[agent-preferences.store] setAgentStatusHooks failed:",
           err
         );
+        throw err;
       }
     },
   })

--- a/src/shared/contracts/agent-attention.ts
+++ b/src/shared/contracts/agent-attention.ts
@@ -1,17 +1,41 @@
 /**
- * Agent Attention 策略设置（P1.5）。
- * 默认可硬编码；设置页持久化可 follow-up。
+ * Agent Attention 策略设置。
+ * 持久化：preferences.agentAttention（须经 preferences-service PATCHABLE_KEYS）。
+ * 系统通知权限探针类型见 `@shared/contracts/notification.ts`。
  */
-export interface AgentAttentionSettings {
-  /** 同一 agentRef 冷却间隔（毫秒）。 */
-  cooldownMs: number;
-  /** 进入 `error` 是否也发系统通知；默认 false（仅 waiting）。 */
-  enableErrorAttention: boolean;
-}
+import { z } from "zod";
+
+export const AGENT_ATTENTION_COOLDOWN_MS = [60_000, 180_000, 600_000] as const;
+export type AgentAttentionCooldownMs =
+  (typeof AGENT_ATTENTION_COOLDOWN_MS)[number];
+
+export const agentAttentionSettingsSchema = z
+  .object({
+    /** 是否向 OS 投递系统通知；关后 Index/标题栏仍更新。 */
+    enabled: z.boolean(),
+    /** 进入 `error` 是否也发系统通知；默认 false（仅 waiting）。 */
+    enableErrorAttention: z.boolean(),
+    /** 目标 panel 已聚焦时是否抑制系统通知。 */
+    suppressWhenFocused: z.boolean(),
+    /** 同一 agentRef 冷却间隔（毫秒）。 */
+    cooldownMs: z.union([
+      z.literal(60_000),
+      z.literal(180_000),
+      z.literal(600_000),
+    ]),
+  })
+  .strict();
+
+export type AgentAttentionSettings = z.infer<
+  typeof agentAttentionSettingsSchema
+>;
 
 export const DEFAULT_AGENT_ATTENTION_SETTINGS: AgentAttentionSettings = {
-  cooldownMs: 180_000,
+  enabled: true,
   enableErrorAttention: false,
+  suppressWhenFocused: true,
+  cooldownMs: 180_000,
 };
 
 export const AGENT_ATTENTION_KIND = "agent.attention" as const;
+export const AGENT_ATTENTION_TEST_KIND = "agent.attention.test" as const;

--- a/src/shared/contracts/notification.ts
+++ b/src/shared/contracts/notification.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 /**
  * 系统级通知（OS 通知中心），与 renderer 内 toast 是两条独立通道。
  * Attention 必填 `kind: "agent.attention"` + `agentRef`；其它调用方勿占用该 kind。
+ * 测试通知使用 `kind: "agent.attention.test"`，无业务 agentRef。
  */
 export const systemNotificationRequestSchema = z
   .object({
@@ -38,4 +39,49 @@ export const systemNotificationResultSchema = z
 
 export type SystemNotificationResult = z.infer<
   typeof systemNotificationResultSchema
+>;
+
+export const systemNotificationPermissionStatusSchema = z.enum([
+  "unsupported",
+  "denied",
+  "unknown",
+  "authorized",
+]);
+
+export type SystemNotificationPermissionStatus = z.infer<
+  typeof systemNotificationPermissionStatusSchema
+>;
+
+export const systemNotificationPermissionSourceSchema = z.enum([
+  "boot",
+  "cached",
+  "forced-probe",
+  "attention-delivery",
+]);
+
+export type SystemNotificationPermissionSource = z.infer<
+  typeof systemNotificationPermissionSourceSchema
+>;
+
+export const systemNotificationPermissionSnapshotSchema = z
+  .object({
+    observedAt: z.number().int().nonnegative(),
+    source: systemNotificationPermissionSourceSchema,
+    status: systemNotificationPermissionStatusSchema,
+  })
+  .strict();
+
+export type SystemNotificationPermissionSnapshot = z.infer<
+  typeof systemNotificationPermissionSnapshotSchema
+>;
+
+export const openSystemNotificationSettingsResultSchema = z
+  .object({
+    opened: z.boolean(),
+    reason: z.string().optional(),
+  })
+  .strict();
+
+export type OpenSystemNotificationSettingsResult = z.infer<
+  typeof openSystemNotificationSettingsResultSchema
 >;

--- a/src/shared/contracts/preferences.ts
+++ b/src/shared/contracts/preferences.ts
@@ -6,6 +6,10 @@ import {
   agentKindSchema,
   agentPermissionModePreferenceSchema,
 } from "./agent.ts";
+import {
+  agentAttentionSettingsSchema,
+  DEFAULT_AGENT_ATTENTION_SETTINGS,
+} from "./agent-attention.ts";
 
 export const themePreferenceSchema = z.enum(["light", "dark", "system"]);
 export const resolvedThemeSchema = z.enum(["light", "dark"]);
@@ -121,6 +125,9 @@ export const projectPreferencesSchema = z.object({
   worktreeRootPath: z.string().max(1024).default(""),
   /** 是否向已安装 agent 的官方 hook 配置里注入 Pier agent 状态 hook (opt-out, 默认开; 关闭即卸载)。 */
   agentStatusHooks: z.boolean().default(true),
+  agentAttention: agentAttentionSettingsSchema.default(
+    DEFAULT_AGENT_ATTENTION_SETTINGS
+  ),
   gitAutoFetchEnabled: z.boolean().default(DEFAULT_GIT_AUTO_FETCH_ENABLED),
   gitAutoFetchIntervalMinutes: z
     .number()

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -42,6 +42,10 @@ export const PIER = {
   AGENT_RUNTIME_INDEX_LIST: "pier://agent-runtime-index:list",
   AGENT_RUNTIME_INDEX_FOCUS: "pier://agent-runtime-index:focus",
   AGENT_RUNTIME_INDEX_FOCUS_WAITING: "pier://agent-runtime-index:focusWaiting",
+  // 系统通知：权限快照 / 测试 / 打开系统设置
+  SYSTEM_NOTIFICATION_PERMISSION: "pier://notification:permission",
+  SYSTEM_NOTIFICATION_TEST: "pier://notification:test",
+  SYSTEM_NOTIFICATION_OPEN_SETTINGS: "pier://notification:open-settings",
 } as const;
 
 export const PIER_BROADCAST = {
@@ -106,6 +110,9 @@ export const PIER_BROADCAST = {
   AGENT_RUNTIME_FOCUS_FEEDBACK: "pier://agent-runtime-index:focus-feedback",
   // Attention 系统通知不可用（权限拒绝等）；payload { reason }
   AGENT_ATTENTION_DEGRADED: "pier://agent-attention:degraded",
+  // 系统通知权限探针快照变化；payload SystemNotificationPermissionSnapshot
+  SYSTEM_NOTIFICATION_PERMISSION_CHANGED:
+    "pier://notification:permission-changed",
 } as const;
 
 export type PierCommand = (typeof PIER)[keyof typeof PIER];

--- a/tests/unit/main/agent-attention.test.ts
+++ b/tests/unit/main/agent-attention.test.ts
@@ -226,4 +226,69 @@ describe("agent attention service", () => {
     );
     expect(showNotification).toHaveBeenCalledTimes(2);
   });
+
+  it("skips notify when enabled is false", async () => {
+    const service = createService({ enabled: false });
+    await service.observe(null, {
+      activities: [agent({ panelId: "p1", status: "waiting", windowId: "11" })],
+      ts: 1,
+    });
+    expect(showNotification).not.toHaveBeenCalled();
+  });
+
+  it("notifies even when focused if suppressWhenFocused is false", async () => {
+    isTargetPanelFocused.mockReturnValue(true);
+    const service = createService({ suppressWhenFocused: false });
+    await service.observe(null, {
+      activities: [agent({ panelId: "p1", status: "waiting", windowId: "11" })],
+      ts: 1,
+    });
+    expect(showNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not re-notify waiting→error when both in trigger set", async () => {
+    const service = createService({ enableErrorAttention: true });
+    await service.observe(null, {
+      activities: [agent({ panelId: "p1", status: "waiting", windowId: "11" })],
+      ts: 1,
+    });
+    expect(showNotification).toHaveBeenCalledTimes(1);
+
+    await service.observe(
+      {
+        activities: [
+          agent({ panelId: "p1", status: "waiting", windowId: "11" }),
+        ],
+        ts: 1,
+      },
+      {
+        activities: [agent({ panelId: "p1", status: "error", windowId: "11" })],
+        ts: 2,
+      }
+    );
+    expect(showNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not re-notify error→waiting when both in trigger set", async () => {
+    const service = createService({ enableErrorAttention: true });
+    await service.observe(null, {
+      activities: [agent({ panelId: "p1", status: "error", windowId: "11" })],
+      ts: 1,
+    });
+    expect(showNotification).toHaveBeenCalledTimes(1);
+
+    await service.observe(
+      {
+        activities: [agent({ panelId: "p1", status: "error", windowId: "11" })],
+        ts: 1,
+      },
+      {
+        activities: [
+          agent({ panelId: "p1", status: "waiting", windowId: "11" }),
+        ],
+        ts: 2,
+      }
+    );
+    expect(showNotification).toHaveBeenCalledTimes(1);
+  });
 });

--- a/tests/unit/main/agent-waiting-evidence-gates.test.ts
+++ b/tests/unit/main/agent-waiting-evidence-gates.test.ts
@@ -1,0 +1,211 @@
+import { createAgentAttentionService } from "@main/services/agent-attention/attention-service.ts";
+import {
+  isAgentStatusHooksIngestEnabled,
+  setAgentStatusHooksIngestEnabled,
+} from "@main/services/agents/agent-status-hooks-gate.ts";
+import {
+  CLAUDE_HOOK_EVENTS,
+  withPierClaudeHooks,
+} from "@main/services/agents/integrations/claude.ts";
+import {
+  CODEX_HOOK_EVENTS,
+  withPierCodexHooks,
+} from "@main/services/agents/integrations/codex.ts";
+import { COPILOT_EVENTS } from "@main/services/agents/integrations/copilot.ts";
+import { CURSOR_EVENTS } from "@main/services/agents/integrations/cursor.ts";
+import { DROID_HOOK_EVENTS } from "@main/services/agents/integrations/droid.ts";
+import { GEMINI_HOOK_EVENTS } from "@main/services/agents/integrations/gemini.ts";
+import { GROK_HOOK_EVENTS } from "@main/services/agents/integrations/grok.ts";
+import {
+  buildOpencodePluginSource,
+  mapOpenCodeNativeEventToPier,
+  OPENCODE_PERMISSION_NATIVE_EVENTS,
+} from "@main/services/agents/integrations/opencode.ts";
+import { getAgentHookIntegration } from "@main/services/agents/integrations/registry.ts";
+import { agentKindSchema } from "@shared/contracts/agent.ts";
+import {
+  agentIndexCounts,
+  isAgentIndexNeedsYou,
+  projectAgentActivities,
+} from "@shared/contracts/agent-runtime-index.ts";
+import {
+  activityStatusForHookEvent,
+  type ForegroundActivity,
+} from "@shared/contracts/foreground-activity.ts";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+function hasPermissionMapping(
+  events: ReadonlyArray<{ nativeEvent: string; pierEvent: string }>,
+  nativeEvent: string
+): boolean {
+  return events.some(
+    (event) =>
+      event.nativeEvent === nativeEvent &&
+      event.pierEvent === "PermissionRequest"
+  );
+}
+
+function nestedHookCommands(settings: Record<string, unknown>): string[] {
+  const hooks = settings.hooks as
+    | Record<string, Array<{ hooks?: Array<{ command?: string }> }>>
+    | undefined;
+  if (!hooks) {
+    return [];
+  }
+  const commands: string[] = [];
+  for (const entries of Object.values(hooks)) {
+    for (const entry of entries ?? []) {
+      for (const hook of entry.hooks ?? []) {
+        if (typeof hook.command === "string") {
+          commands.push(hook.command);
+        }
+      }
+    }
+  }
+  return commands;
+}
+
+describe("S1 top A waiting evidence", () => {
+  it("maps PermissionRequest to waiting in the shared FA contract", () => {
+    expect(activityStatusForHookEvent("PermissionRequest")).toBe("waiting");
+  });
+
+  it("Claude maps native PermissionRequest → PermissionRequest", () => {
+    expect(hasPermissionMapping(CLAUDE_HOOK_EVENTS, "PermissionRequest")).toBe(
+      true
+    );
+  });
+
+  it("Codex maps native PermissionRequest → PermissionRequest", () => {
+    expect(hasPermissionMapping(CODEX_HOOK_EVENTS, "PermissionRequest")).toBe(
+      true
+    );
+  });
+
+  it("Copilot maps permissionRequest → PermissionRequest", () => {
+    expect(hasPermissionMapping(COPILOT_EVENTS, "permissionRequest")).toBe(
+      true
+    );
+  });
+
+  it("OpenCode maps permission.updated → PermissionRequest", () => {
+    for (const native of OPENCODE_PERMISSION_NATIVE_EVENTS) {
+      expect(mapOpenCodeNativeEventToPier(native)).toBe("PermissionRequest");
+    }
+  });
+
+  it("Claude installed hooks emit PermissionRequest pier event", () => {
+    const commands = nestedHookCommands(withPierClaudeHooks({}));
+    expect(commands.some((cmd) => cmd.includes('"PermissionRequest"'))).toBe(
+      true
+    );
+  });
+
+  it("Codex installed hooks emit PermissionRequest pier event", () => {
+    const commands = nestedHookCommands(withPierCodexHooks({}));
+    expect(commands.some((cmd) => cmd.includes('"PermissionRequest"'))).toBe(
+      true
+    );
+  });
+
+  it("OpenCode plugin source maps permission.updated to PermissionRequest", () => {
+    const source = buildOpencodePluginSource();
+    expect(source).toContain(
+      'if (event.type === "permission.updated") return "PermissionRequest";'
+    );
+  });
+
+  it("projects waiting agent into Index needsYou and Attention candidate", async () => {
+    const activity: Extract<ForegroundActivity, { kind: "agent" }> = {
+      agentId: "claude",
+      kind: "agent",
+      panelId: "p1",
+      source: "hook",
+      spawnedAt: 1,
+      status: "waiting",
+      subagentCount: 0,
+      updatedAt: 10,
+      windowId: "11",
+    };
+    const entries = projectAgentActivities([activity]);
+    expect(agentIndexCounts(entries).needsYou).toBeGreaterThanOrEqual(1);
+    expect(entries.some((entry) => isAgentIndexNeedsYou(entry.status))).toBe(
+      true
+    );
+
+    const showNotification = vi.fn(async () => ({ shown: true }));
+    const service = createAgentAttentionService({
+      isTargetPanelFocused: () => false,
+      showNotification,
+    });
+    await service.observe(null, { activities: [activity], ts: 1 });
+    expect(showNotification).toHaveBeenCalled();
+  });
+});
+
+describe("S2 launch-only and no-status", () => {
+  it("launch-only agents have no hook integration", () => {
+    const launchOnly = ["ante", "codebuff", "continue", "rovo", "openclaw"];
+    expect(
+      agentKindSchema.options.filter(
+        (agentId) => getAgentHookIntegration(agentId) === null
+      )
+    ).toEqual(launchOnly);
+  });
+
+  it("Index needsYou ignores launch entries without waiting|error status", () => {
+    const entries = projectAgentActivities([
+      {
+        agentId: "ante",
+        kind: "agent",
+        panelId: "p1",
+        source: "launch",
+        spawnedAt: 1,
+        subagentCount: 0,
+        updatedAt: 10,
+        windowId: "11",
+      },
+    ]);
+    expect(agentIndexCounts(entries).needsYou).toBe(0);
+    expect(entries.every((entry) => !isAgentIndexNeedsYou(entry.status))).toBe(
+      true
+    );
+  });
+});
+
+describe("S3 agentStatusHooks ingest gate", () => {
+  afterEach(() => {
+    setAgentStatusHooksIngestEnabled(true);
+  });
+
+  it("tracks enabled flag for FA hook ingestion", () => {
+    expect(isAgentStatusHooksIngestEnabled()).toBe(true);
+    setAgentStatusHooksIngestEnabled(false);
+    expect(isAgentStatusHooksIngestEnabled()).toBe(false);
+    setAgentStatusHooksIngestEnabled(true);
+    expect(isAgentStatusHooksIngestEnabled()).toBe(true);
+  });
+});
+
+describe("B-tier permission-adjacent mappings retained after review", () => {
+  it("Gemini Notification → PermissionRequest (ToolPermission signal)", () => {
+    expect(hasPermissionMapping(GEMINI_HOOK_EVENTS, "Notification")).toBe(true);
+  });
+
+  it("Grok Notification → PermissionRequest", () => {
+    expect(hasPermissionMapping(GROK_HOOK_EVENTS, "Notification")).toBe(true);
+  });
+
+  it("Droid Notification → PermissionRequest", () => {
+    expect(hasPermissionMapping(DROID_HOOK_EVENTS, "Notification")).toBe(true);
+  });
+
+  it("Cursor shell/MCP before → PermissionRequest", () => {
+    expect(hasPermissionMapping(CURSOR_EVENTS, "beforeShellExecution")).toBe(
+      true
+    );
+    expect(hasPermissionMapping(CURSOR_EVENTS, "beforeMCPExecution")).toBe(
+      true
+    );
+  });
+});

--- a/tests/unit/main/notification-ipc.test.ts
+++ b/tests/unit/main/notification-ipc.test.ts
@@ -59,13 +59,27 @@ const electronMock = vi.hoisted(() => {
 
 const focusFeedback = vi.hoisted(() => ({
   broadcastAgentRuntimeFocusFeedback: vi.fn(),
+  broadcastSystemNotificationPermissionChanged: vi.fn(),
 }));
 
 vi.mock("electron", () => ({
   Notification: electronMock.MockNotification,
+  app: {
+    focus: vi.fn(),
+    hide: vi.fn(),
+    isPackaged: true,
+  },
+  shell: { openExternal: vi.fn(async () => undefined) },
 }));
 
 vi.mock("@main/app-core/window-broadcasts.ts", () => focusFeedback);
+
+vi.mock("@main/windows/window-manager.ts", () => ({
+  windowManager: {
+    getAll: () => [],
+    getFocused: () => null,
+  },
+}));
 
 import { registerNotificationIpc } from "@main/ipc/notification.ts";
 import { resetSystemNotificationPermissionStateForTests } from "@main/services/system-notification.ts";
@@ -119,7 +133,7 @@ describe("notification IPC", () => {
     });
 
     expect(electronMock.constructed).toEqual([
-      { body: "Rebase finished", title: "Pier" },
+      { body: "Rebase finished", silent: false, title: "Pier" },
     ]);
     expect(electronMock.show).toHaveBeenCalledTimes(1);
     expect(result).toEqual({ shown: true });
@@ -130,7 +144,9 @@ describe("notification IPC", () => {
 
     await handler({} as IpcMainInvokeEvent, { title: "Pier" });
 
-    expect(electronMock.constructed).toEqual([{ title: "Pier" }]);
+    expect(electronMock.constructed).toEqual([
+      { silent: false, title: "Pier" },
+    ]);
   });
 
   it("reports shown=false without constructing when unsupported", async () => {

--- a/tests/unit/main/preferences-service-agent-attention.test.ts
+++ b/tests/unit/main/preferences-service-agent-attention.test.ts
@@ -1,0 +1,55 @@
+import { createPreferencesService } from "@main/services/preferences-service.ts";
+import {
+  type AgentAttentionSettings,
+  DEFAULT_AGENT_ATTENTION_SETTINGS,
+} from "@shared/contracts/agent-attention.ts";
+import type { ProjectPreferences } from "@shared/contracts/preferences.ts";
+import { projectPreferencesSchema } from "@shared/contracts/preferences.ts";
+import { describe, expect, it, vi } from "vitest";
+
+function basePreferences(
+  overrides: Partial<ProjectPreferences> = {}
+): ProjectPreferences {
+  return projectPreferencesSchema.parse(overrides);
+}
+
+describe("preferences-service agentAttention whitelist", () => {
+  it("persists agentAttention and includes it in changedKeys", async () => {
+    const nextAttention: AgentAttentionSettings = {
+      enabled: false,
+      enableErrorAttention: false,
+      suppressWhenFocused: true,
+      cooldownMs: 60_000,
+    };
+    const current = basePreferences();
+    const updatePreferences = vi.fn(
+      async (patch: Partial<ProjectPreferences>) =>
+        basePreferences({ ...current, ...patch })
+    );
+    const publish = vi.fn();
+    const service = createPreferencesService({
+      eventBus: { publish },
+      readPreferences: async () => current,
+      updatePreferences,
+    });
+
+    const merged = await service.update({ agentAttention: nextAttention });
+
+    expect(updatePreferences).toHaveBeenCalledWith({
+      agentAttention: nextAttention,
+    });
+    expect(merged.agentAttention).toEqual(nextAttention);
+    expect(publish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        changedKeys: ["agentAttention"],
+        type: "preferences.changed",
+      })
+    );
+  });
+
+  it("defaults agentAttention when preferences parse empty object", () => {
+    expect(basePreferences({}).agentAttention).toEqual(
+      DEFAULT_AGENT_ATTENTION_SETTINGS
+    );
+  });
+});

--- a/tests/unit/main/system-notification.test.ts
+++ b/tests/unit/main/system-notification.test.ts
@@ -1,0 +1,188 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const electronMock = vi.hoisted(() => {
+  const show = vi.fn();
+  const close = vi.fn();
+  const handlers = new Map<string, Array<(...args: unknown[]) => void>>();
+  const isSupported = vi.fn(() => true);
+  let autoEmitShow = true;
+
+  class MockNotification {
+    static isSupported = isSupported;
+    show = () => {
+      show();
+      if (autoEmitShow) {
+        for (const cb of handlers.get("show") ?? []) {
+          cb();
+        }
+      }
+    };
+    close = close;
+    on(event: string, cb: (...args: unknown[]) => void) {
+      const list = handlers.get(event) ?? [];
+      list.push(cb);
+      handlers.set(event, list);
+      return this;
+    }
+    once(event: string, cb: (...args: unknown[]) => void) {
+      const wrapped = (...args: unknown[]) => {
+        const list = handlers.get(event) ?? [];
+        const idx = list.indexOf(wrapped);
+        if (idx >= 0) {
+          list.splice(idx, 1);
+        }
+        cb(...args);
+      };
+      return this.on(event, wrapped);
+    }
+  }
+
+  return {
+    MockNotification,
+    close,
+    handlers,
+    isSupported,
+    openExternal: vi.fn(async () => undefined),
+    setAutoEmitShow(value: boolean) {
+      autoEmitShow = value;
+    },
+    show,
+  };
+});
+
+const childProcessMock = vi.hoisted(() => ({
+  execFile: vi.fn(
+    (
+      _file: string,
+      _args: string[],
+      callback: (err: Error | null, stdout: string, stderr: string) => void
+    ) => {
+      callback(null, "", "");
+      return {} as unknown;
+    }
+  ),
+}));
+
+vi.mock("electron", () => ({
+  Notification: electronMock.MockNotification,
+  app: {
+    focus: vi.fn(),
+    hide: vi.fn(),
+    isPackaged: true,
+  },
+  shell: {
+    openExternal: electronMock.openExternal,
+  },
+}));
+
+vi.mock("node:child_process", () => ({
+  default: { execFile: childProcessMock.execFile },
+  execFile: childProcessMock.execFile,
+}));
+
+import {
+  getSystemNotificationPermissionSnapshot,
+  openSystemNotificationSettings,
+  resetSystemNotificationPermissionStateForTests,
+  showSystemNotification,
+  showTestSystemNotification,
+} from "@main/services/system-notification.ts";
+
+describe("system notification permission probe", () => {
+  beforeEach(() => {
+    resetSystemNotificationPermissionStateForTests();
+    electronMock.handlers.clear();
+    electronMock.show.mockClear();
+    electronMock.close.mockClear();
+    electronMock.openExternal.mockClear();
+    electronMock.isSupported.mockReturnValue(true);
+    electronMock.setAutoEmitShow(true);
+    childProcessMock.execFile.mockClear();
+    childProcessMock.execFile.mockImplementation(
+      (
+        _file: string,
+        _args: string[],
+        callback: (err: Error | null, stdout: string, stderr: string) => void
+      ) => {
+        callback(null, "", "");
+        return {} as unknown;
+      }
+    );
+  });
+
+  it("blocks ordinary path after sticky denied", async () => {
+    electronMock.setAutoEmitShow(false);
+    const first = showSystemNotification({ title: "a" });
+    for (const listener of electronMock.handlers.get("failed") ?? []) {
+      listener({}, "permission denied");
+    }
+    await expect(first).resolves.toEqual({ reason: "denied", shown: false });
+
+    const second = await showSystemNotification({ title: "b" });
+    expect(second).toEqual({ reason: "denied", shown: false });
+    expect(electronMock.show).toHaveBeenCalledTimes(1);
+    expect(getSystemNotificationPermissionSnapshot().status).toBe("denied");
+  });
+
+  it("forceProbe bypasses sticky and can authorize on shown", async () => {
+    electronMock.setAutoEmitShow(false);
+    const denied = showSystemNotification({ title: "a" });
+    for (const listener of electronMock.handlers.get("failed") ?? []) {
+      listener({}, "permission denied");
+    }
+    await denied;
+
+    electronMock.handlers.clear();
+    electronMock.setAutoEmitShow(true);
+    const probed = await showSystemNotification(
+      { title: "test" },
+      { forceProbe: true }
+    );
+    expect(probed).toEqual({ shown: true });
+    expect(getSystemNotificationPermissionSnapshot().status).toBe("authorized");
+
+    const again = await showSystemNotification({ title: "c" });
+    expect(again).toEqual({ shown: true });
+  });
+
+  it("showTestSystemNotification uses forceProbe path", async () => {
+    electronMock.setAutoEmitShow(false);
+    const denied = showSystemNotification({ title: "a" });
+    for (const listener of electronMock.handlers.get("failed") ?? []) {
+      listener({}, "permission denied");
+    }
+    await denied;
+
+    electronMock.handlers.clear();
+    electronMock.setAutoEmitShow(true);
+    const result = await showTestSystemNotification();
+    expect(result.shown).toBe(true);
+    expect(getSystemNotificationPermissionSnapshot().status).toBe("authorized");
+  });
+
+  it("returns unsupported when Notification.isSupported is false", async () => {
+    electronMock.isSupported.mockReturnValue(false);
+    const result = await showSystemNotification({ title: "x" });
+    expect(result).toEqual({ reason: "unsupported", shown: false });
+    expect(getSystemNotificationPermissionSnapshot().status).toBe(
+      "unsupported"
+    );
+  });
+
+  it("openSystemNotificationSettings uses macOS open(1), not shell.openExternal", async () => {
+    const original = process.platform;
+    Object.defineProperty(process, "platform", {
+      configurable: true,
+      value: "darwin",
+    });
+    const result = await openSystemNotificationSettings();
+    expect(result.opened).toBe(true);
+    expect(childProcessMock.execFile).toHaveBeenCalled();
+    expect(childProcessMock.execFile.mock.calls[0]?.[0]).toBe("open");
+    expect(electronMock.openExternal).not.toHaveBeenCalled();
+    Object.defineProperty(process, "platform", {
+      configurable: true,
+      value: original,
+    });
+  });
+});

--- a/tests/unit/renderer/settings-nav.test.ts
+++ b/tests/unit/renderer/settings-nav.test.ts
@@ -23,6 +23,7 @@ describe("settings navigation metadata", () => {
       "environment",
       "keybindings",
       "agents",
+      "notifications",
       "plugins",
       "updates",
     ]);

--- a/tests/unit/renderer/settings-section-alert-layout-governance.test.ts
+++ b/tests/unit/renderer/settings-section-alert-layout-governance.test.ts
@@ -1,0 +1,135 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const ROOT = process.cwd();
+const SETTINGS_COMPONENTS = join(
+  ROOT,
+  "src",
+  "renderer",
+  "pages",
+  "settings",
+  "components"
+);
+const SOURCE_FILE_RE = /\.(ts|tsx)$/;
+
+function _sourceFiles(dir: string): string[] {
+  const entries = readdirSync(dir);
+  const files: string[] = [];
+  for (const entry of entries) {
+    const filePath = join(dir, entry);
+    const stat = statSync(filePath);
+    if (stat.isDirectory()) {
+      files.push(..._sourceFiles(filePath));
+      continue;
+    }
+    if (SOURCE_FILE_RE.test(entry)) {
+      files.push(filePath);
+    }
+  }
+  return files;
+}
+
+function projectRelative(filePath: string): string {
+  return relative(ROOT, filePath);
+}
+
+/**
+ * 取出 `export function XxxSection` 的顶层 return JSX 文本（括号匹配）。
+ * 仅用于治理扫描，不要求完整 TSX 解析。
+ */
+function extractExportedSectionReturn(source: string): string | null {
+  const start = source.search(/export function \w+Section\b/);
+  if (start < 0) {
+    return null;
+  }
+  const returnIdx = source.indexOf("return (", start);
+  if (returnIdx < 0) {
+    return null;
+  }
+  const openParen = returnIdx + "return ".length;
+  if (source[openParen] !== "(") {
+    return null;
+  }
+  let depth = 0;
+  for (let i = openParen; i < source.length; i++) {
+    const ch = source[i];
+    if (ch === "(") {
+      depth += 1;
+      continue;
+    }
+    if (ch === ")") {
+      depth -= 1;
+      if (depth === 0) {
+        return source.slice(openParen + 1, i);
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * 在 Section return JSX 中，若出现 <Alert 且当前不在 <Card …> 深度内 → 违规。
+ * 用简易标签深度：遇到 <Card / <Card> / <Card ...> 加深，</Card> 减浅。
+ */
+function findBareAlertInSectionReturn(jsx: string): boolean {
+  let cardDepth = 0;
+  const tokenRe = /<\/?Card\b[^>]*>|<Alert\b/g;
+  let match = tokenRe.exec(jsx);
+  while (match) {
+    const token = match[0];
+    if (token.startsWith("</Card")) {
+      cardDepth = Math.max(0, cardDepth - 1);
+    } else if (token.startsWith("<Card")) {
+      if (!token.endsWith("/>")) {
+        cardDepth += 1;
+      }
+    } else if (token.startsWith("<Alert") && cardDepth === 0) {
+      return true;
+    }
+    match = tokenRe.exec(jsx);
+  }
+  return false;
+}
+
+describe("settings section Alert layout governance", () => {
+  it("documents the settings Alert-in-Card policy in AGENTS.md", () => {
+    const agentContext = readFileSync(join(ROOT, "AGENTS.md"), "utf8");
+    expect(agentContext).toContain("### 设置页状态提示布局");
+    expect(agentContext).toContain("必须放在 `Card` / `CardContent` 内");
+    expect(agentContext).toContain(
+      "tests/unit/renderer/settings-section-alert-layout-governance.test.ts"
+    );
+  });
+
+  it("keeps top-level settings section return Alerts inside Card", () => {
+    // 仅检查设置对话框直接挂载的 section，不扫嵌套子块（如 managed-plugins-section
+    // 本身渲染在父 Card 内，文件顶层 return 会误报）。
+    const settingsDialog = readFileSync(
+      join(ROOT, "src", "renderer", "pages", "settings", "settings-dialog.tsx"),
+      "utf8"
+    );
+    const mountedSectionFiles = [
+      ...settingsDialog.matchAll(
+        /from "@\/pages\/settings\/components\/([A-Za-z0-9_-]+\.tsx)"/g
+      ),
+    ].map((match) => join(SETTINGS_COMPONENTS, match[1] ?? ""));
+
+    const offenders = mountedSectionFiles.flatMap((filePath) => {
+      if (!filePath.endsWith("-section.tsx")) {
+        return [];
+      }
+      const source = readFileSync(filePath, "utf8");
+      const sectionReturn = extractExportedSectionReturn(source);
+      if (!sectionReturn) {
+        return [];
+      }
+      if (!findBareAlertInSectionReturn(sectionReturn)) {
+        return [];
+      }
+      return [projectRelative(filePath)];
+    });
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/tests/unit/shared/agent-attention-settings.test.ts
+++ b/tests/unit/shared/agent-attention-settings.test.ts
@@ -1,0 +1,53 @@
+import {
+  agentAttentionSettingsSchema,
+  DEFAULT_AGENT_ATTENTION_SETTINGS,
+} from "@shared/contracts/agent-attention.ts";
+import { projectPreferencesSchema } from "@shared/contracts/preferences.ts";
+import { describe, expect, it } from "vitest";
+
+describe("agentAttention settings", () => {
+  it("defaults match product defaults", () => {
+    expect(DEFAULT_AGENT_ATTENTION_SETTINGS).toEqual({
+      enabled: true,
+      enableErrorAttention: false,
+      suppressWhenFocused: true,
+      cooldownMs: 180_000,
+    });
+  });
+
+  it("accepts the three product cooldown presets", () => {
+    for (const cooldownMs of [60_000, 180_000, 600_000] as const) {
+      expect(
+        agentAttentionSettingsSchema.safeParse({
+          ...DEFAULT_AGENT_ATTENTION_SETTINGS,
+          cooldownMs,
+        }).success
+      ).toBe(true);
+    }
+  });
+
+  it("rejects unknown cooldownMs", () => {
+    expect(
+      agentAttentionSettingsSchema.safeParse({
+        ...DEFAULT_AGENT_ATTENTION_SETTINGS,
+        cooldownMs: 123,
+      }).success
+    ).toBe(false);
+  });
+
+  it("preferences parse fills agentAttention default", () => {
+    const parsed = projectPreferencesSchema.parse({});
+    expect(parsed.agentAttention).toEqual(DEFAULT_AGENT_ATTENTION_SETTINGS);
+  });
+
+  it("preferences reject invalid nested agentAttention", () => {
+    expect(
+      projectPreferencesSchema.safeParse({
+        agentAttention: {
+          ...DEFAULT_AGENT_ATTENTION_SETTINGS,
+          cooldownMs: 999,
+        },
+      }).success
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Persist agent attention settings, add a dedicated Notifications settings section, and make agent hook install/uninstall soft-fail so a single agent's config error no longer rolls back the preference update.

## Changes

### Attention settings persistence
- `agentAttention` added to preferences-service `PATCHABLE_KEYS` + zod schema + defaults
- Main-process sync cache via boot read + `preferences.changed` event
- Renderer store (`agent-attention-preferences.store.ts`) with serialized writes + optimistic rollback

### Notifications settings section
- New `NotificationsSection`: attention policy toggles (enabled / error / suppress-when-focused / cooldown), system notification permission probe, diagnostics (send test / open system settings)
- Permission banner + hooks-off hint inside policy Card (follows settings-section-alert-layout governance)
- i18n keys (en + zh-CN)

### System notification IPC
- Permission snapshot / test / open-settings IPC channels + preload API
- Permission source tracking (boot / cached / forced-probe / attention-delivery)
- macOS `open(1)` fallback chain for system notification settings

### Agent attention service
- Gating by `enabled`, `suppressWhenFocused`, `cooldownMs`, `enableErrorAttention`
- Trigger-set semantics: waiting always in T; error only if `enableErrorAttention`. waiting↔error no longer re-notifies.

### Agent status hooks ingest gate
- `agent-status-hooks-gate.ts`: standalone module to avoid registry ↔ foreground-activity circular dependency
- Foreground-activity IPC skips ingestion when gate is off
- Startup path aligns gate + install/uninstall from persisted preference

### S1 evidence gate tests
- Exported hook event tables (Claude, Codex, Copilot, Cursor, Droid, Gemini, Grok)
- OpenCode permission mapping (`OPENCODE_PERMISSION_NATIVE_EVENTS` + `mapOpenCodeNativeEventToPier`)
- `agent-waiting-evidence-gates.test.ts` verifies PermissionRequest → waiting across all integrations

### Soft-fail hook install (review fix)
- `installAllAgentHooks` / `uninstallAllAgentHooks` restored to `Promise.allSettled` + per-integration warn
- `preferences.update` no longer returns failure on hook install error; preference + ingest gate persist, hook failure only logged
- Prevents state split where UI rolls back but disk/gate/other-windows already updated

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint` (0 errors)
- [x] 51 unit tests across agent-attention, notification-ipc, preferences-service, system-notification, settings-nav, settings-section-alert-layout-governance, agent-attention-settings, agent-waiting-evidence-gates
- [ ] `pnpm check` full gate (depcruise + file-size + component tests)
- [ ] Manual smoke: toggle attention settings, send test notification, verify permission banner states
