### PR TITLE
fix(files): keep terminal opens in Pier and release 0.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pier",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Pier — 本地 AI 开发工作台（dockview panel 布局 + 终端 + 代码变更预览 + 多 agent 状态可见性）",
   "type": "module",
   "main": "out/main/index.js",

--- a/packages/plugin-grok/package.json
+++ b/packages/plugin-grok/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pier/plugin-grok",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/plugin-grok/plugin.json
+++ b/packages/plugin-grok/plugin.json
@@ -299,5 +299,5 @@
     }
   ],
   "terminalStatusItems": [],
-  "version": "1.0.2"
+  "version": "1.0.3"
 }

--- a/packages/plugin-grok/src/main/grok-provider.ts
+++ b/packages/plugin-grok/src/main/grok-provider.ts
@@ -266,6 +266,9 @@ export function createGrokProvider(
         env: {
           ...process.env,
           ...processEnv,
+          // Keep login-shell PATH hydration (GUI Electron starts thin).
+          // processEnv may freeze activate-time PATH without ~/.grok/bin.
+          ...(process.env.PATH === undefined ? {} : { PATH: process.env.PATH }),
           GROK_HOME: homeDir,
         },
         signal,

--- a/src/main/app-core/app-core.ts
+++ b/src/main/app-core/app-core.ts
@@ -8,6 +8,7 @@ import {
   type ExternalMainPluginContext,
   type ExternalMainPluginRuntime,
 } from "../plugins/external-main-runtime.ts";
+import { createExternalPluginProcessEnv } from "../plugins/external-plugin-process-env.ts";
 import {
   createMainPluginHostApi,
   type MainPluginHostApi,
@@ -236,6 +237,9 @@ function createPierAppCore(): PierAppCore {
       }
     },
   });
