### PR TITLE
chore(release): bump plugin-ssh to 1.0.6

### DIFF
--- a/packages/plugin-ssh/package.json
+++ b/packages/plugin-ssh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pier/plugin-ssh",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/plugin-ssh/plugin.json
+++ b/packages/plugin-ssh/plugin.json
@@ -137,6 +137,6 @@
     }
   ],
   "terminalStatusItems": [],
-  "version": "1.0.5",
+  "version": "1.0.6",
   "workbenchWidgets": []
 }


### PR DESCRIPTION
## Summary
- Patch bump `pier.ssh` 1.0.5 → 1.0.6 for hosts snapshot cache fix merged in #134
- Triggers Release Plugin on main after merge

## Test plan
- [ ] Release Plugin workflow green
- [ ] `plugin-ssh-v1.0.6` prerelease exists (not Latest)
- [ ] Bot updates `plugins/index.v1.json` on main