### PR TITLE
chore(pricing): daily LiteLLM refresh

### DIFF
--- a/src/main/services/usage-data/pricing-catalog.json
+++ b/src/main/services/usage-data/pricing-catalog.json
@@ -29,6 +29,12 @@
       "inputMicrousd": 3,
       "outputMicrousd": 15
     },
+    "claude-3-haiku": {
+      "cachedInputMicrousd": 0.03,
+      "inputMicrousd": 0.25,
+      "outputMicrousd": 1.25,
+      "aliases": ["anthropic/claude-3-haiku"]
+    },
     "claude-3-haiku-20240307": {
       "cachedInputMicrousd": 0.03,
       "inputMicrousd": 0.25,
@@ -77,6 +83,18 @@
       "cachedInputMicrousd": 0.1,
       "inputMicrousd": 1,
       "outputMicrousd": 5
+    },
+    "claude-haiku-4.5": {
+      "cachedInputMicrousd": 0.1,
+      "inputMicrousd": 1,
+      "outputMicrousd": 5,
+      "aliases": ["anthropic/claude-haiku-4.5"]
+    },
+    "claude-opus-4": {
+      "cachedInputMicrousd": 1.5,
+      "inputMicrousd": 15,
+      "outputMicrousd": 75,
+      "aliases": ["anthropic/claude-opus-4"]
     },
     "claude-opus-4-1": {
       "cachedInputMicrousd": 1.5,
@@ -128,6 +146,54 @@
       "cachedInputMicrousd": 0.5,
       "inputMicrousd": 5,
       "outputMicrousd": 25
+    },
+    "claude-opus-4.1": {
+      "cachedInputMicrousd": 1.5,
+      "inputMicrousd": 15,
+      "outputMicrousd": 75,
+      "aliases": ["anthropic/claude-opus-4.1"]
+    },
+    "claude-opus-4.5": {
+      "cachedInputMicrousd": 0.5,
+      "inputMicrousd": 5,
+      "outputMicrousd": 25,
+      "aliases": ["anthropic/claude-opus-4.5"]
+    },
+    "claude-opus-4.6": {
+      "cachedInputMicrousd": 0.5,
+      "inputMicrousd": 5,
+      "outputMicrousd": 25,
+      "aliases": ["anthropic/claude-opus-4.6"]
+    },
+    "claude-opus-4.7": {
+      "cachedInputMicrousd": 0.5,
+      "inputMicrousd": 5,
+      "outputMicrousd": 25,
+      "aliases": ["anthropic/claude-opus-4.7"]
+    },
+    "claude-opus-4.7-fast": {
+      "cachedInputMicrousd": 3,
+      "inputMicrousd": 30,
+      "outputMicrousd": 150,
+      "aliases": ["anthropic/claude-opus-4.7-fast"]
+    },
+    "claude-opus-4.8": {
+      "cachedInputMicrousd": 0.5,
+      "inputMicrousd": 5,
+      "outputMicrousd": 25,
+      "aliases": ["anthropic/claude-opus-4.8"]
+    },
+    "claude-opus-4.8-fast": {
+      "cachedInputMicrousd": 1,
+      "inputMicrousd": 10,
+      "outputMicrousd": 50,
+      "aliases": ["anthropic/claude-opus-4.8-fast"]
+    },
+    "claude-sonnet-4": {
+      "cachedInputMicrousd": 0.3,
+      "inputMicrousd": 3,
+      "outputMicrousd": 15,
+      "aliases": ["anthropic/claude-sonnet-4"]
     },
     "claude-sonnet-4-20250514": {
       "cachedInputMicrousd": 0.3,
@@ -192,17 +258,47 @@
       },
       "aliases": ["claude-sonnet-4-7-*"]
     },
+    "claude-sonnet-4.5": {
+      "cachedInputMicrousd": 0.3,
+      "inputMicrousd": 3,
+      "outputMicrousd": 15,
+      "aliases": ["anthropic/claude-sonnet-4.5"]
+    },
+    "claude-sonnet-4.6": {
+      "cachedInputMicrousd": 0.3,
+      "inputMicrousd": 3,
+      "outputMicrousd": 15,
+      "aliases": ["anthropic/claude-sonnet-4.6"]
+    },
     "claude-sonnet-5": {
       "cachedInputMicrousd": 0.2,
       "inputMicrousd": 2,
       "outputMicrousd": 10,
       "aliases": ["anthropic/claude-sonnet-5"]
     },
+    "codestral-2508": {
+      "cachedInputMicrousd": 0.03,
+      "inputMicrousd": 0.3,
+      "outputMicrousd": 0.9,
+      "aliases": ["mistralai/codestral-2508"]
+    },
     "deepseek-chat": {
       "cachedInputMicrousd": 0.028,
       "inputMicrousd": 0.28,
       "outputMicrousd": 0.42,
       "aliases": ["deepseek/deepseek-chat"]
+    },
+    "deepseek-chat-v3-0324": {
+      "cachedInputMicrousd": 0.135,
+      "inputMicrousd": 0.27,
+      "outputMicrousd": 1.12,
+      "aliases": ["deepseek/deepseek-chat-v3-0324"]
+    },
+    "deepseek-chat-v3.1": {
+      "cachedInputMicrousd": 0.13,
+      "inputMicrousd": 0.25,
+      "outputMicrousd": 0.95,
+      "aliases": ["deepseek/deepseek-chat-v3.1"]
     },
     "deepseek-coder": {
       "cachedInputMicrousd": 0.014,
@@ -215,6 +311,18 @@
       "inputMicrousd": 0.55,
       "outputMicrousd": 2.19,
       "aliases": ["deepseek/deepseek-r1"]
+    },
+    "deepseek-r1-0528": {
+      "cachedInputMicrousd": 0.35,
+      "inputMicrousd": 0.5,
+      "outputMicrousd": 2.15,
+      "aliases": ["deepseek/deepseek-r1-0528"]
+    },
+    "deepseek-r1-distill-llama-70b": {
+      "cachedInputMicrousd": 0.08,
+      "inputMicrousd": 0.8,
+      "outputMicrousd": 0.8,
+      "aliases": ["deepseek/deepseek-r1-distill-llama-70b"]
     },
     "deepseek-reasoner": {
       "cachedInputMicrousd": 0.028,
@@ -233,11 +341,23 @@
       "inputMicrousd": 0,
       "outputMicrousd": 0
     },
+    "deepseek-v3.1-terminus": {
+      "cachedInputMicrousd": 0.135,
+      "inputMicrousd": 0.27,
+      "outputMicrousd": 1,
+      "aliases": ["deepseek/deepseek-v3.1-terminus"]
+    },
     "deepseek-v3.2": {
       "cachedInputMicrousd": 0.028,
       "inputMicrousd": 0.28,
       "outputMicrousd": 0.4,
       "aliases": ["deepseek/deepseek-v3.2"]
+    },
+    "deepseek-v3.2-exp": {
+      "cachedInputMicrousd": 0.027,
+      "inputMicrousd": 0.27,
+      "outputMicrousd": 0.41,
+      "aliases": ["deepseek/deepseek-v3.2-exp"]
     },
     "deepseek-v4-flash": {
       "cachedInputMicrousd": 0.0028,
@@ -288,6 +408,12 @@
       "outputMicrousd": 2.5,
       "aliases": ["gemini-2.5-flash-*", "google/gemini-2.5-flash"]
     },
