### PR TITLE
fix(plugins): skip locale diagnostics when static fallbacks exist

### DIFF
--- a/src/main/services/plugin-localization.ts
+++ b/src/main/services/plugin-localization.ts
@@ -169,10 +169,14 @@ export async function loadManifestLocaleFiles({
   }
 
   if (!baseDir) {
+    // Packaged builtins ship static locales only; missing baseDir is not a
+    // failure when every declared file locale already has a static fallback.
     return {
-      diagnostics: entries.map(([_, filePath]) =>
-        invalidLocaleDiagnostic({ kind: source.kind, path: filePath })
-      ),
+      diagnostics: entries
+        .filter(([locale]) => !staticLocales[locale])
+        .map(([_, filePath]) =>
+          invalidLocaleDiagnostic({ kind: source.kind, path: filePath })
+        ),
       manifest: manifestWithStaticLocales,
     };
   }
@@ -188,6 +192,11 @@ export async function loadManifestLocaleFiles({
       );
       nextManifest = mergeManifestLocale(nextManifest, locale, messages);
     } catch {
+      // Disk overlay is best-effort when static locales already cover this
+      // locale (production asar has no loose locales/*.json next to main).
+      if (staticLocales[locale]) {
+        continue;
+      }
       diagnostics.push(
         invalidLocaleDiagnostic({
           kind: source.kind,

--- a/tests/unit/main/plugin-service.test.ts
+++ b/tests/unit/main/plugin-service.test.ts
@@ -446,6 +446,100 @@ describe("createPluginService", () => {
     });
   });
 
+  it("builtin 已有 static locale 时磁盘 locale 缺失不报 invalid plugin locale", async () => {
+    const dir = await makeTempDir();
+    const service = createPluginService({
+      sources: [
+        {
+          baseDir: dir,
+          kind: "builtin",
+          locales: {
+            en: { name: "Sample Builtin" },
+            "zh-CN": { name: "示例内置" },
+          },
+          manifest: {
+            ...builtinManifest,
+            localization: {
+              defaultLocale: "en",
+              files: {
+                en: "locales/en.json",
+                "zh-CN": "locales/zh-CN.json",
+              },
+              locales: ["en", "zh-CN"],
+            },
+          },
+        },
+      ],
+      state: emptyState,
+    });
+
+    await expect(service.list()).resolves.toMatchObject({
+      diagnostics: [],
+      entries: [
+        {
+          manifest: {
+            id: "sample.builtin",
+            locales: {
+              en: { name: "Sample Builtin" },
+              "zh-CN": { name: "示例内置" },
+            },
+          },
+        },
+      ],
+    });
+  });
+
+  it("builtin static locale 存在时仍可 overlay 磁盘 locale 文案", async () => {
+    const dir = await makeTempDir();
+    await mkdir(join(dir, "locales"), { recursive: true });
+    await writeFile(
+      join(dir, "locales", "zh-CN.json"),
+      JSON.stringify({
+        name: "磁盘覆盖名",
+        messages: { "ui.title": "来自磁盘" },
+      })
+    );
+    const service = createPluginService({
+      sources: [
+        {
+          baseDir: dir,
+          kind: "builtin",
+          locales: {
+            "zh-CN": {
+              name: "静态名",
+              messages: { "ui.title": "来自静态" },
+            },
+          },
+          manifest: {
+            ...builtinManifest,
+            localization: {
+              defaultLocale: "en",
+              files: { "zh-CN": "locales/zh-CN.json" },
+              locales: ["zh-CN"],
+            },
+          },
+        },
+      ],
+      state: emptyState,
+    });
+
+    await expect(service.list()).resolves.toMatchObject({
+      diagnostics: [],
+      entries: [
+        {
+          manifest: {
+            locales: {
+              "zh-CN": {
+                messages: { "ui.title": "来自磁盘" },
+                name: "磁盘覆盖名",
+              },
+            },
+          },
+        },
+      ],
+    });
+  });
+
   it("enabled/disabled 状态由 userData state 决定", async () => {
     let enabled = false;
     const service = createPluginService({


### PR DESCRIPTION
## Summary
- Packaged builtins only ship static locales; missing on-disk locale JSON no longer emits `invalid plugin locale` when a static entry already covers that locale.
- Disk locale overlays remain best-effort and still win when present.
- Adds unit coverage for the static-fallback and disk-overlay paths.

## Test plan
- [ ] `pnpm test:unit -- tests/unit/main/plugin-service.test.ts`
- [ ] Confirm packaged/builtin plugins with static locales load without locale diagnostics
- [ ] Confirm disk `locales/*.json` still overlays static locale strings when present


Made with [Cursor](https://cursor.com)