### PR TITLE
fix(lsp): 版本探测在截断或超时后仍返回已读到的第一行

### DIFF
--- a/src/main/services/lsp/probe-version.ts
+++ b/src/main/services/lsp/probe-version.ts
@@ -145,9 +145,19 @@ export function probeResolvedBinaryVersion(
         killProbeTree(child);
       } finally {
         releaseChild(child);
-        finish();
+        finish(collectedVersion());
       }
     }, LSP_VERSION_PROBE_TIMEOUT_MS);
+
+    const collectedVersion = (): string | undefined =>
+      parseVersionLine(Buffer.concat(stdoutChunks).toString("utf8"));
+    const finishCollected = (requireSuccess = false, code?: number) => {
+      if (requireSuccess && code !== 0) {
+        finish();
+        return;
+      }
+      finish(collectedVersion());
+    };
 
     child.stdout?.on("data", (chunk: Buffer) => {
       if (settled || byteLength >= VERSION_MAX_BYTES) {
@@ -157,6 +167,16 @@ export function probeResolvedBinaryVersion(
       const slice = chunk.length > room ? chunk.subarray(0, room) : chunk;
       stdoutChunks.push(slice);
       byteLength += slice.length;
+      if (byteLength < VERSION_MAX_BYTES) {
+        return;
+      }
+      clearTimeout(timer);
+      try {
+        killProbeTree(child);
+      } finally {
+        releaseChild(child);
+        finishCollected();
+      }
     });
     child.stderr?.resume();
     child.on("error", () => {
@@ -167,11 +187,7 @@ export function probeResolvedBinaryVersion(
     child.on("close", (code) => {
       clearTimeout(timer);
       releaseChild(child);
-      if (code !== 0) {
-        finish();
-        return;
-      }
-      finish(parseVersionLine(Buffer.concat(stdoutChunks).toString("utf8")));
+      finishCollected(true, code ?? 1);
     });
   });
 }

--- a/tests/unit/main/lsp/probe-version.test.ts
+++ b/tests/unit/main/lsp/probe-version.test.ts
@@ -114,10 +114,27 @@ describe("probeResolvedBinaryVersion", () => {
         ? `echo v1.0 ${"x".repeat(8000)}\r\nexit 0`
         : `printf 'v1.0 ${"x".repeat(8000)}\\n'\nexit 0`
     );
+    const started = Date.now();
     const version = await probeResolvedBinaryVersion(noisy);
     expect(version).toBeDefined();
     expect(version?.length).toBeLessThanOrEqual(64);
+    expect(Date.now() - started).toBeLessThan(LSP_VERSION_PROBE_TIMEOUT_MS);
   });
+
+  it("keeps the first line if the process hangs after printing", async () => {
+    const printThenHang = writeScript(
+      process.platform === "win32" ? "print-hang.cmd" : "print-hang",
+      process.platform === "win32"
+        ? "echo gopls v9.9.9\r\nping -n 30 127.0.0.1 >nul"
+        : "echo gopls v9.9.9\nexec sleep 30"
+    );
+    const started = Date.now();
+    const version = await probeResolvedBinaryVersion(printThenHang);
+    expect(version).toBe("gopls v9.9.9");
+    expect(Date.now() - started).toBeLessThan(
+      LSP_VERSION_PROBE_TIMEOUT_MS + 2000
+    );
+  }, 8000);
 
   it("times out a hanging binary without returning a version", async () => {
     const hang = writeScript(


### PR DESCRIPTION
## Summary
- `--version` 读满上限或超时时，仍返回已经读到的第一行，不再丢成 undefined
- 锁住「打印后挂起」和「超大 stdout」两条路径，避免发布推送在高负载下误红

## Test plan
- [x] `pnpm exec vitest run tests/unit/main/lsp/probe-version.test.ts`
- [x] 本地 pre-push 已绿
- [ ] Quality Gate CI 绿后 squash 合入，再打 `v0.1.28`


Made with [Cursor](https://cursor.com)