### PR TITLE
chore(release): bump host to 0.1.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@
 
 ## [Unreleased]
 
+## [0.1.20] - 2026-08-07
+
+### Added
+
+- **节点图全屏展开。** 工作台 / 画布节点图支持展开到全屏表面，便于大图浏览。
+- **多智能体 CLI 金标画布。** 附带 multi-agent orchestration gold canvas 样例与数据。
+
+### Fixed
+
+- **差异选区复制。** Diff 字符选区与右键复制更可靠；指针命中支持 client 坐标回退。
+- **Git 工作树占用提示。** 切换分支时若目标在另一工作树，给出可读错误说明。
+- **Mermaid SVG 消毒。** 预览 SVG sanitize 收紧，降低恶意/畸形图风险。
+- **CI 覆盖率超时。** pier-canvas SDK 类型检查在 coverage job 下延长超时。
+
 ## [0.1.19] - 2026-08-07
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pier",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "description": "Pier — 本地 AI 开发工作台（dockview panel 布局 + 终端 + 代码变更预览 + 多 agent 状态可见性）",
   "type": "module",
   "main": "out/main/index.js",


### PR DESCRIPTION
## Summary
- Patch bump host to 0.1.20
- CHANGELOG: node-graph expand, multi-agent canvas gold, diff selection, worktree switch errors, mermaid sanitize

## Test plan
- [ ] CI Quality Gate green
- [ ] After merge, tag `v0.1.20` triggers Release App