### PR TITLE
feat(plugins): hide peer sync UI when no peer tools are installed

### DIFF
--- a/packages/plugin-api/package.json
+++ b/packages/plugin-api/package.json
@@ -9,11 +9,13 @@
     "./renderer": "./src/renderer.ts",
     "./account-usage": "./src/account-usage/index.ts",
     "./account-usage/renderer": "./src/account-usage/renderer.ts",
+    "./peer-sync": "./src/peer-sync/index.ts",
     "./react": "./src/react.ts",
     "./jsx-runtime": "./src/jsx-runtime.ts",
     "./jsx-dev-runtime": "./src/jsx-dev-runtime.ts",
     "./react-dom-client": "./src/react-dom-client.ts",
-    "./build-preset": "./src/build-preset.ts"
+    "./build-preset": "./src/build-preset.ts",
+    "./peer-sync/main": "./src/peer-sync/main.ts"
   },
   "peerDependencies": {
     "react": "19.2.7",

--- a/packages/plugin-api/src/peer-sync/availability.ts
+++ b/packages/plugin-api/src/peer-sync/availability.ts
@@ -1,0 +1,113 @@
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { delimiter, dirname, join } from "node:path";
+import type { PeerAvailability } from "./shared.ts";
+
+export type { PeerAvailability, PeerSyncTarget } from "./shared.ts";
+export {
+  ALL_PEER_SYNC_TARGETS,
+  isPeerTargetAvailable,
+  partitionPeerTargets,
+} from "./shared.ts";
+
+export interface PeerAvailabilityOptions {
+  /** Override home directory (tests). */
+  homeDir?: string;
+  /** Override OpenCode data dir (tests). Defaults to `~/.local/share/opencode`. */
+  opencodeDataDir?: string;
+  /** Override PATH for binary probes (tests). */
+  pathEnv?: string;
+}
+
+function resolveHomeDir(opts: PeerAvailabilityOptions): string {
+  return opts.homeDir ?? homedir();
+}
+
+function commandExistsOnPath(
+  command: string,
+  pathEnv: string | undefined
+): boolean {
+  const env = pathEnv ?? process.env.PATH ?? "";
+  for (const dir of env.split(delimiter)) {
+    if (dir.length > 0 && existsSync(join(dir, command))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function opencodeConfigCandidates(home: string): string[] {
+  return [
+    join(home, ".config", "opencode", "opencode.json"),
+    join(home, ".opencode", "opencode.json"),
+  ];
+}
+
+function opencodeAuthPath(opts: PeerAvailabilityOptions): string {
+  const dataDir =
+    opts.opencodeDataDir ??
+    join(resolveHomeDir(opts), ".local", "share", "opencode");
+  return join(dataDir, "auth.json");
+}
+
+function piHome(opts: PeerAvailabilityOptions): string {
+  // Match account sync writers: credentials land under `~/.pi/agent`.
+  return join(resolveHomeDir(opts), ".pi", "agent");
+}
+
+function ompDbPath(opts: PeerAvailabilityOptions): string {
+  // Match account sync writers: OAuth upsert requires an existing agent.db.
+  return join(resolveHomeDir(opts), ".omp", "agent", "agent.db");
+}
+
+/**
+ * Sync-ready probe for OpenCode.
+ *
+ * Evidence: binary on PATH, known config path, data directory, or existing
+ * auth.json. Unlike host hook detect (config-only), this also accepts a bare
+ * CLI install so users can opt into first-time auth materialization.
+ */
+export function isOpencodeSyncReady(
+  opts: PeerAvailabilityOptions = {}
+): boolean {
+  const home = resolveHomeDir(opts);
+  if (commandExistsOnPath("opencode", opts.pathEnv)) {
+    return true;
+  }
+  if (opencodeConfigCandidates(home).some((path) => existsSync(path))) {
+    return true;
+  }
+  const authPath = opencodeAuthPath(opts);
+  return existsSync(authPath) || existsSync(dirname(authPath));
+}
+
+/**
+ * Sync-ready probe for Pi.
+ *
+ * Evidence: `~/.pi/agent` exists or `pi` is on PATH. Matches the auth.json
+ * location written by Codex / Grok peer sync.
+ */
+export function isPiSyncReady(opts: PeerAvailabilityOptions = {}): boolean {
+  return existsSync(piHome(opts)) || commandExistsOnPath("pi", opts.pathEnv);
+}
+
+/**
+ * Sync-ready probe for OMP.
+ *
+ * Stricter than host hook detect: peer sync needs `agent.db` (OMP opened at
+ * least once). Directory or binary alone is not enough.
+ */
+export function isOmpSyncReady(opts: PeerAvailabilityOptions = {}): boolean {
+  return existsSync(ompDbPath(opts));
+}
+
+/** Snapshot of which peer tools can receive a credential mirror right now. */
+export function detectPeerAvailability(
+  opts: PeerAvailabilityOptions = {}
+): PeerAvailability {
+  return {
+    opencode: isOpencodeSyncReady(opts),
+    pi: isPiSyncReady(opts),
+    omp: isOmpSyncReady(opts),
+  };
+}

--- a/packages/plugin-api/src/peer-sync/index.ts
+++ b/packages/plugin-api/src/peer-sync/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Shared peer-tool helpers for official account plugins (Codex, Grok, …).
+ * Renderer-safe entry. Node sync-ready probes: `@pier/plugin-api/peer-sync/main`.
+ */
+
+export {
+  ALL_PEER_SYNC_TARGETS,
+  isPeerTargetAvailable,
+  type PeerAvailability,
+  type PeerSyncTarget,
+  partitionPeerTargets,
+} from "./shared.ts";

--- a/packages/plugin-api/src/peer-sync/main.ts
+++ b/packages/plugin-api/src/peer-sync/main.ts
@@ -1,0 +1,17 @@
+/**
+ * Main-process peer-sync probes (Node builtins).
+ * Renderer must import `@pier/plugin-api/peer-sync` instead.
+ */
+
+export {
+  ALL_PEER_SYNC_TARGETS,
+  detectPeerAvailability,
+  isOmpSyncReady,
+  isOpencodeSyncReady,
+  isPeerTargetAvailable,
+  isPiSyncReady,
+  type PeerAvailability,
+  type PeerAvailabilityOptions,
+  type PeerSyncTarget,
+  partitionPeerTargets,
+} from "./availability.ts";

--- a/packages/plugin-api/src/peer-sync/shared.ts
+++ b/packages/plugin-api/src/peer-sync/shared.ts
@@ -1,0 +1,50 @@
+/**
+ * Shared peer-tool helpers for official account plugins (Codex, Grok, …).
+ * Renderer-safe: no Node builtins. Detection probes live in `./main`.
+ */
+
+export type PeerSyncTarget = "opencode" | "pi" | "omp";
+
+export interface PeerAvailability {
+  omp: boolean;
+  opencode: boolean;
+  pi: boolean;
+}
+
+const PEER_TARGETS = [
+  "opencode",
+  "pi",
+  "omp",
+] as const satisfies readonly PeerSyncTarget[];
+
+export const ALL_PEER_SYNC_TARGETS: readonly PeerSyncTarget[] = PEER_TARGETS;
+
+export function isPeerTargetAvailable(
+  target: PeerSyncTarget,
+  availability: PeerAvailability
+): boolean {
+  return availability[target];
+}
+
+/**
+ * Split protocol-eligible targets into sync-ready vs not-installed.
+ * Callers may further filter by protocol (e.g. Grok OIDC excludes Pi).
+ */
+export function partitionPeerTargets(
+  protocolTargets: readonly PeerSyncTarget[],
+  availability: PeerAvailability
+): {
+  available: PeerSyncTarget[];
+  unavailable: PeerSyncTarget[];
+} {
+  const available: PeerSyncTarget[] = [];
+  const unavailable: PeerSyncTarget[] = [];
+  for (const target of protocolTargets) {
+    if (isPeerTargetAvailable(target, availability)) {
+      available.push(target);
+    } else {
+      unavailable.push(target);
+    }
+  }
+  return { available, unavailable };
+}

--- a/packages/plugin-api/tsconfig.json
+++ b/packages/plugin-api/tsconfig.json
@@ -1,4 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src/**/*.ts", "src/**/*.tsx"]
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["src/peer-sync/availability.ts", "src/peer-sync/main.ts"]
 }

--- a/packages/plugin-codex/src/main/rpc-handlers.ts
+++ b/packages/plugin-codex/src/main/rpc-handlers.ts
@@ -1,4 +1,5 @@
 import type { MainPluginContext } from "@pier/plugin-api/main";
+import { detectPeerAvailability } from "@pier/plugin-api/peer-sync/main";
 import { z } from "zod/mini";
 import {
   addAccountPayloadSchema,
@@ -45,6 +46,10 @@ export function registerCodexRpcHandlers(options: {
   rpc.handle("accounts.syncToPeers", async (payload) => {
     await service.syncToPeers(syncToPeersPayloadSchema.parse(payload));
     return null;
+  });
+  rpc.handle("accounts.peerAvailability", async (payload) => {
+    emptyRpcPayloadSchema.parse(payload);
+    return detectPeerAvailability();
   });
   rpc.handle("accounts.remove", async (payload) => {
     await service.remove(removeAccountPayloadSchema.parse(payload));

--- a/packages/plugin-codex/src/renderer/account-switch.ts
+++ b/packages/plugin-codex/src/renderer/account-switch.ts
@@ -2,4 +2,7 @@ export type {
   PeerSyncDialogMode,
   SwitchConfirmResult,
 } from "./switch-confirm-dialog.tsx";
-export { openSwitchConfirmDialog } from "./switch-confirm-dialog.tsx";
+export {
+  loadPeerAvailability,
+  openSwitchConfirmDialog,
+} from "./switch-confirm-dialog.tsx";

--- a/packages/plugin-codex/src/renderer/accounts-settings-page.tsx
+++ b/packages/plugin-codex/src/renderer/accounts-settings-page.tsx
@@ -1,3 +1,4 @@
+import { partitionPeerTargets } from "@pier/plugin-api/peer-sync";
 import type { ExternalRendererPluginContext } from "@pier/plugin-api/renderer";
 import { Alert, AlertDescription, AlertTitle } from "@pier/ui/alert.tsx";
 import { Badge } from "@pier/ui/badge.tsx";
@@ -36,15 +37,23 @@ import {
 } from "@pier/ui/tooltip.tsx";
 import { cn } from "@pier/ui/utils.ts";
 import { CircleUserRound, RefreshCw, Share2 } from "lucide-react";
-import { Fragment, type JSX, useState } from "react";
-import type { PeerSyncTarget } from "../shared/accounts.ts";
+import { Fragment, type JSX, useEffect, useState } from "react";
+import {
+  ALL_SYNC_TARGETS,
+  EMPTY_PEER_AVAILABILITY,
+  type PeerAvailability,
+  type PeerSyncTarget,
+} from "../shared/accounts.ts";
 import {
   AccountAvatar,
   OtherAccount,
   QuotaGroup,
   resetCredits,
 } from "./account-display.tsx";
-import { openSwitchConfirmDialog } from "./account-switch.ts";
+import {
+  loadPeerAvailability,
+  openSwitchConfirmDialog,
+} from "./account-switch.ts";
 import { AddAccountDialog } from "./add-account-dialog.tsx";
 import { formatAccountError } from "./format-account-error.ts";
 import type { Translate } from "./usage-meter.tsx";
@@ -54,6 +63,17 @@ import { useUsagePollingLease } from "./use-usage-polling-lease.ts";
 
 export interface AccountsSettingsPageProps {
   context: ExternalRendererPluginContext;
+}
+
+function samePeerAvailability(
+  left: PeerAvailability,
+  right: PeerAvailability
+): boolean {
+  return (
+    left.omp === right.omp &&
+    left.opencode === right.opencode &&
+    left.pi === right.pi
+  );
 }
 
 const SETTINGS_LAYOUT_CLASS =
@@ -80,6 +100,41 @@ export function AccountsSettingsPage({
   useUsagePollingLease(context, "settings:accounts", true);
   const t: Translate = (key, fallback) => context.i18n.t(key, fallback);
   const [, setBusyAccountId] = useState<string | null>(null);
+  const [peerAvailability, setPeerAvailability] = useState<PeerAvailability>(
+    EMPTY_PEER_AVAILABILITY
+  );
+  useEffect(() => {
+    // Share only appears for the active account. Skip probing on empty pages so
+    // a late availability resolve cannot remount Add Account dialog callbacks.
+    const activeAccountId = snapshot?.activeAccountId ?? null;
+    if (!activeAccountId) {
+      setPeerAvailability((prev) =>
+        samePeerAvailability(prev, EMPTY_PEER_AVAILABILITY)
+          ? prev
+          : EMPTY_PEER_AVAILABILITY
+      );
+      return;
+    }
+    let cancelled = false;
+    loadPeerAvailability(context)
+      .then((availability) => {
+        if (cancelled) return;
+        setPeerAvailability((prev) =>
+          samePeerAvailability(prev, availability) ? prev : availability
+        );
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setPeerAvailability((prev) =>
+          samePeerAvailability(prev, EMPTY_PEER_AVAILABILITY)
+            ? prev
+            : EMPTY_PEER_AVAILABILITY
+        );
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [context, snapshot?.activeAccountId]);
   const reportError = (err: unknown): void => {
     context.dialogs
       .alert({
@@ -230,28 +285,31 @@ export function AccountsSettingsPage({
             </CardTitle>
             <CardAction className="flex items-center gap-2">
               <TooltipProvider delayDuration={200}>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      aria-label={t(
+                {partitionPeerTargets(ALL_SYNC_TARGETS, peerAvailability)
+                  .available.length > 0 ? (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        aria-label={t(
+                          "pier.codex.accounts.settings.syncPeers",
+                          "Sync to other tools"
+                        )}
+                        onClick={() => handleSyncPeers(active.id)}
+                        size="icon-sm"
+                        type="button"
+                        variant="ghost"
+                      >
+                        <Share2 data-icon="inline-start" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent data-pier-codex-scope="">
+                      {t(
                         "pier.codex.accounts.settings.syncPeers",
                         "Sync to other tools"
                       )}
-                      onClick={() => handleSyncPeers(active.id)}
-                      size="icon-sm"
-                      type="button"
-                      variant="ghost"
-                    >
-                      <Share2 data-icon="inline-start" />
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent data-pier-codex-scope="">
-                    {t(
-                      "pier.codex.accounts.settings.syncPeers",
-                      "Sync to other tools"
-                    )}
-                  </TooltipContent>
-                </Tooltip>
+                    </TooltipContent>
+                  </Tooltip>
+                ) : null}
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <Button

--- a/packages/plugin-codex/src/renderer/switch-confirm-dialog.tsx
+++ b/packages/plugin-codex/src/renderer/switch-confirm-dialog.tsx
@@ -1,3 +1,4 @@
+import { partitionPeerTargets } from "@pier/plugin-api/peer-sync";
 import type {
   ExternalRendererPluginContext,
   RendererPluginContentDialogRenderProps,
@@ -8,6 +9,9 @@ import { type JSX, useState } from "react";
 import {
   ALL_SYNC_TARGETS,
   type CrossToolSyncTarget,
+  EMPTY_PEER_AVAILABILITY,
+  type PeerAvailability,
+  type PeerSyncTarget,
 } from "../shared/accounts.ts";
 import type { Translate } from "./usage-meter.tsx";
 
@@ -18,17 +22,49 @@ export interface SwitchConfirmResult {
   syncTargets: CrossToolSyncTarget[];
 }
 
+function isPeerAvailability(value: unknown): value is PeerAvailability {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.omp === "boolean" &&
+    typeof record.opencode === "boolean" &&
+    typeof record.pi === "boolean"
+  );
+}
+
+export async function loadPeerAvailability(
+  context: ExternalRendererPluginContext
+): Promise<PeerAvailability> {
+  try {
+    const result = await context.rpc.invoke<unknown>(
+      "accounts.peerAvailability",
+      null
+    );
+    // Fail closed on missing/malformed probes (tests often stub unknown RPCs as null).
+    return isPeerAvailability(result) ? result : EMPTY_PEER_AVAILABILITY;
+  } catch {
+    // Fail closed: do not default-select peers we could not probe.
+    return EMPTY_PEER_AVAILABILITY;
+  }
+}
+
 function SwitchConfirmContent({
+  availability,
   mode,
   t,
   close,
 }: {
+  availability: PeerAvailability;
   mode: PeerSyncDialogMode;
   t: Translate;
   close: RendererPluginContentDialogRenderProps<SwitchConfirmResult>["close"];
 }): JSX.Element {
+  const { available } = partitionPeerTargets(ALL_SYNC_TARGETS, availability);
+  const showSyncSection = available.length > 0;
   const [syncTargets, setSyncTargets] = useState<Set<CrossToolSyncTarget>>(
-    () => new Set(ALL_SYNC_TARGETS)
+    () => new Set(available)
   );
 
   function toggleTarget(target: CrossToolSyncTarget): void {
@@ -40,7 +76,7 @@ function SwitchConfirmContent({
     });
   }
 
-  const targetLabel: Record<Exclude<CrossToolSyncTarget, "codex">, string> = {
+  const targetLabel: Record<PeerSyncTarget, string> = {
     opencode: t("pier.codex.switch.syncTarget.opencode", "OpenCode"),
     pi: t("pier.codex.switch.syncTarget.pi", "Pi"),
     omp: t("pier.codex.switch.syncTarget.omp", "OMP"),
@@ -63,30 +99,32 @@ function SwitchConfirmContent({
 
   return (
     <div className="flex flex-col gap-4" data-pier-codex-scope="">
-      <div className="flex flex-col gap-3">
-        <p className="font-medium text-sm">{sectionLabel}</p>
-        <div className="flex flex-col gap-2">
-          {ALL_SYNC_TARGETS.map((target) => {
-            const checked = syncTargets.has(target);
-            return (
-              <label
-                className="flex items-center gap-2 text-sm"
-                htmlFor={`sync-target-${target}`}
-                key={target}
-              >
-                <Checkbox
-                  checked={checked}
-                  id={`sync-target-${target}`}
-                  onCheckedChange={() => {
-                    toggleTarget(target);
-                  }}
-                />
-                <span>{targetLabel[target]}</span>
-              </label>
-            );
-          })}
+      {showSyncSection ? (
+        <div className="flex flex-col gap-3">
+          <p className="font-medium text-sm">{sectionLabel}</p>
+          <div className="flex flex-col gap-2">
+            {available.map((target) => {
+              const checked = syncTargets.has(target);
+              return (
+                <label
+                  className="flex items-center gap-2 text-sm"
+                  htmlFor={`sync-target-${target}`}
+                  key={target}
+                >
+                  <Checkbox
+                    checked={checked}
+                    id={`sync-target-${target}`}
+                    onCheckedChange={() => {
+                      toggleTarget(target);
+                    }}
+                  />
+                  <span>{targetLabel[target]}</span>
+                </label>
+              );
+            })}
+          </div>
         </div>
-      </div>
+      ) : null}
       <div className="flex flex-wrap justify-end gap-2">
         <Button
           onClick={() => close({ confirmed: false, syncTargets: [] })}
@@ -116,6 +154,15 @@ export async function openSwitchConfirmDialog(options: {
 }): Promise<SwitchConfirmResult> {
   const mode = options.mode ?? "switch";
   const { context, t } = options;
+  const availability = await loadPeerAvailability(context);
+  const { available } = partitionPeerTargets(ALL_SYNC_TARGETS, availability);
+
+  // Dedicated sync entry with no installed peers should not open an empty dialog.
+  // The settings Share button is hidden in that case; keep this as a silent guard.
+  if (mode === "sync" && available.length === 0) {
+    return { confirmed: false, syncTargets: [] };
+  }
+
   const title =
     mode === "sync"
       ? t(
@@ -143,7 +190,12 @@ export async function openSwitchConfirmDialog(options: {
     description,
     size: "sm",
     content: (props) => (
-      <SwitchConfirmContent close={props.close} mode={mode} t={t} />
+      <SwitchConfirmContent
+        availability={availability}
+        close={props.close}
+        mode={mode}
+        t={t}
+      />
     ),
   });
   const result = await handle.result;

--- a/packages/plugin-codex/src/shared/accounts.ts
+++ b/packages/plugin-codex/src/shared/accounts.ts
@@ -89,6 +89,18 @@ export const ALL_SYNC_TARGETS: readonly Exclude<
 
 export type PeerSyncTarget = (typeof ALL_SYNC_TARGETS)[number];
 
+export interface PeerAvailability {
+  omp: boolean;
+  opencode: boolean;
+  pi: boolean;
+}
+
+export const EMPTY_PEER_AVAILABILITY: PeerAvailability = {
+  omp: false,
+  opencode: false,
+  pi: false,
+};
+
 export interface SelectAccountPayload {
   accountId: string;
   /** Optional peer tools to mirror credentials into. Defaults to none. */

--- a/packages/plugin-codex/vite.config.main.ts
+++ b/packages/plugin-codex/vite.config.main.ts
@@ -11,7 +11,7 @@ import { defineConfig } from "vite";
  *   resolves them at runtime.
  * - `@pier/plugin-api` / `@pier/plugin-api/main` are types-only entry points
  *   and stay external. Runtime helpers under `@pier/plugin-api/*` (e.g.
- *   `account-usage`) must be **inlined** — installed packages have no
+ *   `account-usage`, `peer-sync/main`) must be **inlined** — installed packages have no
  *   node_modules, and package validation rejects unresolved main imports.
  */
 export default defineConfig({

--- a/packages/plugin-grok/src/main/rpc-handlers.ts
+++ b/packages/plugin-grok/src/main/rpc-handlers.ts
@@ -1,4 +1,5 @@
 import type { MainPluginContext } from "@pier/plugin-api/main";
+import { detectPeerAvailability } from "@pier/plugin-api/peer-sync/main";
 import {
   addAccountPayloadSchema,
   emptyRpcPayloadSchema,
@@ -43,6 +44,10 @@ export function registerGrokRpcHandlers(options: {
   rpc.handle("accounts.syncToPeers", async (payload) => {
     await service.syncToPeers(syncToPeersPayloadSchema.parse(payload));
     return null;
+  });
+  rpc.handle("accounts.peerAvailability", async (payload) => {
+    emptyRpcPayloadSchema.parse(payload);
+    return detectPeerAvailability();
   });
   rpc.handle("accounts.remove", async (payload) => {
     await service.remove(removeAccountPayloadSchema.parse(payload));

--- a/packages/plugin-grok/src/renderer/account-switch.ts
+++ b/packages/plugin-grok/src/renderer/account-switch.ts
@@ -2,4 +2,8 @@ export type {
   PeerSyncDialogMode,
   SwitchConfirmResult,
 } from "./switch-confirm-dialog.tsx";
-export { openSwitchConfirmDialog } from "./switch-confirm-dialog.tsx";
+export {
+  loadPeerAvailability,
+  openSwitchConfirmDialog,
+  protocolTargetsFor,
+} from "./switch-confirm-dialog.tsx";

--- a/packages/plugin-grok/src/renderer/accounts-settings-page.tsx
+++ b/packages/plugin-grok/src/renderer/accounts-settings-page.tsx
@@ -1,3 +1,4 @@
+import { partitionPeerTargets } from "@pier/plugin-api/peer-sync";
 import type { ExternalRendererPluginContext } from "@pier/plugin-api/renderer";
 import { Alert, AlertDescription, AlertTitle } from "@pier/ui/alert.tsx";
 import { Badge } from "@pier/ui/badge.tsx";
@@ -36,15 +37,23 @@ import {
 } from "@pier/ui/tooltip.tsx";
 import { cn } from "@pier/ui/utils.ts";
 import { CircleUserRound, RefreshCw, Share2 } from "lucide-react";
-import { Fragment, type JSX, useState } from "react";
-import type { PeerSyncTarget } from "../shared/accounts.ts";
+import { Fragment, type JSX, useEffect, useState } from "react";
+import {
+  EMPTY_PEER_AVAILABILITY,
+  type PeerAvailability,
+  type PeerSyncTarget,
+} from "../shared/accounts.ts";
 import {
   AccountAvatar,
   accountDisplayLabel,
   OtherAccount,
   QuotaGroup,
 } from "./account-display.tsx";
-import { openSwitchConfirmDialog } from "./account-switch.ts";
+import {
+  loadPeerAvailability,
+  openSwitchConfirmDialog,
+  protocolTargetsFor,
+} from "./account-switch.ts";
 import { AddAccountDialog } from "./add-account-dialog.tsx";
 import { formatAccountError, type Translate } from "./format-account-error.ts";
 import { useAccountsRefresh } from "./use-accounts-refresh.ts";
@@ -53,6 +62,17 @@ import { useUsagePollingLease } from "./use-usage-polling-lease.ts";
 
 export interface AccountsSettingsPageProps {
   context: ExternalRendererPluginContext;
+}
+
+function samePeerAvailability(
+  left: PeerAvailability,
+  right: PeerAvailability
+): boolean {
+  return (
+    left.omp === right.omp &&
+    left.opencode === right.opencode &&
+    left.pi === right.pi
+  );
 }
 
 const SETTINGS_LAYOUT_CLASS =
@@ -75,6 +95,41 @@ export function AccountsSettingsPage({
   useUsagePollingLease(context, "settings:accounts", true);
   const t: Translate = (key, fallback) => context.i18n.t(key, fallback);
   const [busyAccountId, setBusyAccountId] = useState<string | null>(null);
+  const [peerAvailability, setPeerAvailability] = useState<PeerAvailability>(
+    EMPTY_PEER_AVAILABILITY
+  );
+  useEffect(() => {
+    // Share only appears for the active account. Skip probing on empty pages so
+    // a late availability resolve cannot remount Add Account dialog callbacks.
+    const activeAccountId = snapshot?.activeAccountId ?? null;
+    if (!activeAccountId) {
+      setPeerAvailability((prev) =>
+        samePeerAvailability(prev, EMPTY_PEER_AVAILABILITY)
+          ? prev
+          : EMPTY_PEER_AVAILABILITY
+      );
+      return;
+    }
+    let cancelled = false;
+    loadPeerAvailability(context)
+      .then((availability) => {
+        if (cancelled) return;
+        setPeerAvailability((prev) =>
+          samePeerAvailability(prev, availability) ? prev : availability
+        );
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setPeerAvailability((prev) =>
+          samePeerAvailability(prev, EMPTY_PEER_AVAILABILITY)
+            ? prev
+            : EMPTY_PEER_AVAILABILITY
+        );
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [context, snapshot?.activeAccountId]);
 
   const reportError = (err: unknown): void => {
     context.dialogs
@@ -285,28 +340,33 @@ export function AccountsSettingsPage({
             </CardTitle>
             <CardAction className="flex items-center gap-2">
               <TooltipProvider delayDuration={200}>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      aria-label={t(
+                {partitionPeerTargets(
+                  protocolTargetsFor(active.kind),
+                  peerAvailability
+                ).available.length > 0 ? (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        aria-label={t(
+                          "pier.grok.accounts.settings.syncPeers",
+                          "Sync to other tools"
+                        )}
+                        onClick={() => handleSyncPeers(active.id)}
+                        size="icon-sm"
+                        type="button"
+                        variant="ghost"
+                      >
+                        <Share2 data-icon="inline-start" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent data-pier-grok-scope="">
+                      {t(
                         "pier.grok.accounts.settings.syncPeers",
                         "Sync to other tools"
                       )}
-                      onClick={() => handleSyncPeers(active.id)}
-                      size="icon-sm"
-                      type="button"
-                      variant="ghost"
-                    >
-                      <Share2 data-icon="inline-start" />
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent data-pier-grok-scope="">
-                    {t(
-                      "pier.grok.accounts.settings.syncPeers",
-                      "Sync to other tools"
-                    )}
-                  </TooltipContent>
-                </Tooltip>
+                    </TooltipContent>
+                  </Tooltip>
+                ) : null}
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <Button

--- a/packages/plugin-grok/src/renderer/switch-confirm-dialog.tsx
+++ b/packages/plugin-grok/src/renderer/switch-confirm-dialog.tsx
@@ -1,3 +1,4 @@
+import { partitionPeerTargets } from "@pier/plugin-api/peer-sync";
 import type {
   ExternalRendererPluginContext,
   RendererPluginContentDialogRenderProps,
@@ -8,6 +9,9 @@ import { type JSX, useState } from "react";
 import {
   ALL_SYNC_TARGETS,
   type CrossToolSyncTarget,
+  EMPTY_PEER_AVAILABILITY,
+  type PeerAvailability,
+  type PeerSyncTarget,
 } from "../shared/accounts.ts";
 import type { Translate } from "./format-account-error.ts";
 
@@ -18,24 +22,63 @@ export interface SwitchConfirmResult {
   syncTargets: CrossToolSyncTarget[];
 }
 
+function isPeerAvailability(value: unknown): value is PeerAvailability {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.omp === "boolean" &&
+    typeof record.opencode === "boolean" &&
+    typeof record.pi === "boolean"
+  );
+}
+
+export async function loadPeerAvailability(
+  context: ExternalRendererPluginContext
+): Promise<PeerAvailability> {
+  try {
+    const result = await context.rpc.invoke<unknown>(
+      "accounts.peerAvailability",
+      null
+    );
+    // Fail closed on missing/malformed probes (tests often stub unknown RPCs as null).
+    return isPeerAvailability(result) ? result : EMPTY_PEER_AVAILABILITY;
+  } catch {
+    // Fail closed: do not default-select peers we could not probe.
+    return EMPTY_PEER_AVAILABILITY;
+  }
+}
+
+export function protocolTargetsFor(
+  accountKind: "api_key" | "oidc"
+): readonly PeerSyncTarget[] {
+  // pi has no xAI OAuth support, so OIDC accounts never offer it as a peer target.
+  return accountKind === "api_key"
+    ? ALL_SYNC_TARGETS
+    : ALL_SYNC_TARGETS.filter((target) => target !== "pi");
+}
+
 function SwitchConfirmContent({
   accountKind,
+  availability,
   mode,
   t,
   close,
 }: {
   accountKind: "api_key" | "oidc";
+  availability: PeerAvailability;
   mode: PeerSyncDialogMode;
   t: Translate;
   close: RendererPluginContentDialogRenderProps<SwitchConfirmResult>["close"];
 }): JSX.Element {
-  // pi has no xAI OAuth support, so OIDC accounts never offer it as a peer target.
-  const availableTargets =
-    accountKind === "api_key"
-      ? ALL_SYNC_TARGETS
-      : ALL_SYNC_TARGETS.filter((target) => target !== "pi");
+  const { available } = partitionPeerTargets(
+    protocolTargetsFor(accountKind),
+    availability
+  );
+  const showSyncSection = available.length > 0;
   const [syncTargets, setSyncTargets] = useState<Set<CrossToolSyncTarget>>(
-    () => new Set(availableTargets)
+    () => new Set(available)
   );
 
   function toggleTarget(target: CrossToolSyncTarget): void {
@@ -50,7 +93,7 @@ function SwitchConfirmContent({
     });
   }
 
-  const targetLabel: Record<Exclude<CrossToolSyncTarget, "grok">, string> = {
+  const targetLabel: Record<PeerSyncTarget, string> = {
     opencode: t("pier.grok.switch.syncTarget.opencode", "OpenCode"),
     pi: t("pier.grok.switch.syncTarget.pi", "Pi"),
     omp: t("pier.grok.switch.syncTarget.omp", "OMP"),
@@ -73,30 +116,32 @@ function SwitchConfirmContent({
 
   return (
     <div className="flex flex-col gap-4" data-pier-grok-scope="">
-      <div className="flex flex-col gap-3">
-        <p className="font-medium text-sm">{sectionLabel}</p>
-        <div className="flex flex-col gap-2">
-          {availableTargets.map((target) => {
-            const checked = syncTargets.has(target);
-            return (
-              <label
-                className="flex items-center gap-2 text-sm"
-                htmlFor={`sync-target-${target}`}
-                key={target}
-              >
-                <Checkbox
-                  checked={checked}
-                  id={`sync-target-${target}`}
-                  onCheckedChange={() => {
-                    toggleTarget(target);
-                  }}
-                />
-                <span>{targetLabel[target]}</span>
-              </label>
-            );
-          })}
+      {showSyncSection ? (
+        <div className="flex flex-col gap-3">
+          <p className="font-medium text-sm">{sectionLabel}</p>
+          <div className="flex flex-col gap-2">
+            {available.map((target) => {
+              const checked = syncTargets.has(target);
+              return (
+                <label
+                  className="flex items-center gap-2 text-sm"
+                  htmlFor={`sync-target-${target}`}
+                  key={target}
+                >
+                  <Checkbox
+                    checked={checked}
+                    id={`sync-target-${target}`}
+                    onCheckedChange={() => {
+                      toggleTarget(target);
+                    }}
+                  />
+                  <span>{targetLabel[target]}</span>
+                </label>
+              );
+            })}
+          </div>
         </div>
-      </div>
+      ) : null}
       <div className="flex flex-wrap justify-end gap-2">
         <Button
           onClick={() => close({ confirmed: false, syncTargets: [] })}
@@ -127,6 +172,18 @@ export async function openSwitchConfirmDialog(options: {
 }): Promise<SwitchConfirmResult> {
   const mode = options.mode ?? "switch";
   const { accountKind, context, t } = options;
+  const availability = await loadPeerAvailability(context);
+  const { available } = partitionPeerTargets(
+    protocolTargetsFor(accountKind),
+    availability
+  );
+
+  // Dedicated sync entry with no installed peers should not open an empty dialog.
+  // The settings Share button is hidden in that case; keep this as a silent guard.
+  if (mode === "sync" && available.length === 0) {
+    return { confirmed: false, syncTargets: [] };
+  }
+
   const title =
     mode === "sync"
       ? t(
@@ -156,6 +213,7 @@ export async function openSwitchConfirmDialog(options: {
     content: (props) => (
       <SwitchConfirmContent
         accountKind={accountKind}
+        availability={availability}
         close={props.close}
         mode={mode}
         t={t}

--- a/packages/plugin-grok/src/shared/accounts.ts
+++ b/packages/plugin-grok/src/shared/accounts.ts
@@ -75,6 +75,18 @@ export const ALL_SYNC_TARGETS: readonly Exclude<CrossToolSyncTarget, "grok">[] =
 
 export type PeerSyncTarget = (typeof ALL_SYNC_TARGETS)[number];
 
+export interface PeerAvailability {
+  omp: boolean;
+  opencode: boolean;
+  pi: boolean;
+}
+
+export const EMPTY_PEER_AVAILABILITY: PeerAvailability = {
+  omp: false,
+  opencode: false,
+  pi: false,
+};
+
 export interface SyncToPeersPayload {
   accountId?: string | undefined;
   syncTargets: readonly PeerSyncTarget[];

--- a/packages/plugin-grok/vite.config.main.ts
+++ b/packages/plugin-grok/vite.config.main.ts
@@ -11,7 +11,7 @@ import { defineConfig } from "vite";
  *   resolves them at runtime.
  * - `@pier/plugin-api` / `@pier/plugin-api/main` are types-only entry points
  *   and stay external. Runtime helpers under `@pier/plugin-api/*` (e.g.
- *   `account-usage`) must be **inlined** — installed packages have no
+ *   `account-usage`, `peer-sync/main`) must be **inlined** — installed packages have no
  *   node_modules, and package validation rejects unresolved main imports.
  */
 export default defineConfig({

--- a/tests/unit/main/codex-plugin-rpc-handlers.test.ts
+++ b/tests/unit/main/codex-plugin-rpc-handlers.test.ts
@@ -162,4 +162,29 @@ describe("Codex plugin RPC handlers", () => {
       force: true,
     });
   });
+
+  it("exposes accounts.peerAvailability from shared peer-sync probes", async () => {
+    const handlers = new Map<string, (payload: unknown) => Promise<unknown>>();
+    const service = serviceStub();
+    registerCodexRpcHandlers({
+      acquireUsagePolling: vi.fn(async () => undefined),
+      releaseUsagePolling: vi.fn(),
+      rpc: {
+        handle: (method, handler) => {
+          handlers.set(method, handler);
+        },
+      },
+      service,
+    });
+
+    expect(handlers.has("accounts.peerAvailability")).toBe(true);
+    const snapshot = await handlers.get("accounts.peerAvailability")?.(null);
+    expect(snapshot).toEqual(
+      expect.objectContaining({
+        omp: expect.any(Boolean),
+        opencode: expect.any(Boolean),
+        pi: expect.any(Boolean),
+      })
+    );
+  });
 });

--- a/tests/unit/main/grok-plugin-rpc-handlers.test.ts
+++ b/tests/unit/main/grok-plugin-rpc-handlers.test.ts
@@ -46,6 +46,7 @@ describe("Grok plugin RPC handlers", () => {
       "accounts.add",
       "accounts.adoptCurrent",
       "accounts.cancelLogin",
+      "accounts.peerAvailability",
       "accounts.refreshAllUsage",
       "accounts.refreshUsage",
       "accounts.remove",
@@ -121,5 +122,30 @@ describe("Grok plugin RPC handlers", () => {
     await expect(
       handlers.get("accounts.add")?.({ kind: "api_key", apiKey: "" })
     ).rejects.toThrow();
+  });
+
+  it("exposes accounts.peerAvailability from shared peer-sync probes", async () => {
+    const handlers = new Map<string, (payload: unknown) => Promise<unknown>>();
+    const service = serviceStub();
+    registerGrokRpcHandlers({
+      acquireUsagePolling: vi.fn(async () => undefined),
+      releaseUsagePolling: vi.fn(),
+      rpc: {
+        handle: (method, handler) => {
+          handlers.set(method, handler);
+        },
+      },
+      service,
+    });
+
+    expect(handlers.has("accounts.peerAvailability")).toBe(true);
+    const snapshot = await handlers.get("accounts.peerAvailability")?.(null);
+    expect(snapshot).toEqual(
+      expect.objectContaining({
+        omp: expect.any(Boolean),
+        opencode: expect.any(Boolean),
+        pi: expect.any(Boolean),
+      })
+    );
   });
 });

--- a/tests/unit/main/peer-sync-availability.test.ts
+++ b/tests/unit/main/peer-sync-availability.test.ts
@@ -1,0 +1,88 @@
+// @vitest-environment node
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { partitionPeerTargets } from "../../../packages/plugin-api/src/peer-sync/index.ts";
+import { detectPeerAvailability } from "../../../packages/plugin-api/src/peer-sync/main.ts";
+
+let dir = "";
+
+afterEach(async () => {
+  if (dir) {
+    await rm(dir, { force: true, recursive: true });
+    dir = "";
+  }
+});
+
+describe("detectPeerAvailability", () => {
+  it("reports all peers unavailable in an empty home", async () => {
+    dir = await mkdtemp(join(tmpdir(), "pier-peer-availability-"));
+    expect(detectPeerAvailability({ homeDir: dir, pathEnv: dir })).toEqual({
+      omp: false,
+      opencode: false,
+      pi: false,
+    });
+  });
+
+  it("detects opencode via config, pi via home, and omp only with agent.db", async () => {
+    dir = await mkdtemp(join(tmpdir(), "pier-peer-availability-"));
+    const opencodeConfigDir = join(dir, ".config", "opencode");
+    await mkdir(opencodeConfigDir, { recursive: true });
+    await writeFile(join(opencodeConfigDir, "opencode.json"), "{}");
+    await mkdir(join(dir, ".pi", "agent"), { recursive: true });
+    await mkdir(join(dir, ".omp", "agent"), { recursive: true });
+
+    expect(detectPeerAvailability({ homeDir: dir, pathEnv: dir })).toEqual({
+      omp: false,
+      opencode: true,
+      pi: true,
+    });
+
+    await writeFile(join(dir, ".omp", "agent", "agent.db"), "");
+    expect(detectPeerAvailability({ homeDir: dir, pathEnv: dir })).toEqual({
+      omp: true,
+      opencode: true,
+      pi: true,
+    });
+  });
+
+  it("detects binaries on PATH without creating home dirs", async () => {
+    dir = await mkdtemp(join(tmpdir(), "pier-peer-availability-"));
+    const bin = join(dir, "bin");
+    await mkdir(bin, { recursive: true });
+    await writeFile(join(bin, "opencode"), "");
+    await writeFile(join(bin, "pi"), "");
+
+    expect(
+      detectPeerAvailability({
+        homeDir: join(dir, "home"),
+        pathEnv: bin,
+      })
+    ).toEqual({
+      omp: false,
+      opencode: true,
+      pi: true,
+    });
+  });
+});
+
+describe("partitionPeerTargets", () => {
+  it("keeps unavailable targets out of the default selection set", () => {
+    const { available, unavailable } = partitionPeerTargets(
+      ["opencode", "pi", "omp"],
+      { omp: false, opencode: true, pi: false }
+    );
+    expect(available).toEqual(["opencode"]);
+    expect(unavailable).toEqual(["pi", "omp"]);
+  });
+
+  it("returns empty available when no peer tools are installed", () => {
+    const { available, unavailable } = partitionPeerTargets(
+      ["opencode", "pi", "omp"],
+      { omp: false, opencode: false, pi: false }
+    );
+    expect(available).toEqual([]);
+    expect(unavailable).toEqual(["opencode", "pi", "omp"]);
+  });
+});

--- a/tests/unit/renderer/codex-accounts-settings-page.test.tsx
+++ b/tests/unit/renderer/codex-accounts-settings-page.test.tsx
@@ -6,6 +6,7 @@ import {
   fireEvent,
   render,
   screen,
+  waitFor,
 } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { AppContentDialogHost } from "@/components/common/app-content-dialog-host.tsx";
@@ -85,7 +86,13 @@ function contextWithSnapshot(snapshot: CodexAccountsSnapshot): {
     payload?: unknown
   ): Promise<T> => {
     invokeCalls.push({ method, payload });
-    return (method === "accounts.snapshot" ? snapshot : null) as T;
+    if (method === "accounts.snapshot") {
+      return snapshot as T;
+    }
+    if (method === "accounts.peerAvailability") {
+      return { omp: true, opencode: true, pi: true } as T;
+    }
+    return null as T;
   };
   return {
     context: {
@@ -637,6 +644,45 @@ describe("AccountsSettingsPage", () => {
     });
   });
 
+  it("hides the sync-to-peers button when no peer tools are available", async () => {
+    const snap = snapshotWithAccount({
+      accounts: [
+        {
+          id: "acc-1",
+          label: "active@codex.dev",
+          status: "active",
+          error: null,
+        },
+      ],
+    });
+    const { context } = contextWithSnapshot(snap);
+    context.rpc.invoke = async <T,>(
+      method: string,
+      _payload?: unknown
+    ): Promise<T> => {
+      if (method === "accounts.snapshot") {
+        return snap as T;
+      }
+      if (method === "accounts.peerAvailability") {
+        return { omp: false, opencode: false, pi: false } as T;
+      }
+      return null as T;
+    };
+    render(
+      <>
+        <AppContentDialogHost />
+        <AccountsSettingsPage context={context} />
+      </>
+    );
+
+    await screen.findByText("active@codex.dev");
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("button", { name: "Sync to other tools" })
+      ).toBeNull();
+    });
+  });
+
   it("syncs the current account credentials to peer tools without selecting", async () => {
     const snap = snapshotWithAccount({
       accounts: [
@@ -658,7 +704,7 @@ describe("AccountsSettingsPage", () => {
 
     await screen.findByText("active@codex.dev");
     fireEvent.click(
-      screen.getByRole("button", { name: "Sync to other tools" })
+      await screen.findByRole("button", { name: "Sync to other tools" })
     );
 
     expect(
@@ -708,7 +754,7 @@ describe("AccountsSettingsPage", () => {
 
     await screen.findByText("active@codex.dev");
     fireEvent.click(
-      screen.getByRole("button", { name: "Sync to other tools" })
+      await screen.findByRole("button", { name: "Sync to other tools" })
     );
     const cancelButton = await screen.findByRole("button", { name: "Cancel" });
     await act(async () => {

--- a/tests/unit/renderer/codex-accounts-widget.test.tsx
+++ b/tests/unit/renderer/codex-accounts-widget.test.tsx
@@ -114,7 +114,13 @@ function contextWithSnapshot(snapshot: CodexAccountsSnapshot): {
     payload?: unknown
   ): Promise<T> => {
     invokeCalls.push({ method, payload });
-    return (method === "accounts.snapshot" ? snapshot : null) as T;
+    if (method === "accounts.snapshot") {
+      return snapshot as T;
+    }
+    if (method === "accounts.peerAvailability") {
+      return { omp: true, opencode: true, pi: true } as T;
+    }
+    return null as T;
   };
   return {
     context: {

--- a/tests/unit/renderer/grok-accounts-settings-page.test.tsx
+++ b/tests/unit/renderer/grok-accounts-settings-page.test.tsx
@@ -67,6 +67,9 @@ function contextWithSnapshot(snapshot: GrokAccountsSnapshot): {
     if (method === "accounts.snapshot") {
       return snapshot as T;
     }
+    if (method === "accounts.peerAvailability") {
+      return { omp: true, opencode: true, pi: true } as T;
+    }
     return null as T;
   };
   return {
@@ -140,6 +143,32 @@ afterEach(() => {
 });
 
 describe("Grok accounts settings page", () => {
+  it("hides the sync-to-peers button when no peer tools are available", async () => {
+    const snap = snapshotWithAccounts();
+    const { context } = contextWithSnapshot(snap);
+    context.rpc.invoke = async <T,>(method: string): Promise<T> => {
+      if (method === "accounts.snapshot") {
+        return snap as T;
+      }
+      if (method === "accounts.peerAvailability") {
+        return { omp: false, opencode: false, pi: false } as T;
+      }
+      return null as T;
+    };
+    render(
+      <>
+        <AppContentDialogHost />
+        <AccountsSettingsPage context={context} />
+      </>
+    );
+    await screen.findByText("active@example.com");
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("button", { name: "Sync to other tools" })
+      ).toBeNull();
+    });
+  });
+
   it("shows empty state when no accounts", async () => {
     const { context } = contextWithSnapshot(emptySnapshot());
     await act(async () => {


### PR DESCRIPTION
## Summary
- Add shared sync-ready peer availability probes (`opencode` / `pi` / `omp`) and expose them via `accounts.peerAvailability` for Codex and Grok.
- Hide the settings Share sync button when no peer tools are available, instead of opening an empty flow or showing a click toast.
- Keep switch-account dialogs and their descriptions; only list installed peers, and hide the sync checkbox section when none are available.
- Split renderer-safe `@pier/plugin-api/peer-sync` from Node probes at `@pier/plugin-api/peer-sync/main`.

## Test plan
- [x] `pnpm typecheck:packages`
- [x] Vitest coverage for peer availability probes and Codex/Grok RPC handlers
- [x] Codex/Grok accounts settings page tests for hide-when-unavailable behavior
- [ ] Manually verify settings Share button is hidden with no peer tools installed
- [ ] Manually verify Share button appears and sync dialog lists only installed peers
- [ ] Manually verify switch-account dialog still shows switch copy when peers are absent