+    "gemini-2.5-flash-image": {
+      "cachedInputMicrousd": 0.03,
+      "inputMicrousd": 0.3,
+      "outputMicrousd": 2.5,
+      "aliases": ["google/gemini-2.5-flash-image"]
+    },
     "gemini-2.5-flash-lite": {
       "cachedInputMicrousd": 0.01,
       "inputMicrousd": 0.1,
@@ -336,6 +462,18 @@
       },
       "aliases": ["gemini-2.5-pro-*", "google/gemini-2.5-pro"]
     },
+    "gemini-2.5-pro-preview": {
+      "cachedInputMicrousd": 0.125,
+      "inputMicrousd": 1.25,
+      "outputMicrousd": 10,
+      "aliases": ["google/gemini-2.5-pro-preview"]
+    },
+    "gemini-2.5-pro-preview-05-06": {
+      "cachedInputMicrousd": 0.125,
+      "inputMicrousd": 1.25,
+      "outputMicrousd": 10,
+      "aliases": ["google/gemini-2.5-pro-preview-05-06"]
+    },
     "gemini-2.5-pro-preview-tts": {
       "cachedInputMicrousd": 0.125,
       "inputMicrousd": 1.25,
@@ -365,6 +503,18 @@
       "outputMicrousd": 12,
       "aliases": ["gemini-3-pro-*"]
     },
+    "gemini-3-pro-image": {
+      "cachedInputMicrousd": 0.2,
+      "inputMicrousd": 2,
+      "outputMicrousd": 12,
+      "aliases": ["google/gemini-3-pro-image"]
+    },
+    "gemini-3-pro-image-preview": {
+      "cachedInputMicrousd": 0.2,
+      "inputMicrousd": 2,
+      "outputMicrousd": 12,
+      "aliases": ["google/gemini-3-pro-image-preview"]
+    },
     "gemini-3-pro-preview": {
       "cachedInputMicrousd": 0.2,
       "inputMicrousd": 2,
@@ -376,11 +526,29 @@
         "threshold": 200000
       }
     },
+    "gemini-3.1-flash-image": {
+      "cachedInputMicrousd": 0.05,
+      "inputMicrousd": 0.5,
+      "outputMicrousd": 3,
+      "aliases": ["google/gemini-3.1-flash-image"]
+    },
+    "gemini-3.1-flash-image-preview": {
+      "cachedInputMicrousd": 0.05,
+      "inputMicrousd": 0.5,
+      "outputMicrousd": 3,
+      "aliases": ["google/gemini-3.1-flash-image-preview"]
+    },
     "gemini-3.1-flash-lite": {
       "cachedInputMicrousd": 0.025,
       "inputMicrousd": 0.25,
       "outputMicrousd": 1.5,
       "aliases": ["google/gemini-3.1-flash-lite"]
+    },
+    "gemini-3.1-flash-lite-image": {
+      "cachedInputMicrousd": 0.025,
+      "inputMicrousd": 0.25,
+      "outputMicrousd": 1.5,
+      "aliases": ["google/gemini-3.1-flash-lite-image"]
     },
     "gemini-3.1-flash-lite-preview": {
       "cachedInputMicrousd": 0.025,
@@ -423,6 +591,18 @@
       "outputMicrousd": 9,
       "aliases": ["google/gemini-3.5-flash"]
     },
+    "gemini-3.5-flash-lite": {
+      "cachedInputMicrousd": 0.03,
+      "inputMicrousd": 0.3,
+      "outputMicrousd": 2.5,
+      "aliases": ["google/gemini-3.5-flash-lite"]
+    },
+    "gemini-3.6-flash": {
+      "cachedInputMicrousd": 0.15,
+      "inputMicrousd": 1.5,
+      "outputMicrousd": 7.5,
+      "aliases": ["google/gemini-3.6-flash"]
+    },
     "gemini-exp-1206": {
       "cachedInputMicrousd": 0.03,
       "inputMicrousd": 0.3,
@@ -431,12 +611,18 @@
     "gemini-flash": {
       "cachedInputMicrousd": 0.03,
       "inputMicrousd": 0.3,
-      "outputMicrousd": 2.5
+      "outputMicrousd": 2.5,
+      "aliases": ["~google/gemini-flash-latest"]
     },
     "gemini-flash-lite": {
       "cachedInputMicrousd": 0.01,
       "inputMicrousd": 0.1,
       "outputMicrousd": 0.4
+    },
+    "gemini-omni-flash-preview": {
+      "cachedInputMicrousd": 0.15,
+      "inputMicrousd": 1.5,
+      "outputMicrousd": 9
     },
     "gemini-pro": {
       "cachedInputMicrousd": 0.125,
@@ -447,7 +633,8 @@
         "inputMicrousd": 2.5,
         "outputMicrousd": 15,
         "threshold": 200000
-      }
+      },
+      "aliases": ["~google/gemini-pro-latest"]
     },
     "gemini-robotics-er-1.5-preview": {
       "cachedInputMicrousd": 0,
@@ -507,6 +694,12 @@
       "outputMicrousd": 2.2,
       "aliases": ["z-ai/glm-4.6", "zai/glm-4.6"]
     },
+    "glm-4.6v": {
+      "cachedInputMicrousd": 0.055,
+      "inputMicrousd": 0.3,
+      "outputMicrousd": 0.9,
+      "aliases": ["z-ai/glm-4.6v"]
+    },
     "glm-4.7": {
       "cachedInputMicrousd": 0.11,
       "inputMicrousd": 0.6,
@@ -531,11 +724,29 @@
       "outputMicrousd": 5,
       "aliases": ["zai/glm-5-code"]
     },
+    "glm-5-turbo": {
+      "cachedInputMicrousd": 0.24,
+      "inputMicrousd": 1.2,
+      "outputMicrousd": 4,
+      "aliases": ["z-ai/glm-5-turbo"]
+    },
     "glm-5.1": {
       "cachedInputMicrousd": 0.26,
       "inputMicrousd": 1.4,
       "outputMicrousd": 4.4,
       "aliases": ["z-ai/glm-5.1", "zai/glm-5.1"]
+    },
+    "glm-5.2": {
+      "cachedInputMicrousd": 0.1531,
+      "inputMicrousd": 0.8246,
+      "outputMicrousd": 2.5916,
+      "aliases": ["z-ai/glm-5.2"]
+    },
+    "glm-5v-turbo": {
+      "cachedInputMicrousd": 0.24,
+      "inputMicrousd": 1.2,
+      "outputMicrousd": 4,
+      "aliases": ["z-ai/glm-5v-turbo"]
     },
     "gpt-3.5-turbo": {
       "cachedInputMicrousd": 0.05,
@@ -548,6 +759,12 @@
       "inputMicrousd": 0.5,
       "outputMicrousd": 1.5
     },
+    "gpt-3.5-turbo-0613": {
+      "cachedInputMicrousd": 0.1,
+      "inputMicrousd": 1,
+      "outputMicrousd": 2,
+      "aliases": ["openai/gpt-3.5-turbo-0613"]
+    },
     "gpt-3.5-turbo-1106": {
       "cachedInputMicrousd": 0.1,
       "inputMicrousd": 1,
@@ -558,6 +775,12 @@
       "inputMicrousd": 3,
       "outputMicrousd": 4,
       "aliases": ["openai/gpt-3.5-turbo-16k"]
+    },
+    "gpt-3.5-turbo-instruct": {
+      "cachedInputMicrousd": 0.15,
+      "inputMicrousd": 1.5,
+      "outputMicrousd": 2,
+      "aliases": ["openai/gpt-3.5-turbo-instruct"]
     },
     "gpt-4": {
       "cachedInputMicrousd": 3,
@@ -591,6 +814,11 @@
       "outputMicrousd": 30,
       "aliases": ["openai/gpt-4-turbo"]
     },
