### PR TITLE
fix(ci): build GhosttyKit before Release App

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -58,6 +58,19 @@ jobs:
       - name: Verify package.json version matches tag
         run: node ./scripts/verify-app-release-version.mjs "${{ steps.version.outputs.version }}"
 
+      # GhosttyKit is not in git; build:dist requires the xcframework (same as Quality Gate native).
+      - id: ghostty-kit-cache
+        uses: actions/cache@v4
+        with:
+          key: ghostty-kit-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('scripts/build-libghostty.sh', 'native/Vendor/libghostty-spm/Patches/ghostty/**') }}
+          path: native/Vendor/libghostty-spm/GhosttyKit.xcframework
+      - if: steps.ghostty-kit-cache.outputs.cache-hit != 'true'
+        run: brew install zig@0.15
+      - if: steps.ghostty-kit-cache.outputs.cache-hit != 'true'
+        run: xcrun -sdk macosx metal -v || xcodebuild -downloadComponent MetalToolchain
+      - if: steps.ghostty-kit-cache.outputs.cache-hit != 'true'
+        run: pnpm build:libghostty
+
       - name: Build, sign, notarize, and publish
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Release App CI was failing at `pnpm build:dist` with missing `GhosttyKit.xcframework` after CSC/notarize secrets were fixed.
- Add the same GhosttyKit cache + `pnpm build:libghostty` steps used by Quality Gate native job.

## Test plan
- [ ] Merge to main
- [ ] Re-run Actions → Release App → `tag=v0.1.7`
- [ ] Confirm build gets past native / into sign+notarize+publish