### PR TITLE
chore(release): v0.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## [Unreleased]
 
+## [0.1.8] - 2026-07-26
+
 ### Added
 
 - **统一消息中心。** main 侧 NotificationCenterService 统一接收系统/后台

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pier",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Pier — 本地 AI 开发工作台（dockview panel 布局 + 终端 + 代码变更预览 + 多 agent 状态可见性）",
   "type": "module",
   "main": "out/main/index.js",


### PR DESCRIPTION
## Summary

Host-only release after #112.

- Root `package.json` → **0.1.8**
- CHANGELOG: Unreleased → `[0.1.8] - 2026-07-26`
- Plugins: no source changes since latest tags → skip

After merge, tag `v0.1.8` on main to trigger **Release App**.

## Test plan

- [ ] Quality Gate green
- [ ] After tag: Latest has `latest-mac.yml` + arm64/x64 zip + dmg