+    "gpt-4-turbo-2024-04-09": {
+      "cachedInputMicrousd": 1,
+      "inputMicrousd": 10,
+      "outputMicrousd": 30
+    },
     "gpt-4-turbo-preview": {
       "cachedInputMicrousd": 1,
       "inputMicrousd": 10,
@@ -603,17 +831,32 @@
       "outputMicrousd": 8,
       "aliases": ["openai/gpt-4.1"]
     },
+    "gpt-4.1-2025-04-14": {
+      "cachedInputMicrousd": 0.5,
+      "inputMicrousd": 2,
+      "outputMicrousd": 8
+    },
     "gpt-4.1-mini": {
       "cachedInputMicrousd": 0.1,
       "inputMicrousd": 0.4,
       "outputMicrousd": 1.6,
       "aliases": ["openai/gpt-4.1-mini"]
     },
+    "gpt-4.1-mini-2025-04-14": {
+      "cachedInputMicrousd": 0.1,
+      "inputMicrousd": 0.4,
+      "outputMicrousd": 1.6
+    },
     "gpt-4.1-nano": {
       "cachedInputMicrousd": 0.025,
       "inputMicrousd": 0.1,
       "outputMicrousd": 0.4,
       "aliases": ["openai/gpt-4.1-nano"]
+    },
+    "gpt-4.1-nano-2025-04-14": {
+      "cachedInputMicrousd": 0.025,
+      "inputMicrousd": 0.1,
+      "outputMicrousd": 0.4
     },
     "gpt-4o": {
       "cachedInputMicrousd": 1.25,
@@ -624,9 +867,32 @@
     "gpt-4o-2024-05-13": {
       "cachedInputMicrousd": 0.5,
       "inputMicrousd": 5,
-      "outputMicrousd": 15
+      "outputMicrousd": 15,
+      "aliases": ["openai/gpt-4o-2024-05-13"]
+    },
+    "gpt-4o-2024-08-06": {
+      "cachedInputMicrousd": 1.25,
+      "inputMicrousd": 2.5,
+      "outputMicrousd": 10,
+      "aliases": ["openai/gpt-4o-2024-08-06"]
+    },
+    "gpt-4o-2024-11-20": {
+      "cachedInputMicrousd": 1.25,
+      "inputMicrousd": 2.5,
+      "outputMicrousd": 10,
+      "aliases": ["openai/gpt-4o-2024-11-20"]
     },
     "gpt-4o-audio-preview": {
+      "cachedInputMicrousd": 0.25,
+      "inputMicrousd": 2.5,
+      "outputMicrousd": 10
+    },
+    "gpt-4o-audio-preview-2024-12-17": {
+      "cachedInputMicrousd": 0.25,
+      "inputMicrousd": 2.5,
+      "outputMicrousd": 10
+    },
+    "gpt-4o-audio-preview-2025-06-03": {
       "cachedInputMicrousd": 0.25,
       "inputMicrousd": 2.5,
       "outputMicrousd": 10
@@ -637,7 +903,18 @@
       "outputMicrousd": 0.6,
       "aliases": ["openai/gpt-4o-mini"]
     },
+    "gpt-4o-mini-2024-07-18": {
+      "cachedInputMicrousd": 0.075,
+      "inputMicrousd": 0.15,
+      "outputMicrousd": 0.6,
+      "aliases": ["openai/gpt-4o-mini-2024-07-18"]
+    },
     "gpt-4o-mini-audio-preview": {
+      "cachedInputMicrousd": 0.015,
+      "inputMicrousd": 0.15,
+      "outputMicrousd": 0.6
+    },
+    "gpt-4o-mini-audio-preview-2024-12-17": {
       "cachedInputMicrousd": 0.015,
       "inputMicrousd": 0.15,
       "outputMicrousd": 0.6
@@ -653,6 +930,11 @@
       "outputMicrousd": 0.6,
       "aliases": ["openai/gpt-4o-mini-search-preview"]
     },
+    "gpt-4o-mini-search-preview-2025-03-11": {
+      "cachedInputMicrousd": 0.075,
+      "inputMicrousd": 0.15,
+      "outputMicrousd": 0.6
+    },
     "gpt-4o-realtime-preview": {
       "cachedInputMicrousd": 2.5,
       "inputMicrousd": 5,
@@ -664,11 +946,21 @@
       "outputMicrousd": 10,
       "aliases": ["openai/gpt-4o-search-preview"]
     },
+    "gpt-4o-search-preview-2025-03-11": {
+      "cachedInputMicrousd": 1.25,
+      "inputMicrousd": 2.5,
+      "outputMicrousd": 10
+    },
     "gpt-5": {
       "cachedInputMicrousd": 0.125,
       "inputMicrousd": 1.25,
       "outputMicrousd": 10,
       "aliases": ["gpt-5-*", "openai/gpt-5"]
+    },
+    "gpt-5-2025-08-07": {
+      "cachedInputMicrousd": 0.125,
+      "inputMicrousd": 1.25,
+      "outputMicrousd": 10
     },
     "gpt-5-chat": {
       "cachedInputMicrousd": 0.125,
@@ -682,11 +974,28 @@
       "outputMicrousd": 10,
       "aliases": ["openai/gpt-5-codex"]
     },
+    "gpt-5-image": {
+      "cachedInputMicrousd": 1.25,
+      "inputMicrousd": 10,
+      "outputMicrousd": 10,
+      "aliases": ["openai/gpt-5-image"]
+    },
+    "gpt-5-image-mini": {
+      "cachedInputMicrousd": 0.25,
+      "inputMicrousd": 2.5,
+      "outputMicrousd": 2,
+      "aliases": ["openai/gpt-5-image-mini"]
+    },
     "gpt-5-mini": {
       "cachedInputMicrousd": 0.025,
       "inputMicrousd": 0.25,
       "outputMicrousd": 2,
       "aliases": ["openai/gpt-5-mini"]
+    },
+    "gpt-5-mini-2025-08-07": {
+      "cachedInputMicrousd": 0.025,
+      "inputMicrousd": 0.25,
+      "outputMicrousd": 2
     },
     "gpt-5-nano": {
       "cachedInputMicrousd": 0.005,
@@ -694,7 +1003,23 @@
       "outputMicrousd": 0.4,
       "aliases": ["openai/gpt-5-nano"]
     },
+    "gpt-5-nano-2025-08-07": {
+      "cachedInputMicrousd": 0.005,
+      "inputMicrousd": 0.05,
+      "outputMicrousd": 0.4
+    },
+    "gpt-5-pro": {
+      "cachedInputMicrousd": 1.5,
+      "inputMicrousd": 15,
+      "outputMicrousd": 120,
+      "aliases": ["openai/gpt-5-pro"]
+    },
     "gpt-5-search-api": {
+      "cachedInputMicrousd": 0.125,
+      "inputMicrousd": 1.25,
+      "outputMicrousd": 10
+    },
+    "gpt-5-search-api-2025-10-14": {
       "cachedInputMicrousd": 0.125,
       "inputMicrousd": 1.25,
       "outputMicrousd": 10
@@ -704,6 +1029,11 @@
       "inputMicrousd": 1.25,
       "outputMicrousd": 10,
       "aliases": ["openai/gpt-5.1"]
+    },
+    "gpt-5.1-2025-11-13": {
+      "cachedInputMicrousd": 0.125,
+      "inputMicrousd": 1.25,
+      "outputMicrousd": 10
     },
     "gpt-5.1-chat": {
       "cachedInputMicrousd": 0.125,
@@ -717,6 +1047,12 @@
       "outputMicrousd": 10,
       "aliases": ["openai/gpt-5.1-codex"]
     },
+    "gpt-5.1-codex-max": {
+      "cachedInputMicrousd": 0.125,
+      "inputMicrousd": 1.25,
+      "outputMicrousd": 10,
+      "aliases": ["openai/gpt-5.1-codex-max"]
+    },
     "gpt-5.1-codex-mini": {
       "inputMicrousd": 0.25,
       "cachedInputMicrousd": 0.025,
@@ -729,6 +1065,11 @@
       "outputMicrousd": 14,
       "aliases": ["openai/gpt-5.2"]
     },
+    "gpt-5.2-2025-12-11": {
+      "cachedInputMicrousd": 0.175,
+      "inputMicrousd": 1.75,
+      "outputMicrousd": 14
+    },
     "gpt-5.2-chat": {
       "cachedInputMicrousd": 0.175,
       "inputMicrousd": 1.75,
@@ -740,6 +1081,12 @@
       "cachedInputMicrousd": 0.175,
       "outputMicrousd": 14,
       "aliases": ["openai/gpt-5.2-codex"]
+    },
+    "gpt-5.2-pro": {
+      "cachedInputMicrousd": 2.1,
+      "inputMicrousd": 21,
+      "outputMicrousd": 168,
+      "aliases": ["openai/gpt-5.2-pro"]
     },
     "gpt-5.3-chat": {
       "cachedInputMicrousd": 0.175,
@@ -769,6 +1116,17 @@
         "outputMicrousd": 30
       }
     },
