### PR TITLE
fix(plugins): keep immutable digests when regenerating index

### DIFF
--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -229,6 +229,8 @@ jobs:
       - name: Regenerate plugin index
         if: steps.parse.outputs.should_release == 'true'
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
           PIER_PLUGIN_INDEX_REQUIRE_SIGNATURE: "1"
           PIER_PLUGIN_INDEX_SIGNING_KEY_ID: ${{ secrets.PIER_PLUGIN_INDEX_SIGNING_KEY_ID }}
           PIER_PLUGIN_INDEX_SIGNING_PRIVATE_KEY_BASE64: ${{ secrets.PIER_PLUGIN_INDEX_SIGNING_PRIVATE_KEY_BASE64 }}
@@ -238,6 +240,30 @@ jobs:
           # plugin before signing so a single-plugin release cannot shrink the
           # catalog down to only the plugin that was just published.
           pnpm plugins:pack
+          # Prefer immutable GitHub release bits whenever the tag already exists
+          # (including targets published earlier in this job). A fresh pack can
+          # drift across runners; the release asset is the source of truth.
+          for plugin_json in packages/plugin-*/plugin.json; do
+            [ -f "$plugin_json" ] || continue
+            TAIL=$(basename "$(dirname "$plugin_json")")
+            TAIL=${TAIL#plugin-}
+            VERSION=$(node -p "require('./${plugin_json}').version")
+            ID=$(node -p "require('./${plugin_json}').id")
+            TAG="plugin-${TAIL}-v${VERSION}"
+            DIST="packages/plugin-${TAIL}/dist-pkg"
+            if ! gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+              echo "no release yet for $TAG; keeping local pack"
+              continue
+            fi
+            echo "restoring published asset for $TAG into $DIST"
+            mkdir -p "$DIST"
+            gh release download "$TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --pattern "${ID}-${VERSION}.tgz" \
+              --pattern "${ID}-${VERSION}.tgz.sha256" \
+              --dir "$DIST" \
+              --clobber
+          done
           pnpm plugins:index
 
       - name: Commit index update

--- a/scripts/generate-plugin-index.mjs
+++ b/scripts/generate-plugin-index.mjs
@@ -224,38 +224,31 @@ function nextSequence(existingIndex) {
   return sequence;
 }
 
-function assertNoSameVersionDrift(existingIndex, nextPlugins) {
-  const previousPlugins = existingIndex?.plugins;
-  if (
-    !previousPlugins ||
-    typeof previousPlugins !== "object" ||
-    Array.isArray(previousPlugins)
-  ) {
-    return;
-  }
-
-  for (const [id, plugin] of Object.entries(nextPlugins)) {
-    for (const [version, entry] of Object.entries(plugin.versions)) {
-      const previousEntry = previousPlugins[id]?.versions?.[version];
-      if (!previousEntry) {
-        continue;
-      }
-      const cacheKey = `${id}@${version}`;
-      if (previousEntry.sha256 && previousEntry.sha256 !== entry.sha256) {
-        throw new Error(
-          `same-version hash drift for ${cacheKey}: existing ${previousEntry.sha256} vs generated ${entry.sha256}; bump the plugin version instead of rewriting an immutable release`
-        );
-      }
-      if (
+/**
+ * Prefer already-indexed digests for a version that was published before.
+ * Local `plugins:pack` rebuilds are not bit-stable across machines / deps, so
+ * reusing the committed index entry keeps clients pointed at the immutable
+ * GitHub release asset. New versions still come from the local pack.
+ */
+function mergePluginVersions(previousVersions, packedVersions, pluginId) {
+  const merged = { ...(previousVersions ?? {}) };
+  for (const [version, entry] of Object.entries(packedVersions ?? {})) {
+    const previousEntry = previousVersions?.[version];
+    if (previousEntry?.sha256) {
+      const sizeDrift =
         Number.isInteger(previousEntry.size) &&
-        previousEntry.size !== entry.size
-      ) {
-        throw new Error(
-          `same-version size drift for ${cacheKey}: existing ${previousEntry.size} vs generated ${entry.size}; bump the plugin version instead of rewriting an immutable release`
+        previousEntry.size !== entry.size;
+      if (previousEntry.sha256 !== entry.sha256 || sizeDrift) {
+        console.warn(
+          `reusing published digest for ${pluginId}@${version} (local rebuild drifted; bump the plugin version to publish a new asset)`
         );
       }
+      merged[version] = previousEntry;
+      continue;
     }
+    merged[version] = entry;
   }
+  return merged;
 }
 
 const dirents = await readdir(packagesDir, { withFileTypes: true });
@@ -267,10 +260,10 @@ for (const d of dirents) {
 }
 
 const existingIndex = await readExistingIndex();
-assertNoSameVersionDrift(existingIndex, packedPlugins);
 
 // Merge: keep previously indexed plugins that were not re-packed in this run
-// (partial packs / single-plugin recovery must not erase the catalog).
+// (partial packs / single-plugin recovery must not erase the catalog). Same
+// version digests stay immutable even when a local rebuild drifts.
 const plugins = { ...packedPlugins };
 const previousPlugins = existingIndex?.plugins;
 if (
@@ -287,10 +280,7 @@ if (
     plugins[id] = {
       ...previous,
       ...packed,
-      versions: {
-        ...(previous.versions ?? {}),
-        ...packed.versions,
-      },
+      versions: mergePluginVersions(previous.versions, packed.versions, id),
       latest: packed.latest,
     };
   }

--- a/tests/unit/main/managed-plugin-packaging-governance.test.ts
+++ b/tests/unit/main/managed-plugin-packaging-governance.test.ts
@@ -124,6 +124,7 @@ describe("managed plugin packaging governance", () => {
     expect(releaseWorkflow).toContain(
       "Verify existing release asset is immutable"
     );
+    expect(releaseWorkflow).toContain("restoring published asset");
     expect(releaseWorkflow).toContain("pnpm plugins:index");
     expect(releaseWorkflow).toContain("chore(plugins): update index for");
     expect(releaseWorkflow).toContain("--latest=false");

--- a/tests/unit/main/plugin-index-generation.test.ts
+++ b/tests/unit/main/plugin-index-generation.test.ts
@@ -97,20 +97,6 @@ async function writeExistingIndex(options: {
   );
 }
 
-function commandOutput(err: unknown): string {
-  if (typeof err !== "object" || err === null) {
-    return String(err);
-  }
-  const output: string[] = [];
-  if ("stdout" in err) {
-    output.push(String((err as { stdout?: unknown }).stdout ?? ""));
-  }
-  if ("stderr" in err) {
-    output.push(String((err as { stderr?: unknown }).stderr ?? ""));
-  }
-  return output.join("\n");
-}
-
 describe("generate-plugin-index", () => {
   it("signs the generated official index with Ed25519 when signing env is present", async () => {
     const fixture = JSON.parse(
@@ -197,7 +183,7 @@ describe("generate-plugin-index", () => {
     expect(index.sequence).toBe(8);
   });
 
-  it("rejects same-version package hash drift from the existing index", async () => {
+  it("reuses the published digest when a local same-version rebuild drifts", async () => {
     await writeCodexPackage({
       sha256: "a".repeat(64),
       version: "1.2.3",
@@ -208,22 +194,24 @@ describe("generate-plugin-index", () => {
       version: "1.2.3",
     });
 
-    let thrown: unknown;
-    try {
-      await execFileAsync(process.execPath, [SCRIPT_PATH], {
-        cwd: dir,
-        env: {
-          ...process.env,
-          PIER_INDEX_GENERATED_AT: "10",
-        },
-      });
-    } catch (err) {
-      thrown = err;
-    }
+    const { stderr } = await execFileAsync(process.execPath, [SCRIPT_PATH], {
+      cwd: dir,
+      env: {
+        ...process.env,
+        PIER_INDEX_GENERATED_AT: "10",
+      },
+    });
 
-    expect(thrown).toBeInstanceOf(Error);
-    expect(commandOutput(thrown)).toContain(
-      "same-version hash drift for pier.codex@1.2.3"
+    expect(stderr).toContain("reusing published digest for pier.codex@1.2.3");
+    const index = JSON.parse(
+      await readFile(join(dir, "plugins", "index.v1.json"), "utf8")
+    ) as {
+      plugins: {
+        "pier.codex": { versions: { "1.2.3": { sha256: string } } };
+      };
+    };
+    expect(index.plugins["pier.codex"].versions["1.2.3"].sha256).toBe(
+      "b".repeat(64)
     );
   });
 


### PR DESCRIPTION
## Summary
- Release index regen was rebuilding every plugin after publish; local packs can drift vs immutable GitHub assets (blocked codex/grok index update).
- Restore published release tarballs into `dist-pkg` before signing the index, and reuse committed same-version digests in `generate-plugin-index`.

## Test plan
- [ ] Unit: `plugin-index-generation` + packaging governance
- [ ] After merge: re-run Release Plugin so `plugins/index.v1.json` picks up `pier.codex@1.4.3` and `pier.grok@1.1.3`


Made with [Cursor](https://cursor.com)