### PR TITLE
chore(plugins): patch bump claude 1.3.9、codex 1.4.11、grok 1.1.12

### DIFF
--- a/packages/plugin-claude/package.json
+++ b/packages/plugin-claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pier/plugin-claude",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/plugin-claude/plugin.json
+++ b/packages/plugin-claude/plugin.json
@@ -288,5 +288,5 @@
     }
   ],
   "terminalStatusItems": [],
-  "version": "1.3.8"
+  "version": "1.3.9"
 }

--- a/packages/plugin-codex/package.json
+++ b/packages/plugin-codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pier/plugin-codex",
-  "version": "1.4.10",
+  "version": "1.4.11",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/plugin-codex/plugin.json
+++ b/packages/plugin-codex/plugin.json
@@ -251,5 +251,5 @@
     }
   ],
   "terminalStatusItems": [],
-  "version": "1.4.10"
+  "version": "1.4.11"
 }

--- a/packages/plugin-grok/package.json
+++ b/packages/plugin-grok/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pier/plugin-grok",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/plugin-grok/plugin.json
+++ b/packages/plugin-grok/plugin.json
@@ -310,5 +310,5 @@
     }
   ],
   "terminalStatusItems": [],
-  "version": "1.1.11"
+  "version": "1.1.12"
 }


### PR DESCRIPTION
## Summary
- 相对上一发版 tag，claude / codex / grok 有账号用量展示与 Grok 周期边界修复，按 patch 抬版本
- `package.json` 与 `plugin.json` 同步：claude 1.3.9、codex 1.4.11、grok 1.1.12
- ssh 无源码变更，本车跳过

合入 main 后由 Release Plugin 打 prerelease tag，不占 Latest。

## Test plan
- [x] 本地 pre-push 已绿
- [ ] Quality Gate CI 绿后 squash 合入
- [ ] 确认 `plugin-claude-v1.3.9` / `plugin-codex-v1.4.11` / `plugin-grok-v1.1.12` 为 prerelease


Made with [Cursor](https://cursor.com)