+    "gpt-5.4-2026-03-05": {
+      "cachedInputMicrousd": 0.25,
+      "inputMicrousd": 2.5,
+      "outputMicrousd": 15
+    },
+    "gpt-5.4-image-2": {
+      "cachedInputMicrousd": 2,
+      "inputMicrousd": 8,
+      "outputMicrousd": 15,
+      "aliases": ["openai/gpt-5.4-image-2"]
+    },
     "gpt-5.4-mini": {
       "cachedInputMicrousd": 0.075,
       "inputMicrousd": 0.75,
@@ -780,11 +1138,21 @@
         "outputMicrousd": 9
       }
     },
+    "gpt-5.4-mini-2026-03-17": {
+      "cachedInputMicrousd": 0.075,
+      "inputMicrousd": 0.75,
+      "outputMicrousd": 4.5
+    },
     "gpt-5.4-nano": {
       "cachedInputMicrousd": 0.02,
       "inputMicrousd": 0.2,
       "outputMicrousd": 1.25,
       "aliases": ["openai/gpt-5.4-nano"]
+    },
+    "gpt-5.4-nano-2026-03-17": {
+      "cachedInputMicrousd": 0.02,
+      "inputMicrousd": 0.2,
+      "outputMicrousd": 1.25
     },
     "gpt-5.4-pro": {
       "inputMicrousd": 30,
@@ -802,6 +1170,11 @@
         "cachedInputMicrousd": 1.25,
         "outputMicrousd": 75
       }
+    },
+    "gpt-5.5-2026-04-23": {
+      "cachedInputMicrousd": 0.5,
+      "inputMicrousd": 5,
+      "outputMicrousd": 30
     },
     "gpt-5.5-pro": {
       "inputMicrousd": 30,
@@ -825,6 +1198,12 @@
         "outputMicrousd": 12
       }
     },
+    "gpt-5.6-luna-pro": {
+      "cachedInputMicrousd": 0.1,
+      "inputMicrousd": 1,
+      "outputMicrousd": 6,
+      "aliases": ["openai/gpt-5.6-luna-pro"]
+    },
     "gpt-5.6-sol": {
       "cachedInputMicrousd": 0.5,
       "inputMicrousd": 5,
@@ -835,6 +1214,12 @@
         "cachedInputMicrousd": 1,
         "outputMicrousd": 60
       }
+    },
+    "gpt-5.6-sol-pro": {
+      "cachedInputMicrousd": 0.5,
+      "inputMicrousd": 5,
+      "outputMicrousd": 30,
+      "aliases": ["openai/gpt-5.6-sol-pro"]
     },
     "gpt-5.6-terra": {
       "cachedInputMicrousd": 0.25,
@@ -847,6 +1232,12 @@
         "outputMicrousd": 30
       }
     },
+    "gpt-5.6-terra-pro": {
+      "cachedInputMicrousd": 0.25,
+      "inputMicrousd": 2.5,
+      "outputMicrousd": 15,
+      "aliases": ["openai/gpt-5.6-terra-pro"]
+    },
     "gpt-audio": {
       "cachedInputMicrousd": 0.25,
       "inputMicrousd": 2.5,
@@ -858,11 +1249,44 @@
       "inputMicrousd": 2.5,
       "outputMicrousd": 10
     },
+    "gpt-audio-2025-08-28": {
+      "cachedInputMicrousd": 0.25,
+      "inputMicrousd": 2.5,
+      "outputMicrousd": 10
+    },
     "gpt-audio-mini": {
       "cachedInputMicrousd": 0.06,
       "inputMicrousd": 0.6,
       "outputMicrousd": 2.4,
       "aliases": ["openai/gpt-audio-mini"]
+    },
+    "gpt-audio-mini-2025-10-06": {
+      "cachedInputMicrousd": 0.06,
+      "inputMicrousd": 0.6,
+      "outputMicrousd": 2.4
+    },
+    "gpt-audio-mini-2025-12-15": {
+      "cachedInputMicrousd": 0.06,
+      "inputMicrousd": 0.6,
+      "outputMicrousd": 2.4
+    },
+    "gpt-oss-120b": {
+      "cachedInputMicrousd": 0.0037,
+      "inputMicrousd": 0.037,
+      "outputMicrousd": 0.17,
+      "aliases": ["openai/gpt-oss-120b"]
+    },
+    "gpt-oss-20b": {
+      "cachedInputMicrousd": 0.0029,
+      "inputMicrousd": 0.029,
+      "outputMicrousd": 0.14,
+      "aliases": ["openai/gpt-oss-20b", "openai/gpt-oss-20b:free"]
+    },
+    "gpt-oss-safeguard-20b": {
+      "cachedInputMicrousd": 0.0375,
+      "inputMicrousd": 0.075,
+      "outputMicrousd": 0.3,
+      "aliases": ["openai/gpt-oss-safeguard-20b"]
     },
     "gpt-realtime": {
       "cachedInputMicrousd": 0.4,
@@ -894,17 +1318,244 @@
       "inputMicrousd": 0.6,
       "outputMicrousd": 2.4
     },
