### PR TITLE
chore(plugins): patch bump grok to 1.1.11

### DIFF
--- a/packages/plugin-grok/package.json
+++ b/packages/plugin-grok/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pier/plugin-grok",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/plugin-grok/plugin.json
+++ b/packages/plugin-grok/plugin.json
@@ -310,5 +310,5 @@
     }
   ],
   "terminalStatusItems": [],
-  "version": "1.1.10"
+  "version": "1.1.11"
 }


### PR DESCRIPTION
## Summary

- Patch bump `pier.grok` **1.1.10 → 1.1.11** after the 20260812 train (remaining-resets, usage-fetch types).
- `package.json` and `plugin.json` versions kept in lockstep.
- claude / codex / ssh unchanged vs latest tags — skipped.

## Test plan

- [ ] Quality Gate green
- [ ] Merge to main triggers Release Plugin
- [ ] `plugin-grok-v1.1.11` prerelease; Latest remains host-only
- [ ] Bot updates `plugins/index.v1.json` on main