### PR TITLE
fix(ci): materialize App Store Connect API key for notarize

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -71,13 +71,33 @@ jobs:
       - if: steps.ghostty-kit-cache.outputs.cache-hit != 'true'
         run: pnpm build:libghostty
 
+      # @electron/notarize expects APPLE_API_KEY to be a *path* to the .p8 file,
+      # not the PEM body. Materialize the secret on the runner before build:dist.
+      - name: Materialize App Store Connect API key
+        env:
+          APPLE_API_KEY_BODY: ${{ secrets.APPLE_API_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${APPLE_API_KEY_BODY:-}" ]; then
+            echo "APPLE_API_KEY secret empty; skip materialize (keychain profile / Apple ID path may still work)"
+            exit 0
+          fi
+          KEY_PATH="${RUNNER_TEMP}/AuthKey.p8"
+          # Preserve PEM newlines from the secret body.
+          printf '%s\n' "$APPLE_API_KEY_BODY" > "$KEY_PATH"
+          chmod 600 "$KEY_PATH"
+          {
+            echo "APPLE_API_KEY=${KEY_PATH}"
+          } >> "$GITHUB_ENV"
+          echo "Wrote App Store Connect API key to ${KEY_PATH}"
+
       - name: Build, sign, notarize, and publish
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
           CSC_NAME: ${{ secrets.CSC_NAME }}
-          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          # APPLE_API_KEY path is set by the previous step via GITHUB_ENV when present.
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
           APPLE_ID: ${{ secrets.APPLE_ID }}


### PR DESCRIPTION
## Summary
- Release App signing now works with CSC_LINK.
- Notarize failed: `notarytool` got `Invalid option` because `APPLE_API_KEY` was the PEM body; it must be a path to a `.p8` file.
- Write the secret to `$RUNNER_TEMP/AuthKey.p8` and export that path.

## Test plan
- [ ] Merge
- [ ] Re-run Release App with `tag=v0.1.7`
- [ ] Confirm notarize succeeds and assets publish