-    "grok-4": {
-      "inputMicrousd": 5,
-      "cachedInputMicrousd": 1.25,
+    "grok-2": {
+      "cachedInputMicrousd": 0.2,
+      "inputMicrousd": 2,
+      "outputMicrousd": 10,
+      "aliases": ["xai/grok-2", "xai/grok-2-latest"]
+    },
+    "grok-2-1212": {
+      "cachedInputMicrousd": 0.2,
+      "inputMicrousd": 2,
+      "outputMicrousd": 10,
+      "aliases": ["xai/grok-2-1212"]
+    },
+    "grok-2-vision": {
+      "cachedInputMicrousd": 0.2,
+      "inputMicrousd": 2,
+      "outputMicrousd": 10,
+      "aliases": ["xai/grok-2-vision", "xai/grok-2-vision-latest"]
+    },
+    "grok-2-vision-1212": {
+      "cachedInputMicrousd": 0.2,
+      "inputMicrousd": 2,
+      "outputMicrousd": 10,
+      "aliases": ["xai/grok-2-vision-1212"]
+    },
+    "grok-3": {
+      "cachedInputMicrousd": 0.75,
+      "inputMicrousd": 3,
       "outputMicrousd": 15,
-      "aliases": ["grok-4-*"]
+      "aliases": ["xai/grok-3", "xai/grok-3-latest"]
+    },
+    "grok-3-beta": {
+      "cachedInputMicrousd": 0.75,
+      "inputMicrousd": 3,
+      "outputMicrousd": 15,
+      "aliases": ["xai/grok-3-beta"]
+    },
+    "grok-3-fast": {
+      "cachedInputMicrousd": 1.25,
+      "inputMicrousd": 5,
+      "outputMicrousd": 25,
+      "aliases": ["xai/grok-3-fast-latest"]
+    },
+    "grok-3-fast-beta": {
+      "cachedInputMicrousd": 1.25,
+      "inputMicrousd": 5,
+      "outputMicrousd": 25,
+      "aliases": ["xai/grok-3-fast-beta"]
+    },
+    "grok-3-mini": {
+      "cachedInputMicrousd": 0.075,
+      "inputMicrousd": 0.3,
+      "outputMicrousd": 0.5,
+      "aliases": ["xai/grok-3-mini", "xai/grok-3-mini-latest"]
+    },
+    "grok-3-mini-beta": {
+      "cachedInputMicrousd": 0.075,
+      "inputMicrousd": 0.3,
+      "outputMicrousd": 0.5,
+      "aliases": ["xai/grok-3-mini-beta"]
+    },
+    "grok-3-mini-fast": {
+      "cachedInputMicrousd": 0.15,
+      "inputMicrousd": 0.6,
+      "outputMicrousd": 4,
+      "aliases": ["xai/grok-3-mini-fast", "xai/grok-3-mini-fast-latest"]
+    },
+    "grok-3-mini-fast-beta": {
+      "cachedInputMicrousd": 0.15,
+      "inputMicrousd": 0.6,
+      "outputMicrousd": 4,
+      "aliases": ["xai/grok-3-mini-fast-beta"]
+    },
+    "grok-4": {
+      "cachedInputMicrousd": 0.3,
+      "inputMicrousd": 3,
+      "outputMicrousd": 15,
+      "longContext": {
+        "cachedInputMicrousd": 0.6,
+        "inputMicrousd": 6,
+        "outputMicrousd": 30,
+        "threshold": 128000
+      },
+      "aliases": ["grok-4-*", "xai/grok-4", "xai/grok-4-latest"]
+    },
+    "grok-4-0709": {
+      "cachedInputMicrousd": 0.3,
+      "inputMicrousd": 3,
+      "outputMicrousd": 15,
+      "longContext": {
+        "cachedInputMicrousd": 0.6,
+        "inputMicrousd": 6,
+        "outputMicrousd": 30,
+        "threshold": 128000
+      },
+      "aliases": ["xai/grok-4-0709"]
+    },
+    "grok-4-1-fast": {
+      "cachedInputMicrousd": 0.05,
+      "inputMicrousd": 0.2,
+      "outputMicrousd": 0.5,
+      "longContext": {
+        "cachedInputMicrousd": 0.04,
+        "inputMicrousd": 0.4,
+        "outputMicrousd": 1,
+        "threshold": 128000
+      },
+      "aliases": ["xai/grok-4-1-fast"]
+    },
+    "grok-4-1-fast-non-reasoning": {
+      "cachedInputMicrousd": 0.05,
+      "inputMicrousd": 0.2,
+      "outputMicrousd": 0.5,
+      "longContext": {
+        "cachedInputMicrousd": 0.04,
+        "inputMicrousd": 0.4,
+        "outputMicrousd": 1,
+        "threshold": 128000
+      },
+      "aliases": [
+        "xai/grok-4-1-fast-non-reasoning",
+        "xai/grok-4-1-fast-non-reasoning-latest"
+      ]
+    },
+    "grok-4-1-fast-reasoning": {
+      "cachedInputMicrousd": 0.05,
+      "inputMicrousd": 0.2,
+      "outputMicrousd": 0.5,
+      "longContext": {
+        "cachedInputMicrousd": 0.04,
+        "inputMicrousd": 0.4,
+        "outputMicrousd": 1,
+        "threshold": 128000
+      },
+      "aliases": [
+        "xai/grok-4-1-fast-reasoning",
+        "xai/grok-4-1-fast-reasoning-latest"
+      ]
+    },
+    "grok-4-fast-non-reasoning": {
+      "cachedInputMicrousd": 0.05,
+      "inputMicrousd": 0.2,
+      "outputMicrousd": 0.5,
+      "longContext": {
+        "cachedInputMicrousd": 0.04,
+        "inputMicrousd": 0.4,
+        "outputMicrousd": 1,
+        "threshold": 128000
+      },
+      "aliases": ["xai/grok-4-fast-non-reasoning"]
+    },
+    "grok-4-fast-reasoning": {
+      "cachedInputMicrousd": 0.05,
+      "inputMicrousd": 0.2,
+      "outputMicrousd": 0.5,
+      "longContext": {
+        "cachedInputMicrousd": 0.04,
+        "inputMicrousd": 0.4,
+        "outputMicrousd": 1,
+        "threshold": 128000
+      },
+      "aliases": ["xai/grok-4-fast-reasoning"]
+    },
+    "grok-4.20": {
+      "cachedInputMicrousd": 0.2,
+      "inputMicrousd": 1.25,
+      "outputMicrousd": 2.5,
+      "aliases": ["x-ai/grok-4.20"]
+    },
+    "grok-4.20-0309-reasoning": {
+      "cachedInputMicrousd": 0.2,
+      "inputMicrousd": 2,
+      "outputMicrousd": 6,
+      "aliases": ["xai/grok-4.20-0309-reasoning"]
+    },
+    "grok-4.20-beta-0309-non-reasoning": {
+      "cachedInputMicrousd": 0.2,
+      "inputMicrousd": 2,
+      "outputMicrousd": 6,
+      "aliases": ["xai/grok-4.20-beta-0309-non-reasoning"]
+    },
+    "grok-4.20-beta-0309-reasoning": {
+      "cachedInputMicrousd": 0.2,
+      "inputMicrousd": 2,
+      "outputMicrousd": 6,
+      "aliases": ["xai/grok-4.20-beta-0309-reasoning"]
+    },
+    "grok-4.20-multi-agent": {
+      "cachedInputMicrousd": 0.2,
+      "inputMicrousd": 1.25,
+      "outputMicrousd": 2.5,
+      "aliases": ["x-ai/grok-4.20-multi-agent"]
+    },
+    "grok-4.20-multi-agent-beta-0309": {
+      "cachedInputMicrousd": 0.2,
+      "inputMicrousd": 2,
+      "outputMicrousd": 6,
+      "aliases": ["xai/grok-4.20-multi-agent-beta-0309"]
+    },
+    "grok-4.3": {
+      "cachedInputMicrousd": 0.2,
+      "inputMicrousd": 1.25,
+      "outputMicrousd": 2.5,
+      "longContext": {
+        "cachedInputMicrousd": 0.4,
+        "inputMicrousd": 2.5,
+        "outputMicrousd": 5,
+        "threshold": 200000
+      },
+      "aliases": ["x-ai/grok-4.3", "xai/grok-4.3", "xai/grok-4.3-latest"]
     },
     "grok-4.5": {
-      "inputMicrousd": 2,
       "cachedInputMicrousd": 0.5,
+      "inputMicrousd": 2,
       "outputMicrousd": 6,
-      "aliases": ["grok-4.5-*", "xai/grok-4.5", "x-ai/grok-4.5"]
+      "longContext": {
+        "cachedInputMicrousd": 1,
+        "inputMicrousd": 4,
+        "outputMicrousd": 12,
+        "threshold": 200000
+      },
+      "aliases": [
+        "grok-4.5-*",
+        "x-ai/grok-4.5",
+        "xai/grok-4.5",
+        "xai/grok-4.5-latest"
+      ]
+    },
+    "grok-beta": {
+      "cachedInputMicrousd": 0.5,
+      "inputMicrousd": 5,
+      "outputMicrousd": 15,
+      "aliases": ["xai/grok-beta"]
+    },
+    "grok-build-0.1": {
+      "cachedInputMicrousd": 0.2,
+      "inputMicrousd": 1,
+      "outputMicrousd": 2,
+      "aliases": ["x-ai/grok-build-0.1"]
     },
     "grok-code": {
       "inputMicrousd": 0.2,
@@ -912,17 +1563,53 @@
       "outputMicrousd": 1.5,
       "aliases": ["grok-code-*"]
     },
+    "grok-code-fast": {
+      "cachedInputMicrousd": 0.02,
+      "inputMicrousd": 0.2,
+      "outputMicrousd": 1.5,
+      "aliases": ["xai/grok-code-fast"]
+    },
+    "grok-code-fast-1": {
+      "cachedInputMicrousd": 0.02,
+      "inputMicrousd": 0.2,
+      "outputMicrousd": 1.5,
+      "aliases": ["xai/grok-code-fast-1"]
+    },
+    "grok-code-fast-1-0825": {
+      "cachedInputMicrousd": 0.02,
+      "inputMicrousd": 0.2,
+      "outputMicrousd": 1.5,
+      "aliases": ["xai/grok-code-fast-1-0825"]
+    },
+    "grok-vision-beta": {
+      "cachedInputMicrousd": 0.5,
+      "inputMicrousd": 5,
+      "outputMicrousd": 15,
+      "aliases": ["xai/grok-vision-beta"]
+    },
     "kimi": {
       "cachedInputMicrousd": 0.15,
       "inputMicrousd": 2,
       "outputMicrousd": 5,
-      "aliases": ["moonshot/kimi-latest"]
+      "aliases": ["moonshot/kimi-latest", "~moonshotai/kimi-latest"]
+    },
+    "kimi-k2": {
+      "cachedInputMicrousd": 0.057,
+      "inputMicrousd": 0.57,
+      "outputMicrousd": 2.3,
+      "aliases": ["moonshotai/kimi-k2"]
     },
     "kimi-k2-0711-preview": {
       "cachedInputMicrousd": 0.15,
       "inputMicrousd": 0.6,
       "outputMicrousd": 2.5,
       "aliases": ["moonshot/kimi-k2-0711-preview"]
+    },
+    "kimi-k2-0905": {
+      "cachedInputMicrousd": 0.06,
+      "inputMicrousd": 0.6,
+      "outputMicrousd": 2.5,
+      "aliases": ["moonshotai/kimi-k2-0905"]
     },
     "kimi-k2-0905-preview": {
       "cachedInputMicrousd": 0.15,
@@ -965,6 +1652,18 @@
       "outputMicrousd": 4,
       "aliases": ["moonshot/kimi-k2.6", "moonshotai/kimi-k2.6"]
     },
+    "kimi-k2.7-code": {
+      "cachedInputMicrousd": 0.15,
+      "inputMicrousd": 0.71,
+      "outputMicrousd": 3.49,
+      "aliases": ["moonshotai/kimi-k2.7-code"]
+    },
+    "kimi-k3": {
+      "cachedInputMicrousd": 0.3,
+      "inputMicrousd": 3,
+      "outputMicrousd": 15,
+      "aliases": ["moonshotai/kimi-k3"]
+    },
     "kimi-latest-128k": {
       "cachedInputMicrousd": 0.15,
       "inputMicrousd": 2,
@@ -989,6 +1688,60 @@
       "outputMicrousd": 2.5,
       "aliases": ["moonshot/kimi-thinking-preview"]
     },
+    "llama-3.1-70b-instruct": {
+      "cachedInputMicrousd": 0.04,
+      "inputMicrousd": 0.4,
+      "outputMicrousd": 0.4,
+      "aliases": ["meta-llama/llama-3.1-70b-instruct"]
+    },
+    "llama-3.1-8b-instruct": {
+      "cachedInputMicrousd": 0.025,
+      "inputMicrousd": 0.05,
+      "outputMicrousd": 0.08,
+      "aliases": ["meta-llama/llama-3.1-8b-instruct"]
+    },
+    "llama-3.2-1b-instruct": {
+      "cachedInputMicrousd": 0.0027,
+      "inputMicrousd": 0.027,
+      "outputMicrousd": 0.201,
+      "aliases": ["meta-llama/llama-3.2-1b-instruct"]
+    },
+    "llama-3.2-3b-instruct": {
+      "cachedInputMicrousd": 0.005,
+      "inputMicrousd": 0.05,
+      "outputMicrousd": 0.33,
+      "aliases": ["meta-llama/llama-3.2-3b-instruct"]
+    },
+    "llama-3.3-70b-instruct": {
+      "cachedInputMicrousd": 0.013,
+      "inputMicrousd": 0.13,
+      "outputMicrousd": 0.4,
+      "aliases": ["meta-llama/llama-3.3-70b-instruct"]
+    },
+    "llama-4-maverick": {
+      "cachedInputMicrousd": 0.02,
+      "inputMicrousd": 0.2,
+      "outputMicrousd": 0.8,
+      "aliases": ["meta-llama/llama-4-maverick"]
+    },
+    "llama-4-scout": {
+      "cachedInputMicrousd": 0.01,
+      "inputMicrousd": 0.1,
+      "outputMicrousd": 0.3,
+      "aliases": ["meta-llama/llama-4-scout"]
+    },
+    "minimax-01": {
+      "cachedInputMicrousd": 0.02,
+      "inputMicrousd": 0.2,
+      "outputMicrousd": 1.1,
+      "aliases": ["minimax/minimax-01"]
+    },
+    "minimax-m1": {
+      "cachedInputMicrousd": 0.055,
+      "inputMicrousd": 0.55,
+      "outputMicrousd": 2.2,
+      "aliases": ["minimax/minimax-m1"]
+    },
     "minimax-m2": {
       "cachedInputMicrousd": 0.03,
       "inputMicrousd": 0.3,
@@ -999,6 +1752,12 @@
       "cachedInputMicrousd": 0.03,
       "inputMicrousd": 0.3,
       "outputMicrousd": 1.2
+    },
+    "minimax-m2-her": {
+      "cachedInputMicrousd": 0.03,
+      "inputMicrousd": 0.3,
+      "outputMicrousd": 1.2,
+      "aliases": ["minimax/minimax-m2-her"]
     },
     "minimax-m2.1": {
       "cachedInputMicrousd": 0.03,
@@ -1044,6 +1803,12 @@
       "inputMicrousd": 0.3,
       "outputMicrousd": 2.4
     },
+    "minimax-m2.7": {
+      "cachedInputMicrousd": 0.06,
+      "inputMicrousd": 0.3,
+      "outputMicrousd": 1.2,
+      "aliases": ["minimax/minimax-m2.7"]
+    },
     "minimax-m3": {
       "cachedInputMicrousd": 0.06,
       "inputMicrousd": 0.3,
@@ -1054,6 +1819,60 @@
       "cachedInputMicrousd": 0.06,
       "inputMicrousd": 0.3,
       "outputMicrousd": 1.2
+    },
+    "mistral-large-2407": {
+      "cachedInputMicrousd": 0.2,
+      "inputMicrousd": 2,
+      "outputMicrousd": 6,
+      "aliases": ["mistralai/mistral-large-2407"]
+    },
+    "mistral-large-2512": {
+      "cachedInputMicrousd": 0.05,
+      "inputMicrousd": 0.5,
+      "outputMicrousd": 1.5,
+      "aliases": ["mistralai/mistral-large-2512"]
+    },
+    "mistral-medium-3": {
+      "cachedInputMicrousd": 0.04,
+      "inputMicrousd": 0.4,
+      "outputMicrousd": 2,
+      "aliases": ["mistralai/mistral-medium-3"]
+    },
+    "mistral-medium-3-5": {
+      "cachedInputMicrousd": 0.15,
+      "inputMicrousd": 1.5,
+      "outputMicrousd": 7.5,
+      "aliases": ["mistralai/mistral-medium-3-5"]
+    },
+    "mistral-medium-3.1": {
+      "cachedInputMicrousd": 0.04,
+      "inputMicrousd": 0.4,
+      "outputMicrousd": 2,
+      "aliases": ["mistralai/mistral-medium-3.1"]
+    },
+    "mistral-small-24b-instruct-2501": {
+      "cachedInputMicrousd": 0.005,
+      "inputMicrousd": 0.05,
+      "outputMicrousd": 0.08,
+      "aliases": ["mistralai/mistral-small-24b-instruct-2501"]
+    },
+    "mistral-small-2603": {
+      "cachedInputMicrousd": 0.015,
+      "inputMicrousd": 0.15,
+      "outputMicrousd": 0.6,
+      "aliases": ["mistralai/mistral-small-2603"]
+    },
+    "mistral-small-3.1-24b-instruct": {
+      "cachedInputMicrousd": 0.0351,
+      "inputMicrousd": 0.351,
+      "outputMicrousd": 0.555,
+      "aliases": ["mistralai/mistral-small-3.1-24b-instruct"]
+    },
+    "mistral-small-3.2-24b-instruct": {
+      "cachedInputMicrousd": 0.01,
+      "inputMicrousd": 0.1,
+      "outputMicrousd": 0.3,
+      "aliases": ["mistralai/mistral-small-3.2-24b-instruct"]
     },
     "moonshot-v1-128k": {
       "cachedInputMicrousd": 0.2,
@@ -1121,11 +1940,33 @@
       "outputMicrousd": 60,
       "aliases": ["openai/o1"]
     },
+    "o1-2024-12-17": {
+      "cachedInputMicrousd": 7.5,
+      "inputMicrousd": 15,
+      "outputMicrousd": 60
+    },
+    "o1-pro": {
+      "cachedInputMicrousd": 15,
+      "inputMicrousd": 150,
+      "outputMicrousd": 600,
+      "aliases": ["openai/o1-pro"]
+    },
     "o3": {
       "cachedInputMicrousd": 0.5,
       "inputMicrousd": 2,
       "outputMicrousd": 8,
       "aliases": ["openai/o3"]
+    },
+    "o3-2025-04-16": {
+      "cachedInputMicrousd": 0.5,
+      "inputMicrousd": 2,
+      "outputMicrousd": 8
+    },
+    "o3-deep-research": {
+      "cachedInputMicrousd": 2.5,
+      "inputMicrousd": 10,
+      "outputMicrousd": 40,
+      "aliases": ["openai/o3-deep-research"]
     },
     "o3-mini": {
       "cachedInputMicrousd": 0.55,
@@ -1133,11 +1974,63 @@
       "outputMicrousd": 4.4,
       "aliases": ["openai/o3-mini"]
     },
+    "o3-mini-2025-01-31": {
+      "cachedInputMicrousd": 0.55,
+      "inputMicrousd": 1.1,
+      "outputMicrousd": 4.4
+    },
+    "o3-mini-high": {
+      "cachedInputMicrousd": 0.55,
+      "inputMicrousd": 1.1,
+      "outputMicrousd": 4.4,
+      "aliases": ["openai/o3-mini-high"]
+    },
+    "o3-pro": {
+      "cachedInputMicrousd": 2,
+      "inputMicrousd": 20,
+      "outputMicrousd": 80,
+      "aliases": ["openai/o3-pro"]
+    },
     "o4-mini": {
       "cachedInputMicrousd": 0.275,
       "inputMicrousd": 1.1,
       "outputMicrousd": 4.4,
       "aliases": ["openai/o4-mini"]
+    },
+    "o4-mini-2025-04-16": {
+      "cachedInputMicrousd": 0.275,
+      "inputMicrousd": 1.1,
+      "outputMicrousd": 4.4
+    },
+    "o4-mini-deep-research": {
+      "cachedInputMicrousd": 0.5,
+      "inputMicrousd": 2,
+      "outputMicrousd": 8,
+      "aliases": ["openai/o4-mini-deep-research"]
+    },
+    "o4-mini-high": {
+      "cachedInputMicrousd": 0.275,
+      "inputMicrousd": 1.1,
+      "outputMicrousd": 4.4,
+      "aliases": ["openai/o4-mini-high"]
+    },
+    "qwen-2.5-72b-instruct": {
+      "cachedInputMicrousd": 0.036,
+      "inputMicrousd": 0.36,
+      "outputMicrousd": 0.4,
+      "aliases": ["qwen/qwen-2.5-72b-instruct"]
+    },
+    "qwen-2.5-7b-instruct": {
+      "cachedInputMicrousd": 0.004,
+      "inputMicrousd": 0.04,
+      "outputMicrousd": 0.1,
+      "aliases": ["qwen/qwen-2.5-7b-instruct"]
+    },
+    "qwen-2.5-coder-32b-instruct": {
+      "cachedInputMicrousd": 0.066,
+      "inputMicrousd": 0.66,
+      "outputMicrousd": 1,
+      "aliases": ["qwen/qwen-2.5-coder-32b-instruct"]
     },
     "qwen-coder": {
       "cachedInputMicrousd": 0.03,
@@ -1163,6 +2056,33 @@
         "qwen/qwen-plus"
       ]
     },
