### PR TITLE
chore(plugins): patch bump claude/codex/grok/ssh

### DIFF
--- a/packages/plugin-claude/package.json
+++ b/packages/plugin-claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pier/plugin-claude",
-  "version": "1.3.9",
+  "version": "1.3.10",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/plugin-claude/plugin.json
+++ b/packages/plugin-claude/plugin.json
@@ -524,5 +524,5 @@
     }
   ],
   "terminalStatusItems": [],
-  "version": "1.3.9"
+  "version": "1.3.10"
 }

--- a/packages/plugin-codex/package.json
+++ b/packages/plugin-codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pier/plugin-codex",
-  "version": "1.4.11",
+  "version": "1.4.12",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/plugin-codex/plugin.json
+++ b/packages/plugin-codex/plugin.json
@@ -455,5 +455,5 @@
     }
   ],
   "terminalStatusItems": [],
-  "version": "1.4.11"
+  "version": "1.4.12"
 }

--- a/packages/plugin-grok/package.json
+++ b/packages/plugin-grok/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pier/plugin-grok",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/plugin-grok/plugin.json
+++ b/packages/plugin-grok/plugin.json
@@ -568,5 +568,5 @@
     }
   ],
   "terminalStatusItems": [],
-  "version": "1.1.12"
+  "version": "1.1.13"
 }

--- a/packages/plugin-ssh/package.json
+++ b/packages/plugin-ssh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pier/plugin-ssh",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/plugin-ssh/plugin.json
+++ b/packages/plugin-ssh/plugin.json
@@ -251,6 +251,6 @@
     }
   ],
   "terminalStatusItems": [],
-  "version": "1.0.7",
+  "version": "1.0.8",
   "workbenchWidgets": []
 }


### PR DESCRIPTION
## Why
`/publish-project` 阶段 B：相对最近 `plugin-*-v*` tag，四个官方插件都有源码变更（plugin.json 日韩文案；ssh 另有 hosts TERM），需要 patch 发版。

## Versions
- pier.claude 1.3.9 → 1.3.10
- pier.codex 1.4.11 → 1.4.12
- pier.grok 1.1.12 → 1.1.13
- pier.ssh 1.0.7 → 1.0.8

合入 main 后由 Release Plugin 打 prerelease tag。