+  // PATH hydrate must exist before external plugins activate — GUI Electron
+  // lacks login-shell bins (e.g. ~/.grok/bin). ensurePath is memoized.
+  const agentDetection = createAgentDetectionService();
   registerPluginRpcIpc(pluginRpcBus);
   const externalMainRuntime: ExternalMainPluginRuntime =
     createExternalMainPluginRuntime({
@@ -257,12 +261,7 @@ function createPierAppCore(): PierAppCore {
           dataDir: managedPluginPaths.workDir,
           workDir: join(managedPluginPaths.workDir, source.id),
         },
-        processEnv: {
-          CODEX_HOME: process.env.CODEX_HOME,
-          GROK_HOME: process.env.GROK_HOME,
-          HOME: process.env.HOME,
-          PATH: process.env.PATH,
-        },
+        processEnv: createExternalPluginProcessEnv(),
         plugin: { id: source.id, version: source.version },
         rpc: {
           handle: (method, handler) =>
@@ -281,8 +280,10 @@ function createPierAppCore(): PierAppCore {
         managedPlugins.recordActivationResult(input),
       rpcBus: pluginRpcBus,
     });
-  externalMainRuntimeReconciler =
-    createManagedPluginRuntimeReconciler(externalMainRuntime);
+  externalMainRuntimeReconciler = createManagedPluginRuntimeReconciler(
+    externalMainRuntime,
+    { ensurePath: agentDetection.ensurePath }
+  );
   pluginHostRef = pluginHost;
   const managedPluginsReady = usageDataReady
     .then(() =>
@@ -317,8 +318,6 @@ function createPierAppCore(): PierAppCore {
     userDataDir: app.getPath("userData"),
   });
   const runtimeMode = isDevRuntime() ? "development" : "production";
-  // AI 复用本机 CLI agent:探测走 agents 检测服务,选择遵循 defaultAgentId
-  const agentDetection = createAgentDetectionService();
   const agentUsage = createAgentUsageService({
     userDataDir: app.getPath("userData"),
   });

--- a/src/main/app-core/managed-plugin-runtime-reconciler.ts
+++ b/src/main/app-core/managed-plugin-runtime-reconciler.ts
@@ -18,10 +18,20 @@ export interface ManagedPluginRuntimeReconciler {
   reconcile(sources: readonly ManagedPluginRuntimeSource[]): Promise<void>;
 }
 
+export interface CreateManagedPluginRuntimeReconcilerOptions {
+  /**
+   * GUI-launched Electron often lacks login-shell PATH entries
+   * (e.g. ~/.grok/bin). Await this before activating plugins that spawn CLIs.
+   */
+  ensurePath?: () => Promise<void>;
+}
+
 export function createManagedPluginRuntimeReconciler(
-  runtime: ExternalMainPluginRuntime
+  runtime: ExternalMainPluginRuntime,
+  options: CreateManagedPluginRuntimeReconcilerOptions = {}
 ): ManagedPluginRuntimeReconciler {
   const activeKeys = new Map<string, string>();
+  const ensurePath = options.ensurePath;
 
   return {
     async reconcile(sources): Promise<void> {
@@ -40,11 +50,17 @@ export function createManagedPluginRuntimeReconciler(
         const nextKey = runtimeSourceActivationKey(source);
         const currentKey = activeKeys.get(source.id);
         if (!currentKey) {
+          if (ensurePath) {
+            await ensurePath();
+          }
           await runtime.activate(source);
           activeKeys.set(source.id, nextKey);
           continue;
         }
         if (currentKey !== nextKey) {
+          if (ensurePath) {
+            await ensurePath();
+          }
           await runtime.reload(source);
           activeKeys.set(source.id, nextKey);
         }

--- a/src/main/ipc/terminal-open-url-forwarding.ts
+++ b/src/main/ipc/terminal-open-url-forwarding.ts
@@ -4,20 +4,23 @@ import type {
 } from "@shared/contracts/terminal.ts";
 import { terminalOpenUrlEventSchema } from "@shared/contracts/terminal.ts";
 
+const EXTERNAL_SCHEMES = new Set(["http", "https", "mailto"]);
+
 export function classifyTerminalOpenUrlForMain(
   url: string
-): "remote" | "local-candidate" {
+): "remote" | "filesystem" | "app-internal" {
   const trimmed = url.trim();
   if (!trimmed) {
-    return "local-candidate";
+    return "filesystem";
   }
-  if (
-    /^[a-z][a-z0-9+.-]*:/i.test(trimmed) &&
-    !trimmed.toLowerCase().startsWith("file:")
-  ) {
+  const protocol = /^([a-z][a-z0-9+.-]*):/i.exec(trimmed)?.[1]?.toLowerCase();
+  if (!protocol || protocol === "file") {
+    return "filesystem";
+  }
+  if (EXTERNAL_SCHEMES.has(protocol)) {
     return "remote";
   }
-  return "local-candidate";
+  return "app-internal";
 }
 
 export async function handleTerminalOpenUrl(input: {

--- a/src/main/ipc/window.ts
+++ b/src/main/ipc/window.ts
@@ -7,12 +7,46 @@
  * 已迁至 command router: close/create/focus/list
  */
 
+import { parseRendererRuntimeFailureReport } from "@shared/contracts/renderer-runtime-failure.ts";
 import { PIER } from "@shared/ipc-channels.ts";
+import { createLogger } from "@shared/logger.ts";
 import type { IpcMain } from "electron";
 import { findWindowContext } from "../windows/window-identity.ts";
 import { windowManager } from "../windows/window-manager.ts";
 
+const rendererRuntimeLog = createLogger("renderer-runtime");
+
 export function registerWindowIpc(ipcMain: IpcMain): void {
+  ipcMain.on(PIER.WINDOW_RENDERER_RUNTIME_FAILURE, (event, rawFailure) => {
+    const win = windowManager.fromWebContents(event.sender);
+    if (!win) {
+      rendererRuntimeLog.warn(
+        "Dropped renderer runtime failure: unknown window",
+        {
+          senderId: event.sender.id,
+        }
+      );
+      return;
+    }
+    const failure = parseRendererRuntimeFailureReport(rawFailure);
+    if (!failure) {
+      rendererRuntimeLog.warn(
+        "Dropped renderer runtime failure: invalid payload",
+        {
+          senderId: event.sender.id,
+        }
+      );
+      return;
+    }
+    const context = findWindowContext(win);
+    rendererRuntimeLog.error("React root failed", {
+      ...failure,
+      ...(context
+        ? { recordId: context.recordId, windowId: context.windowId }
+        : {}),
+    });
+  });
+
   ipcMain.handle(PIER.WINDOW_CONTEXT, (event) => {
     const win = windowManager.fromWebContents(event.sender);
     if (!win) {

--- a/src/main/plugins/external-plugin-process-env.ts
+++ b/src/main/plugins/external-plugin-process-env.ts
@@ -1,0 +1,25 @@
+/**
+ * Host-facing env slice for external main plugins.
+ *
+ * PATH/HOME/*_HOME must read live process.env so login-shell PATH hydration
+ * (agentDetection.ensurePath) is visible after plugin activate — GUI Electron
+ * starts with a thin PATH that often omits ~/.grok/bin and similar bins.
+ */
+export function createExternalPluginProcessEnv(): Readonly<
+  Record<string, string | undefined>
+> {
+  return {
+    get CODEX_HOME() {
+      return process.env.CODEX_HOME;
+    },
+    get GROK_HOME() {
+      return process.env.GROK_HOME;
+    },
+    get HOME() {
+      return process.env.HOME;
+    },
+    get PATH() {
+      return process.env.PATH;
+    },
+  };
+}

--- a/src/plugins/builtin/files/locales/en.json
+++ b/src/plugins/builtin/files/locales/en.json
@@ -210,6 +210,7 @@
     "files.projectStatus.openFailed": "Unable to open project files",
     "files.notifications.terminalOpenUrl.relativeWithoutCwd": "This terminal has no working directory, so the relative path cannot be opened.",
     "files.notifications.terminalOpenUrl.invalid": "Cannot open this path.",
+    "files.notifications.terminalOpenUrl.unsupportedScheme": "Cannot open this link in Pier.",
     "files.notifications.terminalOpenUrl.openFailed": "Unable to open path."
   },
   "terminalStatusItems": {

--- a/src/plugins/builtin/files/locales/zh-CN.json
+++ b/src/plugins/builtin/files/locales/zh-CN.json
@@ -210,6 +210,7 @@
     "files.projectStatus.openFailed": "无法打开项目文件",
     "files.notifications.terminalOpenUrl.relativeWithoutCwd": "当前终端没有工作目录，无法打开这个相对路径。",
     "files.notifications.terminalOpenUrl.invalid": "无法打开该路径。",
+    "files.notifications.terminalOpenUrl.unsupportedScheme": "Pier 无法打开该链接。",
     "files.notifications.terminalOpenUrl.openFailed": "无法打开路径。"
   },
   "terminalStatusItems": {

--- a/src/plugins/builtin/files/renderer/files-document-paths.ts
+++ b/src/plugins/builtin/files/renderer/files-document-paths.ts
@@ -4,6 +4,22 @@ export function diskDocumentId(root: string, path: string): string {
   return `pier.files.file:${stableFileIdentityHash(`${root}\0${path}`)}`;
 }
 
+/** Join disk panel source root+path into a comparable absolute path identity. */
+export function absoluteDiskSourcePath(root: string, path: string): string {
+  const normalizedRoot = root.replaceAll("\\", "/").replace(/\/+$/, "") || "/";
+  const normalizedPath = path
+    .replaceAll("\\", "/")
+    .replace(/^\/+/, "")
+    .replace(/\/+$/, "");
+  if (!normalizedPath) {
+    return normalizedRoot;
+  }
+  if (normalizedRoot === "/") {
+    return `/${normalizedPath}`;
+  }
+  return `${normalizedRoot}/${normalizedPath}`;
+}
+
 export function isSamePathOrDescendant(
   entryPath: string,
   path: string

--- a/src/plugins/builtin/files/renderer/files-document-types.ts
+++ b/src/plugins/builtin/files/renderer/files-document-types.ts
@@ -6,6 +6,7 @@ import {
 } from "@shared/contracts/file.ts";
 import type { PanelContext } from "@shared/contracts/panel.ts";
 import { z } from "zod";
+import { absoluteDiskSourcePath } from "./files-document-paths.ts";
 
 export type FilesDocumentLanguage =
   | "cpp"
@@ -82,7 +83,10 @@ export function sameFilesDocumentPanelSource(
     return left.id === right.id;
   }
   if (left.kind === "disk" && right.kind === "disk") {
-    return left.root === right.root && left.path === right.path;
+    return (
+      absoluteDiskSourcePath(left.root, left.path) ===
+      absoluteDiskSourcePath(right.root, right.path)
+    );
   }
   return false;
 }

--- a/src/plugins/builtin/files/renderer/files-terminal-open-url-handler.ts
+++ b/src/plugins/builtin/files/renderer/files-terminal-open-url-handler.ts
@@ -20,11 +20,8 @@ import { revealFilesTreePath } from "./files-tree-registry.ts";
 
 type SystemOpenFallbackReason =
   | "binary-or-unsupported"
-  | "missing-panel-context"
-  | "missing-path"
   | "open-instance-failed"
-  | "open-project-failed"
-  | "outside-anchor";
+  | "open-project-failed";
 
 const inflight = new Set<string>();
 
@@ -41,10 +38,32 @@ function toRootRelative(anchor: string, absolutePath: string): string | null {
   return to.slice(prefix.length);
 }
 
+function splitAbsoluteDiskTarget(absolutePath: string): {
+  path: string;
+  root: string;
+} {
+  const normalized =
+    absolutePath.replace(/\\/g, "/").replace(/\/+$/, "") || "/";
+  if (normalized === "/") {
+    return { path: "", root: "/" };
+  }
+  const slash = normalized.lastIndexOf("/");
+  if (slash <= 0) {
+    return { path: normalized.slice(1), root: "/" };
+  }
+  return {
+    path: normalized.slice(slash + 1),
+    root: normalized.slice(0, slash),
+  };
+}
+
 function withTerminalAnchor(
-  context: PanelContext,
+  context: PanelContext | null,
   anchor: string
-): PanelContext {
+): PanelContext | null {
+  if (!context) {
+    return null;
+  }
   return {
     ...context,
     projectRootPath: anchor,
@@ -75,7 +94,7 @@ async function openAbsoluteWithSystem(
 
 function openDiskFile(
   context: RendererPluginContext,
-  panelContext: PanelContext,
+  panelContext: PanelContext | null,
   root: string,
   relativePath: string
 ): void {
@@ -107,12 +126,116 @@ function openDiskFile(
 
   context.panels.openInstance({
     componentId: FILES_FILE_PANEL_ID,
-    ...(existingInstance ? {} : { context: panelContext }),
+    ...(existingInstance || !panelContext ? {} : { context: panelContext }),
     dropUnpinnedInstances: false,
     instanceId: existingInstance?.id ?? createFileFilePanelInstanceId(source),
     params,
     title: sourceTitle(existingSource ?? source),
   });
+}
+
+async function openReadableDiskTarget(
+  context: RendererPluginContext,
+  panelContext: PanelContext | null,
+  root: string,
+  relativePath: string,
+  absolutePath: string
+): Promise<boolean> {
+  const openContext = withTerminalAnchor(panelContext, root);
+
+  if (relativePath === "") {
+    if (!openContext) {
+      context.notifications.error(
+        createFilesTranslate(context)(
+          "files.notifications.terminalOpenUrl.invalid",
+          "Cannot open this path."
+        )
+      );
+      return true;
+    }
+    const opened = openProjectFiles(context, openContext);
+    if (!opened.ok) {
+      return await openAbsoluteWithSystem(
+        context,
+        absolutePath,
+        "open-project-failed"
+      );
+    }
+    globalThis.setTimeout(() => {
+      revealFilesTreePath({ path: "", root });
+    }, 80);
+    return true;
+  }
+
+  const stat = await context.files.stat({
+    path: relativePath,
+    root,
+  });
+
+  if (!stat.exists) {
+    context.notifications.error(
+      createFilesTranslate(context)(
+        "files.notifications.terminalOpenUrl.invalid",
+        "Cannot open this path."
+      )
+    );
+    return true;
+  }
+
+  if (stat.isDirectory) {
+    if (!openContext) {
+      context.notifications.error(
+        createFilesTranslate(context)(
+          "files.notifications.terminalOpenUrl.invalid",
+          "Cannot open this path."
+        )
+      );
+      return true;
+    }
+    const opened = openProjectFiles(context, openContext);
+    if (!opened.ok) {
+      return await openAbsoluteWithSystem(
+        context,
+        absolutePath,
+        "open-project-failed"
+      );
+    }
+    globalThis.setTimeout(() => {
+      revealFilesTreePath({
+        path: relativePath,
+        root,
+      });
+    }, 80);
+    return true;
+  }
+
+  const document = await context.files.readDocument({
+    path: relativePath,
+    root,
+  });
+  if (
+    document.kind === "binary" ||
+    document.kind === "too-large" ||
+    document.kind === "unsupported-encoding" ||
+    document.kind === "unsupported-file"
+  ) {
+    return await openAbsoluteWithSystem(
+      context,
+      absolutePath,
+      "binary-or-unsupported"
+    );
+  }
+
+  try {
+    openDiskFile(context, openContext, root, relativePath);
+    return true;
+  } catch {
+    return await openAbsoluteWithSystem(
+      context,
+      absolutePath,
+      "open-instance-failed"
+    );
+  }
 }
 
 export async function handleFilesTerminalOpenUrl(
@@ -136,6 +259,13 @@ export async function handleFilesTerminalOpenUrl(
           "This terminal has no working directory, so the relative path cannot be opened."
         )
       );
+    } else if (parsed.reason === "unsupported-scheme") {
+      context.notifications.error(
+        t(
+          "files.notifications.terminalOpenUrl.unsupportedScheme",
+          "Cannot open this link in Pier."
+        )
+      );
     } else {
       context.notifications.error(
         t(
@@ -153,108 +283,29 @@ export async function handleFilesTerminalOpenUrl(
   }
   inflight.add(absolutePath);
   try {
-    if (!panelContext) {
-      return await openAbsoluteWithSystem(
-        context,
-        absolutePath,
-        "missing-panel-context"
-      );
-    }
-
     const anchors = terminalOpenUrlAnchors(panelContext);
     const anchor = longestCoveringAnchor(absolutePath, anchors);
-    if (!anchor) {
-      return await openAbsoluteWithSystem(
-        context,
-        absolutePath,
-        "outside-anchor"
-      );
-    }
-
-    const relativePath = toRootRelative(anchor, absolutePath);
-    if (relativePath === null) {
-      return await openAbsoluteWithSystem(
-        context,
-        absolutePath,
-        "outside-anchor"
-      );
-    }
-
-    const openContext = withTerminalAnchor(panelContext, anchor);
-
-    if (relativePath === "") {
-      const opened = openProjectFiles(context, openContext);
-      if (!opened.ok) {
-        return await openAbsoluteWithSystem(
+    if (anchor) {
+      const relativePath = toRootRelative(anchor, absolutePath);
+      if (relativePath !== null) {
+        return await openReadableDiskTarget(
           context,
-          absolutePath,
-          "open-project-failed"
+          panelContext,
+          anchor,
+          relativePath,
+          absolutePath
         );
       }
-      globalThis.setTimeout(() => {
-        revealFilesTreePath({ path: "", root: anchor });
-      }, 80);
-      return true;
     }
 
-    const stat = await context.files.stat({
-      path: relativePath,
-      root: anchor,
-    });
-
-    if (!stat.exists) {
-      return await openAbsoluteWithSystem(
-        context,
-        absolutePath,
-        "missing-path"
-      );
-    }
-
-    if (stat.isDirectory) {
-      const opened = openProjectFiles(context, openContext);
-      if (!opened.ok) {
-        return await openAbsoluteWithSystem(
-          context,
-          absolutePath,
-          "open-project-failed"
-        );
-      }
-      globalThis.setTimeout(() => {
-        revealFilesTreePath({
-          path: relativePath,
-          root: anchor,
-        });
-      }, 80);
-      return true;
-    }
-
-    const document = await context.files.readDocument({
-      path: relativePath,
-      root: anchor,
-    });
-    if (
-      document.kind === "binary" ||
-      document.kind === "too-large" ||
-      document.kind === "unsupported-encoding" ||
-      document.kind === "unsupported-file"
-    ) {
-      return await openAbsoluteWithSystem(
-        context,
-        absolutePath,
-        "binary-or-unsupported"
-      );
-    }
-
-    try {
-      openDiskFile(context, openContext, anchor, relativePath);
-      return true;
-    } catch {
-      return await openAbsoluteWithSystem(
-        context,
-        absolutePath,
-        "open-instance-failed"
-      );
-    }
+    const fallback = splitAbsoluteDiskTarget(absolutePath);
+    return await openReadableDiskTarget(
+      context,
+      panelContext,
+      fallback.root,
+      fallback.path,
+      absolutePath
+    );
   } finally {
     inflight.delete(absolutePath);
   }

--- a/src/plugins/builtin/files/renderer/files-terminal-open-url-resolve.ts
+++ b/src/plugins/builtin/files/renderer/files-terminal-open-url-resolve.ts
@@ -1,7 +1,12 @@
 export type ParsedTerminalOpenUrl =
   | { kind: "remote"; url: string }
   | { kind: "local-path"; path: string }
-  | { kind: "unresolved"; reason: "relative-without-cwd" | "invalid" };
+  | {
+      kind: "unresolved";
+      reason: "relative-without-cwd" | "unsupported-scheme" | "invalid";
+    };
+
+const EXTERNAL_SCHEMES = new Set(["http:", "https:", "mailto:"]);
 
 function isAbsolutePath(path: string): boolean {
   return path.startsWith("/") || /^[A-Za-z]:[\\/]/.test(path);
@@ -45,10 +50,9 @@ function fileUrlToPath(raw: string): string | null {
   }
 }
 
-function hasRemoteScheme(raw: string): boolean {
-  return (
-    /^[a-z][a-z0-9+.-]*:/i.test(raw) && !raw.toLowerCase().startsWith("file:")
-  );
+function schemeOf(raw: string): string | null {
+  const match = /^([a-z][a-z0-9+.-]*:)/i.exec(raw);
+  return match?.[1]?.toLowerCase() ?? null;
 }
 
 export function parseTerminalOpenUrl(
@@ -59,15 +63,19 @@ export function parseTerminalOpenUrl(
   if (!raw) {
     return { kind: "unresolved", reason: "invalid" };
   }
-  if (hasRemoteScheme(raw)) {
-    return { kind: "remote", url: raw };
-  }
-  if (raw.toLowerCase().startsWith("file:")) {
-    const path = fileUrlToPath(raw);
-    if (!path) {
-      return { kind: "unresolved", reason: "invalid" };
+  const scheme = schemeOf(raw);
+  if (scheme) {
+    if (EXTERNAL_SCHEMES.has(scheme)) {
+      return { kind: "remote", url: raw };
     }
-    return { kind: "local-path", path };
+    if (scheme === "file:") {
+      const path = fileUrlToPath(raw);
+      if (!path) {
+        return { kind: "unresolved", reason: "invalid" };
+      }
+      return { kind: "local-path", path };
+    }
+    return { kind: "unresolved", reason: "unsupported-scheme" };
   }
   if (isAbsolutePath(raw)) {
     return { kind: "local-path", path: raw };

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -30,6 +30,7 @@ import {
   RENDERER_COMMAND_CHANNEL,
   RENDERER_COMMAND_RESULT_CHANNEL,
 } from "@shared/contracts/renderer-command-channels.ts";
+import type { RendererRuntimeFailureReport } from "@shared/contracts/renderer-runtime-failure.ts";
 import type { TerminalAPI } from "@shared/contracts/terminal.ts";
 import type {
   WindowContext,
@@ -222,6 +223,7 @@ export interface PierWindowNsAPI {
   getContext: () => Promise<WindowContext>;
   onLayoutPulse: (cb: (pulse: WindowLayoutPulse) => void) => () => void;
   readyToShow: () => void;
+  reportRuntimeFailure: (failure: RendererRuntimeFailureReport) => void;
 }
 
 /** env 子命名空间 — 运行时环境信息. */
@@ -488,6 +490,8 @@ const api: PierWindowAPI = {
     getContext: () => ipcRenderer.invoke("pier://window:context"),
     onLayoutPulse: (cb) => subscribeIpc(PIER_BROADCAST.WINDOW_LAYOUT_PULSE, cb),
     readyToShow: signalRendererBoot,
+    reportRuntimeFailure: (failure) =>
+      ipcRenderer.send(PIER.WINDOW_RENDERER_RUNTIME_FAILURE, failure),
   },
   workspace: workspaceApi,
   worktrees: worktreesApi,

--- a/src/renderer/components/common/app-runtime-error-boundary.tsx
+++ b/src/renderer/components/common/app-runtime-error-boundary.tsx
@@ -1,0 +1,118 @@
+import type { RendererRuntimeFailureReport } from "@shared/contracts/renderer-runtime-failure.ts";
+import {
+  Component,
+  type ErrorInfo,
+  type ReactNode,
+  useLayoutEffect,
+} from "react";
+import { useKeybindingScope } from "@/stores/keybinding-scope.store.ts";
+import {
+  registerTerminalFullscreenWebOverlay,
+  requestTerminalWebFocus,
+} from "@/stores/terminal-input-routing-slice.ts";
+import { StartupErrorScreen } from "./startup-error-screen.tsx";
+
+const RUNTIME_ERROR_OVERLAY_ID = "app-runtime-error";
+const RUNTIME_ERROR_SCOPE_ID = `overlay:${RUNTIME_ERROR_OVERLAY_ID}`;
+
+interface AppRuntimeErrorBoundaryProps {
+  children: ReactNode;
+  onRetry?: () => void;
+}
+
+interface AppRuntimeErrorBoundaryState {
+  error: unknown;
+  hasError: boolean;
+}
+
+function errorReport(
+  error: unknown,
+  info: ErrorInfo
+): RendererRuntimeFailureReport {
+  if (error instanceof Error) {
+    return {
+      message: error.message || "Unknown renderer error",
+      name: error.name || "Error",
+      ...(error.stack ? { stack: error.stack } : {}),
+      ...(info.componentStack ? { componentStack: info.componentStack } : {}),
+    };
+  }
+  return {
+    message: String(error),
+    name: "NonErrorThrow",
+    ...(info.componentStack ? { componentStack: info.componentStack } : {}),
+  };
+}
+
+function RuntimeErrorScreen({
+  error,
+  onRetry,
+}: {
+  error: unknown;
+  onRetry?: () => void;
+}) {
+  useLayoutEffect(() => {
+    // paint 前接管：App 卸载后原生 NSView 仍在。useEffect 会留一帧
+    // “看得到错误页、终端区域点不进 web”的窗口。
+    const overlay = registerTerminalFullscreenWebOverlay(
+      RUNTIME_ERROR_OVERLAY_ID
+    );
+    const releaseFocus = requestTerminalWebFocus(RUNTIME_ERROR_OVERLAY_ID);
+    useKeybindingScope.getState().pushBlockingScope(RUNTIME_ERROR_SCOPE_ID);
+    console.info("[renderer-runtime-fatal] recovery input claimed", {
+      overlayId: RUNTIME_ERROR_OVERLAY_ID,
+      scopeId: RUNTIME_ERROR_SCOPE_ID,
+    });
+    return () => {
+      useKeybindingScope.getState().popBlockingScope(RUNTIME_ERROR_SCOPE_ID);
+      releaseFocus();
+      overlay.dispose();
+    };
+  }, []);
+
+  return (
+    <StartupErrorScreen
+      error={error}
+      kind="runtime"
+      {...(onRetry ? { onRetry } : {})}
+    />
+  );
+}
+
+/**
+ * 覆盖“renderer 进程仍存活，但 React 运行期错误卸载整棵树”的故障域。
+ * 启动阶段仍由 main.tsx 的 StartupErrorScreen 负责，两者不互相吞错。
+ */
+export class AppRuntimeErrorBoundary extends Component<
+  AppRuntimeErrorBoundaryProps,
+  AppRuntimeErrorBoundaryState
+> {
+  override state: AppRuntimeErrorBoundaryState = {
+    error: null,
+    hasError: false,
+  };
+
+  static getDerivedStateFromError(
+    error: unknown
+  ): AppRuntimeErrorBoundaryState {
+    return { error, hasError: true };
+  }
+
+  override componentDidCatch(error: unknown, info: ErrorInfo): void {
+    const report = errorReport(error, info);
+    console.error("[renderer-runtime-fatal]", report);
+    window.pier?.window?.reportRuntimeFailure?.(report);
+  }
+
+  override render(): ReactNode {
+    if (this.state.hasError) {
+      return (
+        <RuntimeErrorScreen
+          error={this.state.error}
+          {...(this.props.onRetry ? { onRetry: this.props.onRetry } : {})}
+        />
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/src/renderer/components/common/command-palette.tsx
+++ b/src/renderer/components/common/command-palette.tsx
@@ -1,12 +1,4 @@
-/**
- * 命令面板 UI:
- *   - state machine 由 controller 管, 这里只渲染 + 路由用户事件回 controller。
- *   - capture-phase keydown 拦 Esc → controller.goBack() (栈非空回退, 栈空关闭),
- *     早于 Radix DismissibleLayer 的 Esc 默认行为。
- *   - 关闭时若 quick-pick 未 accept, dismiss effect 调 onDismiss 还原 preview。
- *   - selectedValue 控制高亮项, 切 quick-pick 时初始化为 checked item, 触发
- *     debounced onChangeSelection (preview 去重)。
- */
+/** 命令面板 UI：controller 管状态；组件负责渲染并路由关闭、回退和选择事件。 */
 
 import {
   Command,
@@ -50,6 +42,7 @@ import {
 import { useCommandPaletteController } from "@/lib/command-palette/controller.ts";
 import { CATEGORY_META } from "@/lib/command-palette/frecency.ts";
 import type { QuickPickItem } from "@/lib/command-palette/types.ts";
+import { useCommandPaletteScroll } from "@/lib/command-palette/use-command-palette-scroll.ts";
 import { useQuickPickQueryChange } from "@/lib/command-palette/use-quick-pick-query-change.ts";
 import { formatChord } from "@/lib/keybindings/formatter.ts";
 import {
@@ -151,6 +144,12 @@ export function CommandPalette() {
   const quickPick = controller.quickPick;
   const isOpen = controller.open;
   const requestId = controller.requestId;
+  const listRef = useCommandPaletteScroll({
+    isOpen,
+    query: normalizedQuery,
+    requestId,
+    selectedValue,
+  });
   const [retainedPresentation, setRetainedPresentation] = useState({
     mode,
     quickPick,
@@ -485,7 +484,7 @@ export function CommandPalette() {
           </div>
         ) : null}
         {quickPick?.onAcceptQuery ? null : (
-          <CommandList className="max-h-[min(60vh,520px)]">
+          <CommandList className="max-h-[min(60vh,520px)]" ref={listRef}>
             <CommandEmpty>
               {presentedMode === "quick-pick"
                 ? t("commandPalette.emptyQuickPick")

--- a/src/renderer/components/common/startup-error-screen.tsx
+++ b/src/renderer/components/common/startup-error-screen.tsx
@@ -1,11 +1,12 @@
 import { Button } from "@pier/ui/button.tsx";
 import {
-  Card,
-  CardContent,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from "@pier/ui/card.tsx";
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@pier/ui/empty.tsx";
 import { Spinner } from "@pier/ui/spinner.tsx";
 import { StatusIcon } from "@pier/ui/status-icon.tsx";
 import i18next from "i18next";
@@ -13,6 +14,7 @@ import { RotateCcw } from "lucide-react";
 
 export interface StartupErrorScreenProps {
   error: unknown;
+  kind?: "runtime" | "startup";
   onRetry?: () => void;
 }
 
@@ -48,41 +50,48 @@ export function StartupScreen() {
   );
 }
 
-function fallbackCopy() {
+function fallbackCopy(kind: "runtime" | "startup") {
   const isChinese = document.documentElement.lang.startsWith("zh");
+  if (kind === "runtime") {
+    return isChinese
+      ? {
+          description: "终端会话已保留，请重新加载。",
+          retry: "重新加载",
+          title: "界面出现错误",
+        }
+      : {
+          description: "Terminal sessions are preserved. Reload to continue.",
+          retry: "Reload",
+          title: "Interface error",
+        };
+  }
   return isChinese
     ? {
-        description:
-          "Pier 无法完成核心初始化。请重试；如果问题持续存在，请保留下面的错误详情。",
-        details: "错误详情",
+        description: "请重新加载后再试。",
         retry: "重新加载",
         title: "Pier 启动失败",
       }
     : {
-        description:
-          "Pier could not finish core initialization. Retry, and keep the error details below if the problem continues.",
-        details: "Error details",
+        description: "Reload to try again.",
         retry: "Reload",
         title: "Pier failed to start",
       };
 }
 
-function translatedCopy() {
-  const fallback = fallbackCopy();
+function translatedCopy(kind: "runtime" | "startup") {
+  const fallback = fallbackCopy(kind);
   if (!i18next.isInitialized) {
     return fallback;
   }
+  const key = kind === "runtime" ? "runtimeError" : "startupError";
   return {
-    description: i18next.t("workspace.startupError.description", {
+    description: i18next.t(`workspace.${key}.description`, {
       defaultValue: fallback.description,
     }),
-    details: i18next.t("workspace.startupError.details", {
-      defaultValue: fallback.details,
-    }),
-    retry: i18next.t("workspace.startupError.retry", {
+    retry: i18next.t(`workspace.${key}.retry`, {
       defaultValue: fallback.retry,
     }),
-    title: i18next.t("workspace.startupError.title", {
+    title: i18next.t(`workspace.${key}.title`, {
       defaultValue: fallback.title,
     }),
   };
@@ -105,47 +114,37 @@ function retryStartup(): void {
 
 export function StartupErrorScreen({
   error,
+  kind = "startup",
   onRetry = retryStartup,
 }: StartupErrorScreenProps) {
-  const copy = translatedCopy();
+  const copy = translatedCopy(kind);
   const detail = formatStartupError(error);
 
   return (
-    <main className="flex min-h-screen items-center justify-center bg-background p-6 text-foreground">
-      <Card className="flex max-h-[min(80vh,36rem)] w-full max-w-xl">
-        <CardHeader className="shrink-0">
-          <div className="flex items-start gap-3">
-            <StatusIcon className="mt-0.5" kind="error" />
-            <div className="min-w-0 flex-1">
-              <CardTitle>
-                <h1>{copy.title}</h1>
-              </CardTitle>
-              <p className="mt-2 text-muted-foreground text-sm leading-6">
-                {copy.description}
-              </p>
-            </div>
-          </div>
-        </CardHeader>
-        <CardContent
-          className="min-h-0 flex-1 overflow-y-auto px-0"
-          data-scrollbar="stable"
-        >
-          <div className="px-(--card-spacing)">
-            <div className="font-medium text-foreground text-sm">
-              {copy.details}
-            </div>
-            <pre className="mt-2 whitespace-pre-wrap break-words font-mono text-muted-foreground text-xs leading-5">
-              {detail}
-            </pre>
-          </div>
-        </CardContent>
-        <CardFooter className="shrink-0 justify-end">
+    <main className="flex min-h-screen bg-background text-foreground">
+      <Empty className="rounded-none p-6">
+        <EmptyHeader>
+          <EmptyMedia>
+            <StatusIcon kind="error" />
+          </EmptyMedia>
+          <EmptyTitle>
+            <h1>{copy.title}</h1>
+          </EmptyTitle>
+          <EmptyDescription>{copy.description}</EmptyDescription>
+        </EmptyHeader>
+        <EmptyContent className="max-w-xl">
+          <pre
+            className="max-h-[min(50vh,20rem)] w-full overflow-y-auto whitespace-pre-wrap break-words rounded-md bg-muted p-3 text-left font-mono text-muted-foreground text-xs leading-5"
+            data-scrollbar="stable"
+          >
+            {detail}
+          </pre>
           <Button onClick={onRetry} size="sm" type="button">
             <RotateCcw aria-hidden data-icon="inline-start" />
             {copy.retry}
           </Button>
-        </CardFooter>
-      </Card>
+        </EmptyContent>
+      </Empty>
     </main>
   );
 }

--- a/src/renderer/i18n/locales/en/workspace.ts
+++ b/src/renderer/i18n/locales/en/workspace.ts
@@ -15,11 +15,14 @@ export const workspace = {
     unavailableTitle: "Plugin panel unavailable",
   },
   startupError: {
-    description:
-      "Pier could not finish core initialization. Retry, and keep the error details below if the problem continues.",
-    details: "Error details",
+    description: "Reload to try again.",
     retry: "Reload",
     title: "Pier failed to start",
+  },
+  runtimeError: {
+    description: "Terminal sessions are preserved. Reload to continue.",
+    retry: "Reload",
+    title: "Interface error",
   },
   tab: {
     unsaved: "Unsaved changes",

--- a/src/renderer/i18n/locales/zh-CN/workspace.ts
+++ b/src/renderer/i18n/locales/zh-CN/workspace.ts
@@ -11,11 +11,14 @@ export const workspace = {
     unavailableTitle: "插件面板不可用",
   },
   startupError: {
-    description:
-      "Pier 无法完成核心初始化。请重试；如果问题持续存在，请保留下面的错误详情。",
-    details: "错误详情",
+    description: "请重新加载后再试。",
     retry: "重新加载",
     title: "Pier 启动失败",
+  },
+  runtimeError: {
+    description: "终端会话已保留，请重新加载。",
+    retry: "重新加载",
+    title: "界面出现错误",
   },
   tab: {
     unsaved: "未保存的更改",

--- a/src/renderer/lib/command-palette/use-command-palette-scroll.ts
+++ b/src/renderer/lib/command-palette/use-command-palette-scroll.ts
@@ -1,0 +1,43 @@
+import { type RefObject, useLayoutEffect, useRef } from "react";
+
+interface CommandPaletteScrollOptions {
+  isOpen: boolean;
+  query: string;
+  requestId: number;
+  selectedValue: string;
+}
+
+export function useCommandPaletteScroll({
+  isOpen,
+  query,
+  requestId,
+  selectedValue,
+}: CommandPaletteScrollOptions): RefObject<HTMLDivElement | null> {
+  const listRef = useRef<HTMLDivElement>(null);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: Query and session changes must reset the reused list.
+  useLayoutEffect(() => {
+    const list = listRef.current;
+    if (!(isOpen && list)) {
+      return;
+    }
+    list.scrollTop = 0;
+  }, [isOpen, query, requestId]);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: Query and session changes must reveal the committed selection.
+  useLayoutEffect(() => {
+    if (!(isOpen && selectedValue && listRef.current)) {
+      return;
+    }
+    const animationFrame = window.requestAnimationFrame(() => {
+      listRef.current
+        ?.querySelector<HTMLElement>('[cmdk-item][aria-selected="true"]')
+        ?.scrollIntoView({ block: "nearest" });
+    });
+    return () => {
+      window.cancelAnimationFrame(animationFrame);
+    };
+  }, [isOpen, query, requestId, selectedValue]);
+
+  return listRef;
+}

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -12,6 +12,7 @@ import {
 import { installBundledFontFaces } from "./app/fonts.ts";
 import { AppContentDialogHost } from "./components/common/app-content-dialog-host.tsx";
 import { AppDialogHost } from "./components/common/app-dialog-host.tsx";
+import { AppRuntimeErrorBoundary } from "./components/common/app-runtime-error-boundary.tsx";
 import {
   StartupErrorScreen,
   StartupScreen,
@@ -165,7 +166,9 @@ async function bootstrap() {
   root.render(
     <>
       <RendererBootSignal key="application" />
-      <App />
+      <AppRuntimeErrorBoundary>
+        <App />
+      </AppRuntimeErrorBoundary>
     </>
   );
   requestAnimationFrame(() => {

--- a/src/shared/contracts/renderer-runtime-failure.ts
+++ b/src/shared/contracts/renderer-runtime-failure.ts
@@ -1,0 +1,69 @@
+export const RENDERER_RUNTIME_FAILURE_LIMITS = {
+  componentStack: 8000,
+  message: 2000,
+  name: 128,
+  stack: 12_000,
+} as const;
+
+export interface RendererRuntimeFailureReport {
+  componentStack?: string;
+  message: string;
+  name: string;
+  stack?: string;
+}
+
+function boundedString(
+  value: unknown,
+  maxLength: number,
+  required: boolean
+): string | undefined {
+  if (typeof value !== "string") {
+    return;
+  }
+  const normalized = value.trim();
+  if (required && normalized.length === 0) {
+    return;
+  }
+  return normalized.slice(0, maxLength);
+}
+
+/**
+ * Renderer 是可信宿主代码，但故障对象仍须在 IPC 边界限长，避免异常递归或超长
+ * 组件树把主进程诊断日志撑爆。未知字段不进入日志。
+ */
+export function parseRendererRuntimeFailureReport(
+  value: unknown
+): RendererRuntimeFailureReport | null {
+  if (!(value && typeof value === "object")) {
+    return null;
+  }
+  const name = boundedString(
+    Reflect.get(value, "name"),
+    RENDERER_RUNTIME_FAILURE_LIMITS.name,
+    true
+  );
+  const message = boundedString(
+    Reflect.get(value, "message"),
+    RENDERER_RUNTIME_FAILURE_LIMITS.message,
+    true
+  );
+  if (!(name && message)) {
+    return null;
+  }
+  const stack = boundedString(
+    Reflect.get(value, "stack"),
+    RENDERER_RUNTIME_FAILURE_LIMITS.stack,
+    false
+  );
+  const componentStack = boundedString(
+    Reflect.get(value, "componentStack"),
+    RENDERER_RUNTIME_FAILURE_LIMITS.componentStack,
+    false
+  );
+  return {
+    message,
+    name,
+    ...(stack ? { stack } : {}),
+    ...(componentStack ? { componentStack } : {}),
+  };
+}

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -31,6 +31,7 @@ export const PIER = {
   WINDOW_RENDERER_BOOT_CHALLENGE: "pier://window:renderer-boot-challenge",
   WINDOW_RENDERER_BOOT_REQUEST: "pier://window:renderer-boot-request",
   WINDOW_RENDERER_READY: "pier://window:renderer-ready",
+  WINDOW_RENDERER_RUNTIME_FAILURE: "pier://window:renderer-runtime-failure",
   // renderer → main plugin RPC invoke channel. Separate from PIER.COMMAND_EXECUTE
   // so plugin RPC is NEVER reachable from CLI local-control or capability-only
   // command authorization (design §7.0 / §7.3).

--- a/tests/component/app-runtime-error-boundary.test.tsx
+++ b/tests/component/app-runtime-error-boundary.test.tsx
@@ -1,0 +1,100 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const routingMocks = vi.hoisted(() => ({
+  dispose: vi.fn(),
+  popBlockingScope: vi.fn(),
+  pushBlockingScope: vi.fn(),
+  registerFullscreenOverlay: vi.fn(),
+  releaseFocus: vi.fn(),
+  requestWebFocus: vi.fn(),
+}));
+
+vi.mock("@/stores/keybinding-scope.store.ts", () => ({
+  useKeybindingScope: {
+    getState: () => ({
+      popBlockingScope: routingMocks.popBlockingScope,
+      pushBlockingScope: routingMocks.pushBlockingScope,
+    }),
+  },
+}));
+
+vi.mock("@/stores/terminal-input-routing-slice.ts", () => ({
+  registerTerminalFullscreenWebOverlay: routingMocks.registerFullscreenOverlay,
+  requestTerminalWebFocus: routingMocks.requestWebFocus,
+}));
+
+import { AppRuntimeErrorBoundary } from "@/components/common/app-runtime-error-boundary.tsx";
+
+function BrokenWorkspace(): never {
+  throw new Error("panel descriptor render failed");
+}
+
+describe("AppRuntimeErrorBoundary", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+    Reflect.deleteProperty(window, "pier");
+  });
+
+  it("replaces a failed app tree with an interactive full-window recovery screen", () => {
+    document.documentElement.lang = "en";
+    const retry = vi.fn();
+    const reportRuntimeFailure = vi.fn();
+    routingMocks.registerFullscreenOverlay.mockReturnValue({
+      dispose: routingMocks.dispose,
+      flush: vi.fn(),
+    });
+    routingMocks.requestWebFocus.mockReturnValue(routingMocks.releaseFocus);
+    Object.defineProperty(window, "pier", {
+      configurable: true,
+      value: { window: { reportRuntimeFailure } },
+    });
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.spyOn(console, "info").mockImplementation(() => undefined);
+
+    const view = render(
+      <AppRuntimeErrorBoundary onRetry={retry}>
+        <BrokenWorkspace />
+      </AppRuntimeErrorBoundary>
+    );
+
+    expect(
+      screen.getByRole("heading", {
+        name: "Interface error",
+      })
+    ).toBeVisible();
+    expect(
+      screen.getByText("Terminal sessions are preserved. Reload to continue.")
+    ).toBeVisible();
+    expect(view.container.querySelector('[data-slot="empty"]')).not.toBeNull();
+    expect(screen.getByText(/panel descriptor render failed/)).toBeVisible();
+    // useLayoutEffect: input ownership is claimed before paint/yield.
+    expect(routingMocks.registerFullscreenOverlay).toHaveBeenCalledWith(
+      "app-runtime-error"
+    );
+    expect(routingMocks.requestWebFocus).toHaveBeenCalledWith(
+      "app-runtime-error"
+    );
+    expect(routingMocks.pushBlockingScope).toHaveBeenCalledWith(
+      "overlay:app-runtime-error"
+    );
+    expect(reportRuntimeFailure).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "panel descriptor render failed",
+        name: "Error",
+        stack: expect.stringContaining("panel descriptor render failed"),
+      })
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Reload" }));
+    expect(retry).toHaveBeenCalledOnce();
+
+    view.unmount();
+    expect(routingMocks.popBlockingScope).toHaveBeenCalledWith(
+      "overlay:app-runtime-error"
+    );
+    expect(routingMocks.releaseFocus).toHaveBeenCalledOnce();
+    expect(routingMocks.dispose).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/component/command-palette-scroll.test.tsx
+++ b/tests/component/command-palette-scroll.test.tsx
@@ -1,0 +1,255 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CommandPalette } from "@/components/common/command-palette.tsx";
+import { initI18n } from "@/i18n/index.ts";
+import { useCommandPaletteController } from "@/lib/command-palette/controller.ts";
+import type { QuickPickItem } from "@/lib/command-palette/types.ts";
+import { resetAppDialogForTests } from "@/stores/app-dialog.store.ts";
+
+class TestResizeObserver {
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+}
+
+const originalScrollIntoView = Element.prototype.scrollIntoView;
+const originalRequestAnimationFrame = window.requestAnimationFrame;
+const originalCancelAnimationFrame = window.cancelAnimationFrame;
+const scrollIntoViewMock = vi.fn();
+let nextAnimationFrameId = 1;
+let animationFrames = new Map<number, FrameRequestCallback>();
+
+function flushAnimationFrames(): void {
+  const pending = [...animationFrames.values()];
+  animationFrames.clear();
+  for (const callback of pending) {
+    callback(performance.now());
+  }
+}
+
+function makeItems(prefix: string): QuickPickItem[] {
+  return Array.from({ length: 30 }, (_, index) => ({
+    id: `${prefix}-${index}`,
+    label: `${prefix} ${index}`,
+  }));
+}
+
+function getList(): HTMLDivElement {
+  const lists = document.querySelectorAll<HTMLDivElement>(
+    '[data-slot="command-list"]'
+  );
+  if (lists.length !== 1) {
+    throw new Error(`expected one command list, received ${lists.length}`);
+  }
+  return lists.item(0);
+}
+
+function getItem(label: string): HTMLElement {
+  const item = screen.getByText(label).closest<HTMLElement>("[cmdk-item]");
+  if (!item) {
+    throw new Error(`expected command item for ${label}`);
+  }
+  return item;
+}
+
+async function waitForSelected(label: string): Promise<HTMLElement> {
+  const item = getItem(label);
+  await waitFor(() => {
+    expect(item).toHaveAttribute("aria-selected", "true");
+  });
+  return item;
+}
+
+describe("CommandPalette list scrolling", () => {
+  beforeEach(async () => {
+    await initI18n();
+    vi.stubGlobal("ResizeObserver", TestResizeObserver);
+    animationFrames = new Map();
+    nextAnimationFrameId = 1;
+    window.requestAnimationFrame = vi.fn((callback: FrameRequestCallback) => {
+      const id = nextAnimationFrameId;
+      nextAnimationFrameId += 1;
+      animationFrames.set(id, callback);
+      return id;
+    });
+    window.cancelAnimationFrame = vi.fn((id: number) => {
+      animationFrames.delete(id);
+    });
+    Element.prototype.scrollIntoView = scrollIntoViewMock;
+    resetAppDialogForTests();
+    useCommandPaletteController.setState({
+      mode: "commands",
+      open: false,
+      quickPick: null,
+      requestId: 0,
+      stack: [],
+    });
+    Object.defineProperty(window, "pier", {
+      configurable: true,
+      value: {
+        terminal: {
+          applyHostSnapshot: vi.fn(),
+        },
+      },
+    });
+  });
+
+  afterEach(() => {
+    useCommandPaletteController.setState({
+      mode: "commands",
+      open: false,
+      quickPick: null,
+      requestId: 0,
+      stack: [],
+    });
+    vi.restoreAllMocks();
+    resetAppDialogForTests();
+    vi.unstubAllGlobals();
+    window.requestAnimationFrame = originalRequestAnimationFrame;
+    window.cancelAnimationFrame = originalCancelAnimationFrame;
+    if (originalScrollIntoView) {
+      Element.prototype.scrollIntoView = originalScrollIntoView;
+    } else {
+      Reflect.deleteProperty(Element.prototype, "scrollIntoView");
+    }
+  });
+
+  it("resets the hidden list to the first match after search changes", async () => {
+    const items = makeItems("Task");
+    items[0] = { id: "alpha", label: "Alpha Result" };
+    render(<CommandPalette />);
+
+    act(() => {
+      useCommandPaletteController.getState().openQuickPick({
+        items,
+        onAccept: vi.fn(),
+        placeholder: "Search tasks",
+        title: "Tasks",
+      });
+    });
+
+    await waitForSelected("Alpha Result");
+    act(flushAnimationFrames);
+    const list = getList();
+    list.scrollTop = 240;
+    scrollIntoViewMock.mockClear();
+
+    fireEvent.change(screen.getByPlaceholderText("Search tasks"), {
+      target: { value: "alpha" },
+    });
+    const selected = await waitForSelected("Alpha Result");
+    act(flushAnimationFrames);
+
+    expect(list.scrollTop).toBe(0);
+    expect(selected).toHaveAttribute("aria-selected", "true");
+    expect(scrollIntoViewMock).toHaveBeenCalledWith({ block: "nearest" });
+    expect(list).toHaveAttribute("data-scrollbar", "none");
+    expect(list).toHaveClass("no-scrollbar");
+  });
+
+  it("resets and reveals the selection when a new picker session opens", async () => {
+    render(<CommandPalette />);
+    act(() => {
+      useCommandPaletteController.getState().openQuickPick({
+        items: makeItems("First"),
+        onAccept: vi.fn(),
+        title: "First picker",
+      });
+    });
+
+    await waitForSelected("First 0");
+    act(flushAnimationFrames);
+    const list = getList();
+    list.scrollTop = 240;
+    scrollIntoViewMock.mockClear();
+    const secondItems = makeItems("Second").map((item, index) => ({
+      ...item,
+      checked: index === 12,
+    }));
+
+    act(() => {
+      useCommandPaletteController.getState().openQuickPick({
+        items: secondItems,
+        onAccept: vi.fn(),
+        title: "Second picker",
+      });
+    });
+
+    const selected = await waitForSelected("Second 12");
+    act(flushAnimationFrames);
+    expect(getList()).toBe(list);
+    expect(list.scrollTop).toBe(0);
+    expect(selected).toHaveAttribute("aria-selected", "true");
+    expect(scrollIntoViewMock).toHaveBeenCalledWith({ block: "nearest" });
+  });
+
+  it("preserves scroll when an async update keeps the selected item", async () => {
+    const items = makeItems("Async");
+    render(<CommandPalette />);
+    act(() => {
+      useCommandPaletteController.getState().openQuickPick({
+        items,
+        onAccept: vi.fn(),
+        title: "Async picker",
+      });
+    });
+
+    await waitForSelected("Async 0");
+    act(flushAnimationFrames);
+    fireEvent.pointerMove(getItem("Async 15"), { pointerType: "mouse" });
+    const selected = await waitForSelected("Async 15");
+    act(flushAnimationFrames);
+    const list = getList();
+    list.scrollTop = 240;
+    scrollIntoViewMock.mockClear();
+
+    act(() => {
+      useCommandPaletteController.getState().updateQuickPick({
+        items: items.map((item) =>
+          item.id === "Async-15"
+            ? { ...item, detail: "Updated asynchronously" }
+            : item
+        ),
+      });
+    });
+
+    await screen.findByText("Updated asynchronously");
+    expect(selected).toHaveAttribute("aria-selected", "true");
+    expect(list.scrollTop).toBe(240);
+    expect(scrollIntoViewMock).not.toHaveBeenCalled();
+  });
+
+  it("reveals the fallback selection when replaced content removes the selection", async () => {
+    render(<CommandPalette />);
+    act(() => {
+      useCommandPaletteController.getState().openQuickPick({
+        items: makeItems("Original"),
+        onAccept: vi.fn(),
+        title: "Original picker",
+      });
+    });
+
+    await waitForSelected("Original 0");
+    act(flushAnimationFrames);
+    fireEvent.pointerMove(getItem("Original 15"), { pointerType: "mouse" });
+    await waitForSelected("Original 15");
+    act(flushAnimationFrames);
+    const list = getList();
+    list.scrollTop = 240;
+    scrollIntoViewMock.mockClear();
+
+    act(() => {
+      useCommandPaletteController.getState().replaceQuickPick({
+        items: makeItems("Replacement"),
+        onAccept: vi.fn(),
+        title: "Replacement picker",
+      });
+    });
+
+    const selected = await waitForSelected("Replacement 0");
+    act(flushAnimationFrames);
+    expect(selected).toHaveAttribute("aria-selected", "true");
+    expect(scrollIntoViewMock).toHaveBeenCalledWith({ block: "nearest" });
+  });
+});

--- a/tests/component/startup-error-screen.test.tsx
+++ b/tests/component/startup-error-screen.test.tsx
@@ -26,7 +26,9 @@ describe("startup screens", () => {
     expect(
       screen.getByRole("heading", { name: "Pier failed to start" })
     ).toBeVisible();
+    expect(screen.getByText("Reload to try again.")).toBeVisible();
     expect(screen.getByText(/preload unavailable/)).toBeVisible();
+    expect(container.querySelector('[data-slot="empty"]')).not.toBeNull();
     expect(container.querySelector('[data-slot="alert"]')).toBeNull();
     expect(container.querySelector('[data-scrollbar="stable"]')).not.toBeNull();
 

--- a/tests/unit/main/agent-detection-service.test.ts
+++ b/tests/unit/main/agent-detection-service.test.ts
@@ -63,6 +63,21 @@ describe("agent detection", () => {
     expect(result.detectedIds).toContain("claude");
   });
 
+  it("ensurePath 幂等水合，不重复 hydratePath", async () => {
+    let hydrateCount = 0;
+    const service = createAgentDetectionService({
+      hydratePath: () => {
+        hydrateCount += 1;
+        return Promise.resolve(["/new/bin"]);
+      },
+      probe: () => Promise.resolve(false),
+    });
+
+    await service.ensurePath();
+    await service.ensurePath();
+    expect(hydrateCount).toBe(1);
+  });
+
   it("detect 复用探测快照，只有 refresh 才重新 probe", async () => {
     let probeCount = 0;
     const service = createAgentDetectionService({

--- a/tests/unit/main/external-plugin-process-env.test.ts
+++ b/tests/unit/main/external-plugin-process-env.test.ts
@@ -1,0 +1,20 @@
+import { createExternalPluginProcessEnv } from "@main/plugins/external-plugin-process-env.ts";
+import { afterEach, describe, expect, it } from "vitest";
+
+describe("createExternalPluginProcessEnv", () => {
+  const originalPath = process.env.PATH;
+
+  afterEach(() => {
+    process.env.PATH = originalPath;
+  });
+
+  it("reads PATH live so post-activate hydration is visible", () => {
+    process.env.PATH = "/gui/bin";
+    const env = createExternalPluginProcessEnv();
+    expect(env.PATH).toBe("/gui/bin");
+
+    process.env.PATH = "/live/shell/bin:/gui/bin";
+    expect(env.PATH).toBe("/live/shell/bin:/gui/bin");
+    expect({ ...env }.PATH).toBe("/live/shell/bin:/gui/bin");
+  });
+});

--- a/tests/unit/main/grok-plugin-provider.test.ts
+++ b/tests/unit/main/grok-plugin-provider.test.ts
@@ -244,4 +244,36 @@ describe("pier.grok provider", () => {
     await provider.login(managedHome, new AbortController().signal, "device");
     expect(spawnLogin).toHaveBeenCalledOnce();
   });
+
+  it("login prefers live process PATH over stale processEnv snapshot", async () => {
+    const credentials = memoryCredentials();
+    const managedHome = join(dir, "runtime-homes", "grok", "account-path");
+    await mkdir(managedHome, { recursive: true });
+    const originalPath = process.env.PATH;
+    process.env.PATH = "/live/shell/bin:/usr/bin";
+    try {
+      let seenPath: string | undefined;
+      const provider = createGrokProvider({
+        credentials,
+        processEnv: {
+          // GUI launch snapshot: missing user bin dirs like ~/.grok/bin
+          PATH: "/gui/bin:/usr/bin",
+          HOME: process.env.HOME,
+        },
+        realGrokHome: join(dir, "real-grok"),
+        spawnLogin: async (_cmd, _args, opts) => {
+          seenPath = opts.env.PATH;
+          await writeFile(join(managedHome, "auth.json"), AUTH, {
+            mode: 0o600,
+          });
+        },
+      });
+
+      await provider.login(managedHome, new AbortController().signal, "oauth");
+
+      expect(seenPath).toBe("/live/shell/bin:/usr/bin");
+    } finally {
+      process.env.PATH = originalPath;
+    }
+  });
 });

--- a/tests/unit/main/managed-plugin-runtime-reconciler.test.ts
+++ b/tests/unit/main/managed-plugin-runtime-reconciler.test.ts
@@ -19,8 +19,6 @@ function source(
     manifest: {
       apiVersion: 1,
       commands: [],
-      workbenchWidgets: [],
-      settingsPages: [],
       engines: { pier: ">=0.1.0" },
       id: "pier.codex",
       main: "dist/main.js",
@@ -28,8 +26,10 @@ function source(
       panels: [],
       permissions: [],
       renderer: "dist/renderer.js",
+      settingsPages: [],
       terminalStatusItems: [],
       version,
+      workbenchWidgets: [],
     },
     rendererEntryUrl: `pier-plugin://pier.codex/${version}/dist/renderer.js`,
     version,
@@ -80,5 +80,28 @@ describe("managed plugin runtime reconciler", () => {
     expect(runtimeSourceActivationKey(stable)).not.toBe(
       runtimeSourceActivationKey(revised)
     );
+  });
+
+  it("awaits ensurePath before first activate and reload", async () => {
+    const order: string[] = [];
+    const externalRuntime = runtime();
+    externalRuntime.activate = vi.fn(async () => {
+      order.push("activate");
+    });
+    externalRuntime.reload = vi.fn(async () => {
+      order.push("reload");
+    });
+    const ensurePath = vi.fn(async () => {
+      order.push("ensurePath");
+    });
+    const reconciler = createManagedPluginRuntimeReconciler(externalRuntime, {
+      ensurePath,
+    });
+
+    await reconciler.reconcile([source("1.0.0")]);
+    await reconciler.reconcile([source("1.0.1")]);
+
+    expect(ensurePath).toHaveBeenCalledTimes(2);
+    expect(order).toEqual(["ensurePath", "activate", "ensurePath", "reload"]);
   });
 });

--- a/tests/unit/main/terminal-open-url-forwarding.test.ts
+++ b/tests/unit/main/terminal-open-url-forwarding.test.ts
@@ -11,12 +11,19 @@ describe("classifyTerminalOpenUrlForMain", () => {
     expect(classifyTerminalOpenUrlForMain("mailto:a@b.c")).toBe("remote");
   });
 
-  it("treats file and bare paths as local-candidate", () => {
-    expect(classifyTerminalOpenUrlForMain("file:///tmp/a")).toBe(
-      "local-candidate"
+  it("treats file and bare paths as filesystem candidates", () => {
+    expect(classifyTerminalOpenUrlForMain("file:///tmp/a")).toBe("filesystem");
+    expect(classifyTerminalOpenUrlForMain("/tmp/a")).toBe("filesystem");
+    expect(classifyTerminalOpenUrlForMain("docs/a.md")).toBe("filesystem");
+  });
+
+  it("keeps unknown schemes inside the app", () => {
+    expect(classifyTerminalOpenUrlForMain("local://notes.md")).toBe(
+      "app-internal"
     );
-    expect(classifyTerminalOpenUrlForMain("/tmp/a")).toBe("local-candidate");
-    expect(classifyTerminalOpenUrlForMain("docs/a.md")).toBe("local-candidate");
+    expect(classifyTerminalOpenUrlForMain("zed://file/repo/a.ts")).toBe(
+      "app-internal"
+    );
   });
 });
 
@@ -36,7 +43,7 @@ describe("handleTerminalOpenUrl", () => {
     expect(broadcast).not.toHaveBeenCalled();
   });
 
-  it("broadcasts local candidates", async () => {
+  it("broadcasts filesystem candidates", async () => {
     const openExternal = vi.fn(async () => undefined);
     const broadcast = vi.fn();
     await handleTerminalOpenUrl({
@@ -52,6 +59,25 @@ describe("handleTerminalOpenUrl", () => {
       kind: "text",
       panelId: "t1",
       url: "/repo/a.md",
+    });
+  });
+
+  it("never opens unknown schemes externally", async () => {
+    const openExternal = vi.fn(async () => undefined);
+    const broadcast = vi.fn();
+    await handleTerminalOpenUrl({
+      broadcast,
+      kind: "text",
+      openExternal,
+      panelId: "t1",
+      url: "local://drag-tab-cross-window-plan.md",
+      windowId: 7,
+    });
+    expect(openExternal).not.toHaveBeenCalled();
+    expect(broadcast).toHaveBeenCalledWith({
+      kind: "text",
+      panelId: "t1",
+      url: "local://drag-tab-cross-window-plan.md",
     });
   });
 });

--- a/tests/unit/main/window-runtime-failure-ipc.test.ts
+++ b/tests/unit/main/window-runtime-failure-ipc.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  error: vi.fn(),
+  fromWebContents: vi.fn(),
+  handle: vi.fn(),
+  on: vi.fn(),
+  warn: vi.fn(),
+}));
+
+vi.mock("@shared/logger.ts", () => ({
+  createLogger: () => ({ error: mocks.error, warn: mocks.warn }),
+}));
+vi.mock("@main/windows/window-manager.ts", () => ({
+  windowManager: {
+    close: vi.fn(),
+    findInternalIdByWindow: vi.fn(),
+    fromWebContents: mocks.fromWebContents,
+  },
+}));
+vi.mock("@main/windows/window-identity.ts", () => ({
+  findWindowContext: () => ({
+    recordId: "record-main",
+    windowId: "main",
+  }),
+}));
+
+import { registerWindowIpc } from "@main/ipc/window.ts";
+
+describe("window renderer runtime failure IPC", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.fromWebContents.mockReturnValue({ id: 42 });
+  });
+
+  it("persists a bounded report only for a known Pier window", () => {
+    registerWindowIpc({ handle: mocks.handle, on: mocks.on } as never);
+    const listener = mocks.on.mock.calls.find(
+      ([channel]) => channel === "pier://window:renderer-runtime-failure"
+    )?.[1] as ((event: unknown, payload: unknown) => void) | undefined;
+    expect(listener).toBeTypeOf("function");
+
+    listener?.(
+      { sender: { id: 7 } },
+      {
+        message: "render failed",
+        name: "TypeError",
+        stack: "TypeError: render failed",
+      }
+    );
+    expect(mocks.error).toHaveBeenCalledWith("React root failed", {
+      message: "render failed",
+      name: "TypeError",
+      recordId: "record-main",
+      stack: "TypeError: render failed",
+      windowId: "main",
+    });
+    expect(mocks.warn).not.toHaveBeenCalled();
+
+    mocks.fromWebContents.mockReturnValueOnce(null);
+    listener?.({ sender: { id: 8 } }, { message: "foreign", name: "Error" });
+    expect(mocks.warn).toHaveBeenCalledWith(
+      "Dropped renderer runtime failure: unknown window",
+      { senderId: 8 }
+    );
+
+    listener?.({ sender: { id: 7 } }, { message: "", name: "Error" });
+    expect(mocks.warn).toHaveBeenCalledWith(
+      "Dropped renderer runtime failure: invalid payload",
+      { senderId: 7 }
+    );
+    expect(mocks.error).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/unit/renderer/files-document-store.test.ts
+++ b/tests/unit/renderer/files-document-store.test.ts
@@ -354,6 +354,18 @@ describe("files-document-store", () => {
     ).toBe(false);
     expect(
       sameFilesDocumentPanelSource(
+        { kind: "disk", path: "src/README.md", root: "/repo" },
+        { kind: "disk", path: "README.md", root: "/repo/src" }
+      )
+    ).toBe(true);
+    expect(
+      sameFilesDocumentPanelSource(
+        { kind: "disk", path: "README.md", root: "/repo/" },
+        { kind: "disk", path: "README.md", root: "/repo" }
+      )
+    ).toBe(true);
+    expect(
+      sameFilesDocumentPanelSource(
         { id: "pier.files.untitled:1", kind: "untitled", name: "Draft.md" },
         { id: "pier.files.untitled:1", kind: "untitled", name: "Renamed.md" }
       )

--- a/tests/unit/renderer/files-terminal-open-url-handler.test.ts
+++ b/tests/unit/renderer/files-terminal-open-url-handler.test.ts
@@ -89,7 +89,7 @@ describe("handleFilesTerminalOpenUrl", () => {
     expect(openPath).not.toHaveBeenCalled();
   });
 
-  it("openPaths outside anchors", async () => {
+  it("opens readable text files outside anchors via Files", async () => {
     await expect(
       handleFilesTerminalOpenUrl(context, {
         kind: "text",
@@ -97,7 +97,37 @@ describe("handleFilesTerminalOpenUrl", () => {
         url: "/tmp/outside.md",
       })
     ).resolves.toBe(true);
-    expect(openPath).toHaveBeenCalledWith({ path: "/tmp/outside.md" });
+    expect(stat).toHaveBeenCalledWith({
+      path: "outside.md",
+      root: "/tmp",
+    });
+    expect(openInstance).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({
+          source: {
+            kind: "disk",
+            path: "outside.md",
+            root: "/tmp",
+          },
+        }),
+        title: "outside.md",
+      })
+    );
+    expect(openPath).not.toHaveBeenCalled();
+  });
+
+  it("reports unsupported schemes without system open", async () => {
+    await expect(
+      handleFilesTerminalOpenUrl(context, {
+        kind: "text",
+        panelId: "t1",
+        url: "local://drag-tab-cross-window-plan.md",
+      })
+    ).resolves.toBe(true);
+    expect(notificationsError).toHaveBeenCalledWith(
+      "Cannot open this link in Pier."
+    );
+    expect(openPath).not.toHaveBeenCalled();
     expect(openInstance).not.toHaveBeenCalled();
   });
 
@@ -170,6 +200,40 @@ describe("handleFilesTerminalOpenUrl", () => {
     expect(openPath).not.toHaveBeenCalled();
   });
 
+  it("reuses an open tab when absolute path matches under a different root split", async () => {
+    const existingId = "pier.files.filePanel:disk:abs-split:tab-1";
+    listInstances.mockReturnValue([
+      {
+        groupId: "g1",
+        id: existingId,
+        params: {
+          pinned: false,
+          source: {
+            kind: "disk",
+            path: "src/README.md",
+            root: "/repo",
+          },
+        },
+      },
+    ]);
+
+    await expect(
+      handleFilesTerminalOpenUrl(context, {
+        kind: "text",
+        panelId: "t1",
+        url: "/repo/src/README.md",
+      })
+    ).resolves.toBe(true);
+
+    expect(openInstance).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dropUnpinnedInstances: false,
+        instanceId: existingId,
+      })
+    );
+    expect(openPath).not.toHaveBeenCalled();
+  });
+
   it("falls back for binary documents", async () => {
     readDocument.mockResolvedValue({ kind: "binary", mime: null });
     await expect(
@@ -183,24 +247,25 @@ describe("handleFilesTerminalOpenUrl", () => {
     expect(openInstance).not.toHaveBeenCalled();
   });
 
-  it("logs why system open fallback is used", async () => {
+  it("logs why system open fallback is used for unsupported files", async () => {
     const info = vi.spyOn(console, "info").mockImplementation(() => undefined);
+    readDocument.mockResolvedValue({ kind: "binary", mime: null });
     try {
       await expect(
         handleFilesTerminalOpenUrl(context, {
           kind: "text",
           panelId: "t1",
-          url: "/tmp/outside.md",
+          url: "/tmp/outside.bin",
         })
       ).resolves.toBe(true);
       expect(info).toHaveBeenCalledWith(
         "[files-terminal-open-url] system open fallback",
         expect.objectContaining({
-          path: "/tmp/outside.md",
-          reason: "outside-anchor",
+          path: "/tmp/outside.bin",
+          reason: "binary-or-unsupported",
         })
       );
-      expect(openPath).toHaveBeenCalledWith({ path: "/tmp/outside.md" });
+      expect(openPath).toHaveBeenCalledWith({ path: "/tmp/outside.bin" });
     } finally {
       info.mockRestore();
     }

--- a/tests/unit/renderer/files-terminal-open-url-resolve.test.ts
+++ b/tests/unit/renderer/files-terminal-open-url-resolve.test.ts
@@ -15,6 +15,16 @@ describe("parseTerminalOpenUrl", () => {
       url: "mailto:a@b.com",
     });
   });
+  it("keeps unsupported schemes inside the app", () => {
+    expect(parseTerminalOpenUrl("local://notes.md", "/repo")).toEqual({
+      kind: "unresolved",
+      reason: "unsupported-scheme",
+    });
+    expect(parseTerminalOpenUrl("zed://file/repo/a.ts", "/repo")).toEqual({
+      kind: "unresolved",
+      reason: "unsupported-scheme",
+    });
+  });
 
   it("decodes file:// URLs", () => {
     expect(

--- a/tests/unit/renderer/startup-order-invariants.test.ts
+++ b/tests/unit/renderer/startup-order-invariants.test.ts
@@ -40,6 +40,12 @@ describe("renderer startup ordering", () => {
     );
   });
 
+  it("keeps the application tree inside the runtime recovery boundary", () => {
+    expect(source).toMatch(
+      /<AppRuntimeErrorBoundary>\s*<App \/>\s*<\/AppRuntimeErrorBoundary>/
+    );
+  });
+
   it("renders a visible fatal state when bootstrap rejects", () => {
     expect(source).toContain("<StartupErrorScreen error={err} />");
     expect(source).toContain("window.pier?.window?.readyToShow?.()");

--- a/tests/unit/renderer/workspace-host-invariants.test.ts
+++ b/tests/unit/renderer/workspace-host-invariants.test.ts
@@ -70,7 +70,7 @@ const WORKSPACE_READY_WHEN_USER_TOUCHED_RE =
 const BOOT_SIGNAL_AFTER_COMPONENT_MOUNT_RE =
   /function RendererBootSignal\(\)[\s\S]{0,180}?useEffect\(\(\) => \{\s*window\.pier\?\.window\?\.readyToShow\?\.\(\)/;
 const FINAL_APP_RETAINS_BOOT_SIGNAL_RE =
-  /root\.render\(\s*<>\s*<RendererBootSignal key="application" \/>\s*<App \/>/;
+  /root\.render\(\s*<>\s*<RendererBootSignal key="application" \/>\s*<AppRuntimeErrorBoundary>\s*<App \/>\s*<\/AppRuntimeErrorBoundary>/;
 
 describe("workspace-host invariants (#17 #19)", () => {
   it("declares userTouched flag and uses it to gate fromJSON (防 user 操作被 saved layout 覆盖)", () => {

--- a/tests/unit/shared/renderer-runtime-failure.test.ts
+++ b/tests/unit/shared/renderer-runtime-failure.test.ts
@@ -1,0 +1,48 @@
+import {
+  parseRendererRuntimeFailureReport,
+  RENDERER_RUNTIME_FAILURE_LIMITS,
+} from "@shared/contracts/renderer-runtime-failure.ts";
+import { describe, expect, it } from "vitest";
+
+describe("renderer runtime failure report", () => {
+  it("accepts known fields, trims them, and drops unknown data", () => {
+    expect(
+      parseRendererRuntimeFailureReport({
+        componentStack: "  at WorkspaceHost  ",
+        message: "  render failed  ",
+        name: "  TypeError  ",
+        secret: "not forwarded",
+        stack: "  TypeError: render failed  ",
+      })
+    ).toEqual({
+      componentStack: "at WorkspaceHost",
+      message: "render failed",
+      name: "TypeError",
+      stack: "TypeError: render failed",
+    });
+  });
+
+  it("rejects malformed required fields and bounds diagnostic text", () => {
+    expect(parseRendererRuntimeFailureReport(null)).toBeNull();
+    expect(
+      parseRendererRuntimeFailureReport({ message: "", name: "Error" })
+    ).toBeNull();
+
+    const parsed = parseRendererRuntimeFailureReport({
+      componentStack: "c".repeat(
+        RENDERER_RUNTIME_FAILURE_LIMITS.componentStack + 20
+      ),
+      message: "m".repeat(RENDERER_RUNTIME_FAILURE_LIMITS.message + 20),
+      name: "n".repeat(RENDERER_RUNTIME_FAILURE_LIMITS.name + 20),
+      stack: "s".repeat(RENDERER_RUNTIME_FAILURE_LIMITS.stack + 20),
+    });
+    expect(parsed?.componentStack).toHaveLength(
+      RENDERER_RUNTIME_FAILURE_LIMITS.componentStack
+    );
+    expect(parsed?.message).toHaveLength(
+      RENDERER_RUNTIME_FAILURE_LIMITS.message
+    );
+    expect(parsed?.name).toHaveLength(RENDERER_RUNTIME_FAILURE_LIMITS.name);
+    expect(parsed?.stack).toHaveLength(RENDERER_RUNTIME_FAILURE_LIMITS.stack);
+  });
+});


### PR DESCRIPTION
## Summary
- Keep terminal URL opens inside Pier: unknown schemes never `openExternal`, readable out-of-project text files open in Files instead of the system Markdown app (Zed).
- Reuse already-open file tabs by normalized absolute path identity across different root/path splits.
- Bump host to `0.1.3` and `pier.grok` to `1.0.3` for release (includes prior Grok login-shell PATH hydration and renderer recovery fixes on this branch).

## Test plan
- [x] `pnpm exec vitest run` targeted terminal open-url + files document identity suites
- [x] Biome check on touched files
- [ ] CI Quality Gate green
- [ ] After merge: host tag `v0.1.3` Release App; plugin release for grok `1.0.3` via package.json path trigger
- [ ] Manual: click project-external `.md` from terminal opens in Pier Files; bare `'/Users/xyz/.omp/agent/sessions/-ABC-pier/2026-07-19T00-56-17-888Z_019f77df-b6e0-7000-b410-7ea772387632/local'` stays in-app without Zed; re-click same file reuses tab