+    "qwen-plus-2025-01-25": {
+      "cachedInputMicrousd": 0.04,
+      "inputMicrousd": 0.4,
+      "outputMicrousd": 1.2,
+      "aliases": ["dashscope/qwen-plus-2025-01-25"]
+    },
+    "qwen-plus-2025-04-28": {
+      "cachedInputMicrousd": 0.04,
+      "inputMicrousd": 0.4,
+      "outputMicrousd": 1.2,
+      "aliases": ["dashscope/qwen-plus-2025-04-28"]
+    },
+    "qwen-plus-2025-07-14": {
+      "cachedInputMicrousd": 0.04,
+      "inputMicrousd": 0.4,
+      "outputMicrousd": 1.2,
+      "aliases": ["dashscope/qwen-plus-2025-07-14"]
+    },
+    "qwen-plus-2025-07-28": {
+      "cachedInputMicrousd": 0.026,
+      "inputMicrousd": 0.26,
+      "outputMicrousd": 0.78,
+      "aliases": [
+        "qwen/qwen-plus-2025-07-28",
+        "qwen/qwen-plus-2025-07-28:thinking"
+      ]
+    },
     "qwen-turbo": {
       "cachedInputMicrousd": 0.005,
       "inputMicrousd": 0.05,
@@ -1173,6 +2093,120 @@
         "dashscope/qwen-turbo-2025-04-28",
         "dashscope/qwen-turbo-latest"
       ]
