### PR TITLE
chore(release): bump plugins claude/codex/grok/ssh

### DIFF
--- a/packages/plugin-claude/package.json
+++ b/packages/plugin-claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pier/plugin-claude",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/plugin-claude/plugin.json
+++ b/packages/plugin-claude/plugin.json
@@ -268,5 +268,5 @@
     }
   ],
   "terminalStatusItems": [],
-  "version": "1.3.4"
+  "version": "1.3.5"
 }

--- a/packages/plugin-codex/package.json
+++ b/packages/plugin-codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pier/plugin-codex",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/plugin-codex/plugin.json
+++ b/packages/plugin-codex/plugin.json
@@ -235,5 +235,5 @@
     }
   ],
   "terminalStatusItems": [],
-  "version": "1.4.5"
+  "version": "1.4.6"
 }

--- a/packages/plugin-grok/package.json
+++ b/packages/plugin-grok/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pier/plugin-grok",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/plugin-grok/plugin.json
+++ b/packages/plugin-grok/plugin.json
@@ -284,5 +284,5 @@
     }
   ],
   "terminalStatusItems": [],
-  "version": "1.1.5"
+  "version": "1.1.6"
 }

--- a/packages/plugin-ssh/package.json
+++ b/packages/plugin-ssh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pier/plugin-ssh",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/plugin-ssh/plugin.json
+++ b/packages/plugin-ssh/plugin.json
@@ -137,6 +137,6 @@
     }
   ],
   "terminalStatusItems": [],
-  "version": "1.0.3",
+  "version": "1.0.4",
   "workbenchWidgets": []
 }


### PR DESCRIPTION
## Summary
- Patch-bump official managed plugins after the develop batch landed on main:
  - pier.claude 1.3.4 → **1.3.5**
  - pier.codex 1.4.5 → **1.4.6**
  - pier.grok 1.1.5 → **1.1.6**
  - pier.ssh 1.0.3 → **1.0.4**
- package.json and plugin.json versions kept in sync; Release Plugin will pack and index on merge.

## Test plan
- [ ] CI green
- [ ] Release Plugin workflow succeeds and updates plugins/index.v1.json
- [ ] Plugin tags are prerelease (not Latest)