### PR TITLE
chore(release): bump host to 0.1.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@
 
 ## [Unreleased]
 
+## [0.1.19] - 2026-08-07
+
+### Added
+
+- **行内审查评论。** Git 变更预览支持行内评论、漂移提示与智能体交接回路。
+- **Shell 环境与任务运行控制。** VS Code 风格 shell dump、TaskRuns 窗口归属与终端运行条右锚定。
+
+### Fixed
+
+- **Shell dump 污染与超时。** 剥离 ELECTRON_*/PIER dump 键，fallback 共享一次超时预算。
+- **后台任务可见性。** 后台任务要求 windowId，避免运行条丢失；诊断 ctx 有界。
+- **智能体探测注入。** 测试用 probe 不再被真实 PATH which 干扰。
+
 ## [0.1.18] - 2026-08-05
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pier",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "Pier — 本地 AI 开发工作台（dockview panel 布局 + 终端 + 代码变更预览 + 多 agent 状态可见性）",
   "type": "module",
   "main": "out/main/index.js",

--- a/packages/plugin-codex/package.json
+++ b/packages/plugin-codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pier/plugin-codex",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/plugin-codex/plugin.json
+++ b/packages/plugin-codex/plugin.json
@@ -249,5 +249,5 @@
     }
   ],
   "terminalStatusItems": [],
-  "version": "1.4.8"
+  "version": "1.4.9"
 }

--- a/packages/plugin-grok/package.json
+++ b/packages/plugin-grok/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pier/plugin-grok",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/plugin-grok/plugin.json
+++ b/packages/plugin-grok/plugin.json
@@ -306,5 +306,5 @@
     }
   ],
   "terminalStatusItems": [],
-  "version": "1.1.8"
+  "version": "1.1.9"
 }


### PR DESCRIPTION
## Summary

- Host **0.1.19** (CHANGELOG Unreleased → 0.1.19)
- **pier.codex** 1.4.8 → **1.4.9**
- **pier.grok** 1.1.8 → **1.1.9**
- Skip claude/ssh (no source changes since last tags)

## Test plan

- [x] Version parity package.json ↔ plugin.json
- [ ] CI Quality Gate
- After merge: Release Plugin for codex/grok; tag `v0.1.19` for host