+    },
+    "qwen-turbo-2024-11-01": {
+      "cachedInputMicrousd": 0.005,
+      "inputMicrousd": 0.05,
+      "outputMicrousd": 0.2,
+      "aliases": ["dashscope/qwen-turbo-2024-11-01"]
+    },
+    "qwen-turbo-2025-04-28": {
+      "cachedInputMicrousd": 0.005,
+      "inputMicrousd": 0.05,
+      "outputMicrousd": 0.2,
+      "aliases": ["dashscope/qwen-turbo-2025-04-28"]
+    },
+    "qwen2.5-vl-72b-instruct": {
+      "cachedInputMicrousd": 0.4,
+      "inputMicrousd": 0.8,
+      "outputMicrousd": 1,
+      "aliases": ["qwen/qwen2.5-vl-72b-instruct"]
+    },
+    "qwen3-14b": {
+      "cachedInputMicrousd": 0.0228,
+      "inputMicrousd": 0.2275,
+      "outputMicrousd": 0.91,
+      "aliases": ["qwen/qwen3-14b"]
+    },
+    "qwen3-235b-a22b": {
+      "cachedInputMicrousd": 0.0455,
+      "inputMicrousd": 0.455,
+      "outputMicrousd": 1.82,
+      "aliases": ["qwen/qwen3-235b-a22b"]
+    },
+    "qwen3-235b-a22b-2507": {
+      "cachedInputMicrousd": 0.009,
+      "inputMicrousd": 0.09,
+      "outputMicrousd": 0.55,
+      "aliases": ["qwen/qwen3-235b-a22b-2507"]
+    },
+    "qwen3-235b-a22b-thinking-2507": {
+      "cachedInputMicrousd": 0.03,
+      "inputMicrousd": 0.3,
+      "outputMicrousd": 3,
+      "aliases": ["qwen/qwen3-235b-a22b-thinking-2507"]
+    },
+    "qwen3-30b-a3b": {
+      "cachedInputMicrousd": 0.013,
+      "inputMicrousd": 0.13,
+      "outputMicrousd": 0.52,
+      "aliases": ["qwen/qwen3-30b-a3b"]
+    },
+    "qwen3-30b-a3b-instruct-2507": {
+      "cachedInputMicrousd": 0.01,
+      "inputMicrousd": 0.1,
+      "outputMicrousd": 0.3,
+      "aliases": ["qwen/qwen3-30b-a3b-instruct-2507"]
+    },
+    "qwen3-30b-a3b-thinking-2507": {
+      "cachedInputMicrousd": 0.013,
+      "inputMicrousd": 0.13,
+      "outputMicrousd": 1.56,
+      "aliases": ["qwen/qwen3-30b-a3b-thinking-2507"]
+    },
+    "qwen3-32b": {
+      "cachedInputMicrousd": 0.008,
+      "inputMicrousd": 0.08,
+      "outputMicrousd": 0.28,
+      "aliases": ["qwen/qwen3-32b"]
+    },
+    "qwen3-8b": {
+      "cachedInputMicrousd": 0.0117,
+      "inputMicrousd": 0.117,
+      "outputMicrousd": 0.455,
+      "aliases": ["qwen/qwen3-8b"]
+    },
+    "qwen3-coder": {
+      "cachedInputMicrousd": 0.038,
+      "inputMicrousd": 0.38,
+      "outputMicrousd": 1.55,
+      "aliases": ["qwen/qwen3-coder"]
+    },
+    "qwen3-coder-30b-a3b-instruct": {
+      "cachedInputMicrousd": 0.007,
+      "inputMicrousd": 0.07,
+      "outputMicrousd": 0.27,
+      "aliases": ["qwen/qwen3-coder-30b-a3b-instruct"]
+    },
+    "qwen3-coder-flash": {
+      "cachedInputMicrousd": 0.039,
+      "inputMicrousd": 0.195,
+      "outputMicrousd": 0.975,
+      "aliases": ["qwen/qwen3-coder-flash"]
+    },
+    "qwen3-coder-next": {
+      "cachedInputMicrousd": 0.07,
+      "inputMicrousd": 0.11,
+      "outputMicrousd": 0.8,
+      "aliases": ["qwen/qwen3-coder-next"]
+    },
+    "qwen3-coder-plus": {
+      "cachedInputMicrousd": 0.13,
+      "inputMicrousd": 0.65,
+      "outputMicrousd": 3.25,
+      "aliases": ["qwen/qwen3-coder-plus"]
+    },
+    "qwen3-max": {
+      "cachedInputMicrousd": 0.156,
+      "inputMicrousd": 0.78,
+      "outputMicrousd": 3.9,
+      "aliases": ["qwen/qwen3-max"]
+    },
+    "qwen3-max-thinking": {
+      "cachedInputMicrousd": 0.078,
+      "inputMicrousd": 0.78,
+      "outputMicrousd": 3.9,
+      "aliases": ["qwen/qwen3-max-thinking"]
     },
     "qwen3-next-80b-a3b-instruct": {
       "cachedInputMicrousd": 0.015,
@@ -1211,6 +2245,18 @@
         "qwen/qwen3-vl-235b-a22b-thinking"
       ]
     },
