### PR TITLE
chore(release): bump plugin-ssh to 1.0.5

### DIFF
--- a/packages/plugin-ssh/package.json
+++ b/packages/plugin-ssh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pier/plugin-ssh",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/plugin-ssh/plugin.json
+++ b/packages/plugin-ssh/plugin.json
@@ -137,6 +137,6 @@
     }
   ],
   "terminalStatusItems": [],
-  "version": "1.0.4",
+  "version": "1.0.5",
   "workbenchWidgets": []
 }


### PR DESCRIPTION
## Summary
- Patch-bump `pier.ssh` 1.0.4 → 1.0.5 so Release Plugin publishes the import-hosts scroll-fade fix from #131.
- claude / codex / grok: no package changes vs latest tags — skipped.

## Test plan
- [ ] Quality Gate green
- [ ] After merge, Release Plugin creates prerelease `plugin-ssh-v1.0.5` and updates `plugins/index.v1.json`