### PR TITLE
chore(plugins): patch bump claude/codex/grok/ssh

### DIFF
--- a/packages/plugin-claude/package.json
+++ b/packages/plugin-claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pier/plugin-claude",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/plugin-claude/plugin.json
+++ b/packages/plugin-claude/plugin.json
@@ -288,5 +288,5 @@
     }
   ],
   "terminalStatusItems": [],
-  "version": "1.3.7"
+  "version": "1.3.8"
 }

--- a/packages/plugin-codex/package.json
+++ b/packages/plugin-codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pier/plugin-codex",
-  "version": "1.4.9",
+  "version": "1.4.10",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/plugin-codex/plugin.json
+++ b/packages/plugin-codex/plugin.json
@@ -251,5 +251,5 @@
     }
   ],
   "terminalStatusItems": [],
-  "version": "1.4.9"
+  "version": "1.4.10"
 }

--- a/packages/plugin-grok/package.json
+++ b/packages/plugin-grok/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pier/plugin-grok",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/plugin-grok/plugin.json
+++ b/packages/plugin-grok/plugin.json
@@ -308,5 +308,5 @@
     }
   ],
   "terminalStatusItems": [],
-  "version": "1.1.9"
+  "version": "1.1.10"
 }

--- a/packages/plugin-ssh/package.json
+++ b/packages/plugin-ssh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pier/plugin-ssh",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/plugin-ssh/plugin.json
+++ b/packages/plugin-ssh/plugin.json
@@ -139,6 +139,6 @@
     }
   ],
   "terminalStatusItems": [],
-  "version": "1.0.6",
+  "version": "1.0.7",
   "workbenchWidgets": []
 }


### PR DESCRIPTION
## Summary
- Patch bump official plugins after main accounts/hosts snapshot UI changes:
  - pier.claude 1.3.7 → 1.3.8
  - pier.codex 1.4.9 → 1.4.10
  - pier.grok 1.1.9 → 1.1.10
  - pier.ssh 1.0.6 → 1.0.7
- package.json and plugin.json kept in lockstep.

## Test plan
- [ ] Release Plugin workflow builds prerelease tags
- [ ] plugins/index.v1.json updated on main
- [ ] Latest remains host-only