+    "qwen3-vl-30b-a3b-instruct": {
+      "cachedInputMicrousd": 0.015,
+      "inputMicrousd": 0.15,
+      "outputMicrousd": 0.6,
+      "aliases": ["qwen/qwen3-vl-30b-a3b-instruct"]
+    },
+    "qwen3-vl-30b-a3b-thinking": {
+      "cachedInputMicrousd": 0.013,
+      "inputMicrousd": 0.13,
+      "outputMicrousd": 1.56,
+      "aliases": ["qwen/qwen3-vl-30b-a3b-thinking"]
+    },
     "qwen3-vl-32b-instruct": {
       "cachedInputMicrousd": 0.016,
       "inputMicrousd": 0.16,
@@ -1225,6 +2271,18 @@
       "inputMicrousd": 0.16,
       "outputMicrousd": 2.87,
       "aliases": ["dashscope/qwen3-vl-32b-thinking"]
+    },
+    "qwen3-vl-8b-instruct": {
+      "cachedInputMicrousd": 0.0117,
+      "inputMicrousd": 0.117,
+      "outputMicrousd": 0.455,
+      "aliases": ["qwen/qwen3-vl-8b-instruct"]
+    },
+    "qwen3-vl-8b-thinking": {
+      "cachedInputMicrousd": 0.0117,
+      "inputMicrousd": 0.117,
+      "outputMicrousd": 1.365,
+      "aliases": ["qwen/qwen3-vl-8b-thinking"]
     },
     "qwq-plus": {
       "cachedInputMicrousd": 0.08,


### PR DESCRIPTION
## Summary
Daily model pricing catalog refresh from LiteLLM + OpenRouter fill-missing.

Includes **kimi-k3** (OpenRouter fill-missing: $3/$15 per 1M) and other new models.

## Note
Automated workflow failed at PR creation because org setting
"Allow GitHub Actions to create and approve pull requests" is off
(`default_workflow_permissions: read`). Branch was still pushed successfully.