### PR TITLE
feat: 智能体一键安装与账号重置次数展示

### DIFF
--- a/packages/plugin-api/src/main.ts
+++ b/packages/plugin-api/src/main.ts
@@ -13,8 +13,31 @@ export interface PluginConfigurationApi {
   set(key: string, value: unknown): Promise<void>;
 }
 
+export interface DocumentOriginFetchRequest {
+  body?: Uint8Array;
+  headers?: Record<string, string>;
+  method?: "GET" | "POST";
+  origin: string;
+  signal?: AbortSignal;
+  url: string;
+}
+
+export interface DocumentOriginFetchResult {
+  body: Uint8Array;
+  ok: boolean;
+  status: number;
+}
+
 export interface MainPluginContext {
   configuration: PluginConfigurationApi;
+  /**
+   * Fetch `url` as a first-party document of `origin`. Host-owned: plugins
+   * must not import Electron. The host allowlists origins, requires https
+   * same-origin URLs, and honors `signal`.
+   */
+  documentOriginFetch?(
+    request: DocumentOriginFetchRequest
+  ): Promise<DocumentOriginFetchResult>;
   events: {
     emit(event: string, payload: unknown): void;
   };

--- a/packages/plugin-codex/src/main/codex-reset-credits.ts
+++ b/packages/plugin-codex/src/main/codex-reset-credits.ts
@@ -1,0 +1,134 @@
+import type { AccountUsageMetric } from "@pier/plugin-api/account-usage";
+import {
+  createTimeoutSignal,
+  mergeAbortSignals,
+} from "@pier/plugin-api/account-usage";
+
+export const CODEX_RESET_CREDITS_METRIC_ID = "codex:reset-credits";
+export const CODEX_RESET_CREDITS_URL =
+  "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits";
+
+const RESET_CREDITS_TIMEOUT_MS = 8000;
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function asNonNegativeInt(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 0) {
+    return;
+  }
+  return value;
+}
+
+function nestedResetCredits(
+  root: Record<string, unknown>
+): Record<string, unknown> | null {
+  return (
+    asRecord(root.data) ??
+    asRecord(root.rate_limit_reset_credits) ??
+    asRecord(root.rateLimitResetCredits)
+  );
+}
+
+function creditsList(source: Record<string, unknown>): unknown {
+  return source.credits;
+}
+
+function availableCountFromRecord(
+  source: Record<string, unknown>
+): number | undefined {
+  const direct = asNonNegativeInt(
+    source.availableCount ?? source.available_count
+  );
+  if (direct !== undefined) {
+    return direct;
+  }
+  const credits = creditsList(source);
+  if (!Array.isArray(credits)) {
+    return;
+  }
+  let count = 0;
+  for (const item of credits) {
+    const row = asRecord(item);
+    if (row?.status === "available") {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+/** Map /wham/rate-limit-reset-credits JSON into the shared scalar metric. */
+export function parseCodexResetCredits(payload: unknown): AccountUsageMetric[] {
+  const root = asRecord(payload);
+  if (!root) {
+    return [];
+  }
+  const nested = nestedResetCredits(root);
+  const sources = nested ? [root, nested] : [root];
+  for (const source of sources) {
+    const count = availableCountFromRecord(source);
+    if (count !== undefined && count > 0) {
+      return [
+        {
+          format: "count",
+          id: CODEX_RESET_CREDITS_METRIC_ID,
+          kind: "scalar",
+          value: count,
+        },
+      ];
+    }
+    if (count === 0) {
+      return [];
+    }
+  }
+  return [];
+}
+
+export function mergeResetCreditMetrics(
+  metrics: readonly AccountUsageMetric[],
+  extra: readonly AccountUsageMetric[]
+): AccountUsageMetric[] {
+  if (extra.length === 0) {
+    return [...metrics];
+  }
+  if (metrics.some((metric) => metric.id === CODEX_RESET_CREDITS_METRIC_ID)) {
+    return [...metrics];
+  }
+  return [...metrics, ...extra];
+}
+
+/** Best-effort companion to /wham/usage. 429 / missing field must not poison quota. */
+export async function fetchCodexResetCreditsSoft(options: {
+  accessToken: string;
+  accountId: string;
+  fetchImpl: typeof fetch;
+  signal: AbortSignal;
+}): Promise<AccountUsageMetric[]> {
+  try {
+    const response = await options.fetchImpl(CODEX_RESET_CREDITS_URL, {
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${options.accessToken}`,
+        "OAI-Product-Sku": "CODEX",
+        ...(options.accountId.length > 0
+          ? { "ChatGPT-Account-Id": options.accountId }
+          : {}),
+      },
+      method: "GET",
+      signal: mergeAbortSignals([
+        options.signal,
+        createTimeoutSignal(RESET_CREDITS_TIMEOUT_MS),
+      ]),
+    });
+    if (!response.ok || options.signal.aborted) {
+      return [];
+    }
+    return parseCodexResetCredits(JSON.parse(await response.text()));
+  } catch {
+    return [];
+  }
+}

--- a/packages/plugin-codex/src/main/codex-usage-http.ts
+++ b/packages/plugin-codex/src/main/codex-usage-http.ts
@@ -1,7 +1,4 @@
-import type {
-  AccountUsageMetric,
-  AccountUsageQuotaMetric,
-} from "@pier/plugin-api/account-usage";
+import type { AccountUsageQuotaMetric } from "@pier/plugin-api/account-usage";
 import {
   createTimeoutSignal,
   mergeAbortSignals,
@@ -11,6 +8,11 @@ import {
   parseCodexAccountCheckMembership,
   parseCodexSubscriptionsMembership,
 } from "./codex-membership.ts";
+import {
+  fetchCodexResetCreditsSoft,
+  mergeResetCreditMetrics,
+  parseCodexResetCredits,
+} from "./codex-reset-credits.ts";
 import {
   extractAccountIdFromAccessToken,
   parseCodexAuthJsonTokens,
@@ -258,21 +260,10 @@ export function parseWhamUsageResult(json: unknown): AccountUsageResult {
     );
   }
 
-  const availableCount = data.rate_limit_reset_credits?.available_count;
-  // 0 表示没有可用重置次数：不进指标列表，避免 UI 展示「额度重置次数 0」
-  if (
-    typeof availableCount === "number" &&
-    Number.isInteger(availableCount) &&
-    availableCount > 0
-  ) {
-    const resetCredits: AccountUsageMetric = {
-      format: "count",
-      id: "codex:reset-credits",
-      kind: "scalar",
-      value: availableCount,
-    };
-    out.metrics.push(resetCredits);
-  }
+  out.metrics = mergeResetCreditMetrics(
+    out.metrics,
+    parseCodexResetCredits(json)
+  );
 
   if (out.metrics.length === 0) {
     return {
@@ -374,7 +365,18 @@ export async function fetchCodexUsageHttp(
       };
     }
     const result = parseWhamUsageResult(json);
-    if (result.status !== "ok" || accountId.length === 0) return result;
+    if (result.status !== "ok") return result;
+    const resetCredits = await fetchCodexResetCreditsSoft({
+      accessToken,
+      accountId,
+      fetchImpl,
+      signal: requestSignal,
+    });
+    const withCredits = {
+      ...result,
+      metrics: mergeResetCreditMetrics(result.metrics, resetCredits),
+    };
+    if (accountId.length === 0) return withCredits;
     const membership = await fetchCodexMembershipSoft({
       accessToken,
       accountId,
@@ -383,14 +385,14 @@ export async function fetchCodexUsageHttp(
     });
     return membership
       ? {
-          ...result,
+          ...withCredits,
           membershipResolved: true,
           planType: membership.planType,
           ...(membership.expiresAt === undefined
             ? {}
             : { subscriptionExpiresAt: membership.expiresAt }),
         }
-      : result;
+      : withCredits;
   } catch (error) {
     if (options.signal.aborted) {
       return { status: "error", error: "Aborted", metrics: [] };

--- a/packages/plugin-codex/src/main/rate-limits.ts
+++ b/packages/plugin-codex/src/main/rate-limits.ts
@@ -1,7 +1,8 @@
-import type {
-  AccountUsageMetric,
-  AccountUsageQuotaMetric,
-} from "@pier/plugin-api/account-usage";
+import type { AccountUsageQuotaMetric } from "@pier/plugin-api/account-usage";
+import {
+  mergeResetCreditMetrics,
+  parseCodexResetCredits,
+} from "./codex-reset-credits.ts";
 import type { AccountUsageResult } from "./types.ts";
 
 interface RpcWindow {
@@ -112,24 +113,8 @@ export function parseRateLimitsResult(result: unknown): AccountUsageResult {
   if (typeof planTypeCandidate === "string" && planTypeCandidate.length > 0) {
     out.planType = planTypeCandidate;
   }
-  let resetCreditsMetric: AccountUsageMetric | undefined;
-  const resetCredits = rl.rateLimitResetCredits ?? obj.rateLimitResetCredits;
-  if (resetCredits && typeof resetCredits === "object") {
-    const available = (resetCredits as Record<string, unknown>).availableCount;
-    // 0 表示没有可用重置次数：不进指标列表，避免 UI 展示「额度重置次数 0」
-    if (
-      typeof available === "number" &&
-      Number.isInteger(available) &&
-      available > 0
-    ) {
-      resetCreditsMetric = {
-        format: "count",
-        id: "codex:reset-credits",
-        kind: "scalar",
-        value: available,
-      };
-    }
-  }
+  const resetCreditsMetric =
+    parseCodexResetCredits(obj)[0] ?? parseCodexResetCredits(rl)[0];
   if (hasMultiBucketView) {
     const preferredLimitId =
       typeof rl.limitId === "string" && rl.limitId.length > 0
@@ -205,7 +190,7 @@ export function parseRateLimitsResult(result: unknown): AccountUsageResult {
     };
   }
   if (resetCreditsMetric) {
-    out.metrics.push(resetCreditsMetric);
+    out.metrics = mergeResetCreditMetrics(out.metrics, [resetCreditsMetric]);
   }
   return out;
 }

--- a/packages/plugin-grok/src/main/accounts-usage.ts
+++ b/packages/plugin-grok/src/main/accounts-usage.ts
@@ -4,6 +4,7 @@ import {
   type UsageCacheEntryBase,
 } from "@pier/plugin-api/account-usage";
 import type { GrokUsageSnapshot } from "../shared/accounts.ts";
+import { GROK_RESET_CREDITS_METRIC_ID } from "./reset-credits.ts";
 import type { GrokSubscriptionInfo } from "./subscription-parse.ts";
 import type { AccountUsageResult } from "./types.ts";
 
@@ -37,9 +38,15 @@ export function createUsageCacheEntry(
 }
 
 export function toUsageSnapshot(entry: UsageCacheEntry): GrokUsageSnapshot {
+  const metrics =
+    entry.status === "error"
+      ? entry.metrics.filter(
+          (metric) => metric.id !== GROK_RESET_CREDITS_METRIC_ID
+        )
+      : entry.metrics;
   return {
     attemptedAt: entry.attemptedAt,
-    metrics: entry.metrics,
+    metrics,
     status: entry.status,
     ...(entry.updatedAt === undefined ? {} : { updatedAt: entry.updatedAt }),
     ...(entry.error ? { error: entry.error } : {}),

--- a/packages/plugin-grok/src/main/grok-provider.ts
+++ b/packages/plugin-grok/src/main/grok-provider.ts
@@ -7,9 +7,12 @@ import {
   fetchGrokUsage,
   USAGE_TEMPORARILY_UNAVAILABLE_ERROR,
 } from "./grok-usage.ts";
+import {
+  originFetchOption,
+  type RemainingResetsOriginFetch,
+} from "./grok-usage-types.ts";
 import type { AccountIdentity } from "./identity.ts";
 import { parseGrokAuthJson, readGrokIdentity } from "./identity.ts";
-// Class A: login spawn uses hostSpawnEnv / resolveProcessEnv (not bare process.env).
 import {
   defaultRealGrokHome,
   defaultSpawnLogin,
@@ -28,6 +31,7 @@ export interface CreateGrokProviderOpts {
   logger?: { warn(message: string, ...args: unknown[]): void };
   processEnv?: Readonly<Record<string, string | undefined>>;
   realGrokHome?: string;
+  remainingResetsOriginFetch?: RemainingResetsOriginFetch;
   resolveProcessEnv?: (request?: {
     cwd?: string;
   }) => Promise<{ env: Record<string, string> }>;
@@ -48,7 +52,6 @@ export interface GrokAccountProvider {
   fetchUsage(options: {
     accountHomeDir?: string | undefined;
     kind: "api_key" | "oidc";
-    /** Fires after OIDC session persisted; mirror tokens to real Grok home. */
     onSessionRefreshed?: ((authJson: string) => Promise<void>) | undefined;
     signal: AbortSignal;
   }): Promise<AccountUsageResult>;
@@ -94,6 +97,7 @@ export function createGrokProvider(
   const realGrokHome = opts.realGrokHome ?? defaultRealGrokHome(processEnv);
   const spawnLogin = opts.spawnLogin ?? defaultSpawnLogin;
   const fetchImpl = opts.fetchImpl;
+  const remainingResetsOriginFetch = opts.remainingResetsOriginFetch;
   const credentials = opts.credentials;
   const logger = opts.logger;
   const credentialTails = new Map<string, Promise<void>>();
@@ -358,9 +362,7 @@ export function createGrokProvider(
           readManagedAuth(accountHomeDir)
         );
       } catch (error) {
-        // ENOENT means there are genuinely no stored credentials (re-login
-        // path below). Any other read failure (safeStorage locked, store IO)
-        // is transient — the session may be perfectly healthy.
+        // ENOENT: no stored credentials. Other read failures are transient.
         if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
           return {
             status: "error",
@@ -375,14 +377,13 @@ export function createGrokProvider(
         authJson,
         kind: "oidc",
         signal: options.signal,
+        ...originFetchOption(remainingResetsOriginFetch),
         onAuthJsonUpdated: async (nextAuthJson) => {
           await withCredentialLock(accountHomeDir, async () => {
             await credentials.set(credentialKey(accountHomeDir), nextAuthJson);
             await rm(join(accountHomeDir, "auth.json"), { force: true });
           });
-          // Mirror rotated tokens into the real Grok home when the caller
-          // owns the active account; a single-use rotated refresh token that
-          // only lives in the plugin store would strand the CLI's own copy.
+          // Mirror rotated tokens into the real Grok home for the active CLI copy.
           await options.onSessionRefreshed?.(nextAuthJson);
         },
         ...(fetchImpl ? { fetchImpl } : {}),

--- a/packages/plugin-grok/src/main/grok-provider.ts
+++ b/packages/plugin-grok/src/main/grok-provider.ts
@@ -13,6 +13,7 @@ import {
 } from "./grok-usage-types.ts";
 import type { AccountIdentity } from "./identity.ts";
 import { parseGrokAuthJson, readGrokIdentity } from "./identity.ts";
+// Class A: login spawn uses resolveProcessEnv, not bare process.env.
 import {
   defaultRealGrokHome,
   defaultSpawnLogin,

--- a/packages/plugin-grok/src/main/grok-usage-types.ts
+++ b/packages/plugin-grok/src/main/grok-usage-types.ts
@@ -1,3 +1,5 @@
+import type { AccountUsageMetric } from "@pier/plugin-api/account-usage";
+
 export type FetchImpl = (
   input: string,
   init?: {
@@ -12,6 +14,18 @@ export type FetchImpl = (
   status: number;
   text(): Promise<string>;
 }>;
+
+export type RemainingResetsOriginFetch = (request: {
+  sessionKey: string;
+  signal: AbortSignal;
+  userId?: string | null;
+}) => Promise<AccountUsageMetric[]>;
+
+export function originFetchOption(
+  remainingResetsOriginFetch: RemainingResetsOriginFetch | undefined
+): { remainingResetsOriginFetch?: RemainingResetsOriginFetch } {
+  return remainingResetsOriginFetch ? { remainingResetsOriginFetch } : {};
+}
 
 export function resolveFetchImpl(fetchImpl?: FetchImpl): FetchImpl {
   return fetchImpl ?? (globalThis.fetch as unknown as FetchImpl);

--- a/packages/plugin-grok/src/main/grok-usage.ts
+++ b/packages/plugin-grok/src/main/grok-usage.ts
@@ -4,7 +4,12 @@ import {
   isAuthFailureMessage,
 } from "./billing-http-error.ts";
 import { parseGrokBillingResult } from "./billing-parse.ts";
-import { type FetchImpl, resolveFetchImpl } from "./grok-usage-types.ts";
+import {
+  type FetchImpl,
+  originFetchOption,
+  type RemainingResetsOriginFetch,
+  resolveFetchImpl,
+} from "./grok-usage-types.ts";
 import {
   accessTokenExpired,
   extractSessionKeyFromAuthJson,
@@ -97,6 +102,7 @@ export async function fetchGrokUsage(options: {
   kind: "api_key" | "oidc";
   fetchImpl?: FetchImpl;
   onAuthJsonUpdated?: (authJson: string) => Promise<void> | void;
+  remainingResetsOriginFetch?: RemainingResetsOriginFetch;
   signal: AbortSignal;
 }): Promise<AccountUsageResult> {
   if (options.kind === "api_key") {
@@ -132,6 +138,7 @@ export async function fetchGrokUsage(options: {
       fetchGrokUsageAttempt({
         authJson,
         ...(options.fetchImpl ? { fetchImpl: options.fetchImpl } : {}),
+        ...originFetchOption(options.remainingResetsOriginFetch),
         onAuthJsonUpdated,
         overallDeadlineMs: isRetry
           ? USAGE_RETRY_OVERALL_DEADLINE_MS
@@ -154,6 +161,7 @@ export async function fetchGrokUsage(options: {
       overall: null,
       sessionKey: latestSessionKey,
       userId: userIdFromEntry(selectOidcAuthEntry(authJson)?.entry),
+      ...originFetchOption(options.remainingResetsOriginFetch),
     });
   }
   return result;
@@ -163,6 +171,7 @@ async function fetchGrokUsageAttempt(options: {
   fetchImpl?: FetchImpl;
   onAuthJsonUpdated?: (authJson: string) => Promise<void> | void;
   overallDeadlineMs: number;
+  remainingResetsOriginFetch?: RemainingResetsOriginFetch;
   signal: AbortSignal;
 }): Promise<AccountUsageResult> {
   let authJson = options.authJson;
@@ -407,6 +416,7 @@ async function fetchGrokUsageAttempt(options: {
         overall: null,
         sessionKey,
         userId: userIdFromEntry(selected?.entry),
+        ...originFetchOption(options.remainingResetsOriginFetch),
       });
     }
     if (
@@ -439,6 +449,7 @@ async function fetchGrokUsageAttempt(options: {
           overall: null,
           sessionKey,
           userId: userIdFromEntry(selected?.entry),
+          ...originFetchOption(options.remainingResetsOriginFetch),
         });
       }
       if (
@@ -462,6 +473,7 @@ async function fetchGrokUsageAttempt(options: {
         overall: null,
         sessionKey,
         userId: userIdFromEntry(selected?.entry),
+        ...originFetchOption(options.remainingResetsOriginFetch),
       });
     }
     return softenEmptyQuotaResult(

--- a/packages/plugin-grok/src/main/index.ts
+++ b/packages/plugin-grok/src/main/index.ts
@@ -4,6 +4,8 @@ import { createUsagePollingRegistry } from "@pier/plugin-api/account-usage";
 import type { MainPluginModule } from "@pier/plugin-api/main";
 import { createGrokAccountsService } from "./accounts-service.ts";
 import { createGrokProvider } from "./grok-provider.ts";
+import { originFetchOption } from "./grok-usage-types.ts";
+import { createRemainingResetsOriginFetch } from "./reset-credits-fetch.ts";
 import { registerGrokRpcHandlers } from "./rpc-handlers.ts";
 import { createGrokAccountsStateStore } from "./state.ts";
 
@@ -23,6 +25,11 @@ export const plugin: MainPluginModule = {
       ...(context.resolveUserCommand
         ? { resolveUserCommand: context.resolveUserCommand }
         : {}),
+      ...originFetchOption(
+        context.documentOriginFetch
+          ? createRemainingResetsOriginFetch(context.documentOriginFetch)
+          : undefined
+      ),
       realGrokHome:
         context.processEnv.GROK_HOME ??
         process.env.GROK_HOME ??

--- a/packages/plugin-grok/src/main/reset-credits-fetch.ts
+++ b/packages/plugin-grok/src/main/reset-credits-fetch.ts
@@ -1,0 +1,125 @@
+import type { AccountUsageMetric } from "@pier/plugin-api/account-usage";
+import type {
+  DocumentOriginFetchRequest,
+  DocumentOriginFetchResult,
+} from "@pier/plugin-api/main";
+import type {
+  FetchImpl,
+  RemainingResetsOriginFetch,
+} from "./grok-usage-types.ts";
+import {
+  GROK_REMAINING_RESETS_REQUEST_BODY,
+  GROK_REMAINING_RESETS_URL,
+  parseGrokRemainingResetsRpcResult,
+} from "./reset-credits.ts";
+import {
+  createTimeoutSignal,
+  mergeAbortSignals,
+} from "./usage-fetch-timeouts.ts";
+
+const CLI_USER_AGENT = "grok-cli/1.0.0";
+const REMAINING_RESETS_HOP_TIMEOUT_MS = 8000;
+const REMAINING_RESETS_ORIGIN = "https://grok.com/";
+
+function remainingResetsHeaders(
+  sessionKey: string,
+  userId: string | null | undefined,
+  extra?: Record<string, string>
+): Record<string, string> {
+  return {
+    Accept: "application/grpc-web+proto",
+    Authorization: `Bearer ${sessionKey}`,
+    "Content-Type": "application/grpc-web+proto",
+    "x-grpc-web": "1",
+    "x-grok-client-mode": "cli",
+    "x-xai-token-auth": "xai-grok-cli",
+    ...(userId ? { "x-userid": userId } : {}),
+    ...extra,
+  };
+}
+
+export function createRemainingResetsOriginFetch(
+  documentOriginFetch: (
+    request: DocumentOriginFetchRequest
+  ) => Promise<DocumentOriginFetchResult>
+): RemainingResetsOriginFetch {
+  return async (request) => {
+    try {
+      const result = await documentOriginFetch({
+        body: GROK_REMAINING_RESETS_REQUEST_BODY,
+        headers: remainingResetsHeaders(request.sessionKey, request.userId),
+        method: "POST",
+        origin: REMAINING_RESETS_ORIGIN,
+        signal: mergeAbortSignals([
+          request.signal,
+          createTimeoutSignal(REMAINING_RESETS_HOP_TIMEOUT_MS),
+        ]),
+        url: GROK_REMAINING_RESETS_URL,
+      });
+      if (!result.ok) return [];
+      return parseGrokRemainingResetsRpcResult(result.body).metrics;
+    } catch {
+      return [];
+    }
+  };
+}
+
+async function metricsFromHttpResponse(response: {
+  arrayBuffer?: () => Promise<ArrayBuffer>;
+  ok: boolean;
+  text(): Promise<string>;
+}): Promise<AccountUsageMetric[] | undefined> {
+  if (!response.ok) return;
+  if (typeof response.arrayBuffer === "function") {
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    if (bytes.length > 0) {
+      const parsed = parseGrokRemainingResetsRpcResult(bytes);
+      return parsed.valid ? parsed.metrics : undefined;
+    }
+  }
+  const parsed = parseGrokRemainingResetsRpcResult(await response.text());
+  return parsed.valid ? parsed.metrics : undefined;
+}
+
+export async function fetchGrokRemainingResetsSoft(options: {
+  fetchImpl: FetchImpl;
+  originFetch?: RemainingResetsOriginFetch;
+  sessionKey: string;
+  signal: AbortSignal;
+  userId?: string | null;
+}): Promise<AccountUsageMetric[]> {
+  const request = {
+    sessionKey: options.sessionKey,
+    signal: options.signal,
+    ...(options.userId ? { userId: options.userId } : {}),
+  };
+  try {
+    const response = await options.fetchImpl(GROK_REMAINING_RESETS_URL, {
+      body: GROK_REMAINING_RESETS_REQUEST_BODY,
+      headers: remainingResetsHeaders(options.sessionKey, options.userId, {
+        Origin: "https://grok.com",
+        Referer: "https://grok.com/",
+        "User-Agent": CLI_USER_AGENT,
+      }),
+      method: "POST",
+      signal: mergeAbortSignals([
+        options.signal,
+        createTimeoutSignal(REMAINING_RESETS_HOP_TIMEOUT_MS),
+      ]),
+    });
+    if (!options.signal.aborted) {
+      const metrics = await metricsFromHttpResponse(response);
+      if (metrics) return metrics;
+    }
+  } catch {
+    // Cloudflare HTML / transport: fall through to grok.com origin fetch.
+  }
+  if (options.signal.aborted || !options.originFetch) {
+    return [];
+  }
+  try {
+    return await options.originFetch(request);
+  } catch {
+    return [];
+  }
+}

--- a/packages/plugin-grok/src/main/reset-credits.ts
+++ b/packages/plugin-grok/src/main/reset-credits.ts
@@ -1,11 +1,15 @@
 import type { AccountUsageMetric } from "@pier/plugin-api/account-usage";
-import type { FetchImpl } from "./grok-usage-types.ts";
-import {
-  createTimeoutSignal,
-  mergeAbortSignals,
-} from "./usage-fetch-timeouts.ts";
 
 export const GROK_RESET_CREDITS_METRIC_ID = "grok:reset-credits";
+
+interface RemainingResetsParseResult {
+  metrics: AccountUsageMetric[];
+  valid: boolean;
+}
+
+function invalidRemainingResets(): RemainingResetsParseResult {
+  return { metrics: [], valid: false };
+}
 
 /** Official ConsumerUi remaining-resets RPC (grpc-web). */
 export const GROK_REMAINING_RESETS_URL =
@@ -16,9 +20,6 @@ export const GROK_REMAINING_RESETS_REQUEST_BODY = new Uint8Array([
   0, 0, 0, 0, 0,
 ]);
 
-const CLI_USER_AGENT = "grok-cli/1.0.0";
-const REMAINING_RESETS_HOP_TIMEOUT_MS = 8000;
-
 function asRecord(value: unknown): Record<string, unknown> | null {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
     return null;
@@ -26,8 +27,8 @@ function asRecord(value: unknown): Record<string, unknown> | null {
   return value as Record<string, unknown>;
 }
 
-function asPositiveInt(value: unknown): number | undefined {
-  if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
+function asNonNegativeInt(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 0) {
     return;
   }
   return value;
@@ -110,7 +111,7 @@ function tokensFromRecord(root: Record<string, unknown>): unknown {
 function availableCountFromRecord(
   root: Record<string, unknown>
 ): number | undefined {
-  const direct = asPositiveInt(
+  const direct = asNonNegativeInt(
     root.availableCount ?? root.available_count ?? root.resetCount
   );
   if (direct !== undefined) return direct;
@@ -123,7 +124,7 @@ function availableCountFromRecord(
     "remaining_resets",
   ]) {
     const nested = asRecord(root[key]);
-    const count = asPositiveInt(
+    const count = asNonNegativeInt(
       nested?.availableCount ?? nested?.available_count
     );
     if (count !== undefined) return count;
@@ -131,8 +132,12 @@ function availableCountFromRecord(
   return;
 }
 
-function parseJsonResets(payload: unknown, now: number): AccountUsageMetric[] {
+function parseJsonResets(
+  payload: unknown,
+  now: number
+): RemainingResetsParseResult | null {
   const root = asRecord(payload);
+  if (!root) return null;
   const config = asRecord(root?.config);
   const sources = [root, config].filter(
     (value): value is Record<string, unknown> => value !== null
@@ -140,12 +145,17 @@ function parseJsonResets(payload: unknown, now: number): AccountUsageMetric[] {
   for (const source of sources) {
     const tokens = tokensFromRecord(source);
     if (tokens !== undefined) {
-      return metricFromCount(countValidTokens(tokens, now));
+      return {
+        metrics: metricFromCount(countValidTokens(tokens, now)),
+        valid: true,
+      };
     }
     const available = availableCountFromRecord(source);
-    if (available !== undefined) return metricFromCount(available);
+    if (available !== undefined) {
+      return { metrics: metricFromCount(available), valid: true };
+    }
   }
-  return [];
+  return null;
 }
 
 function decodeBase64(value: string): Uint8Array | undefined {
@@ -268,38 +278,60 @@ function parseResetTokenProto(
 function parseRemainingResetsProto(
   bytes: Uint8Array,
   now: number
-): AccountUsageMetric[] {
+): { metrics: AccountUsageMetric[]; valid: boolean } {
   let offset = 0;
   const tokens: Array<{ tokenId: string; validityEnd: number }> = [];
   while (offset < bytes.length) {
     const key = readVarint(bytes, offset);
-    if (!key) return [];
+    if (!key) return { metrics: [], valid: false };
     const { field, wire } = protoField(key.value);
     if (wire !== 2) {
       const skipped = skipProtoField(bytes, key.offset, wire);
-      if (!skipped) return [];
+      if (!skipped) return { metrics: [], valid: false };
       offset = skipped;
       continue;
     }
     const nested = readLengthDelimited(bytes, key.offset);
-    if (!nested) return [];
+    if (!nested) return { metrics: [], valid: false };
     offset = nested.offset;
     if (field === 10) {
       const token = parseResetTokenProto(nested.value);
       if (token) tokens.push(token);
     }
   }
-  return metricFromCount(countValidTokens(tokens, now));
+  return {
+    metrics: metricFromCount(countValidTokens(tokens, now)),
+    valid: true,
+  };
+}
+
+function grpcStatusFromTrailer(bytes: Uint8Array): number | undefined {
+  const trailer = new TextDecoder().decode(bytes);
+  const match = trailer.match(/(?:^|\r?\n)grpc-status:\s*(\d+)(?:\r?\n|$)/i);
+  if (!match?.[1]) return;
+  const status = Number(match[1]);
+  return Number.isInteger(status) ? status : undefined;
 }
 
 function parseGrpcWebBinary(
   bytes: Uint8Array,
   now: number
-): AccountUsageMetric[] {
+): RemainingResetsParseResult | null {
   let offset = 0;
+  let metrics: AccountUsageMetric[] = [];
+  let sawData = false;
+  let sawFrame = false;
+  let sawTrailer = false;
+  let trailerStatus: number | undefined;
   while (offset + 5 <= bytes.length) {
     const flag = bytes[offset];
-    if (flag === undefined) return [];
+    if (flag === undefined) {
+      return sawFrame ? invalidRemainingResets() : null;
+    }
+    if (flag !== 0 && flag !== 128) {
+      return sawFrame ? invalidRemainingResets() : null;
+    }
+    sawFrame = true;
     const length = new DataView(
       bytes.buffer,
       bytes.byteOffset + offset + 1,
@@ -307,25 +339,57 @@ function parseGrpcWebBinary(
     ).getUint32(0);
     const start = offset + 5;
     const end = start + length;
-    if (length < 0 || end > bytes.length) return [];
-    if (flag < 128 && length > 0) {
+    if (end > bytes.length) return invalidRemainingResets();
+    if (flag === 0) {
+      sawData = true;
       const parsed = parseRemainingResetsProto(bytes.subarray(start, end), now);
-      if (parsed.length > 0) return parsed;
+      if (!parsed.valid) return invalidRemainingResets();
+      if (parsed.metrics.length > 0) metrics = parsed.metrics;
+    } else {
+      if (sawTrailer || end !== bytes.length) {
+        return invalidRemainingResets();
+      }
+      sawTrailer = true;
+      trailerStatus = grpcStatusFromTrailer(bytes.subarray(start, end));
+      if (trailerStatus === undefined) return invalidRemainingResets();
     }
     offset = end;
   }
-  return [];
+  if (!sawFrame) return null;
+  if (
+    offset !== bytes.length ||
+    !sawData ||
+    !sawTrailer ||
+    trailerStatus !== 0
+  ) {
+    return invalidRemainingResets();
+  }
+  return { metrics, valid: true };
 }
 
-function parseGrpcWebText(text: string, now: number): AccountUsageMetric[] {
-  const frames = text.match(/[A-Za-z0-9+/]+={0,2}/g) ?? [];
+function parseGrpcWebText(
+  text: string,
+  now: number
+): RemainingResetsParseResult | null {
+  const compact = text.replace(/\s+/g, "");
+  const frames = compact.match(/[A-Za-z0-9+/]+={0,2}/g) ?? [];
+  if (frames.join("") !== compact) return null;
+  const chunks: Uint8Array[] = [];
+  let totalLength = 0;
   for (const frame of frames) {
     const bytes = decodeBase64(frame);
-    if (!bytes || bytes.length < 5) continue;
-    const parsed = parseGrpcWebBinary(bytes, now);
-    if (parsed.length > 0) return parsed;
+    if (!bytes) return null;
+    chunks.push(bytes);
+    totalLength += bytes.length;
   }
-  return [];
+  if (chunks.length === 0) return null;
+  const bytes = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return parseGrpcWebBinary(bytes, now);
 }
 
 /**
@@ -333,63 +397,52 @@ function parseGrpcWebText(text: string, now: number): AccountUsageMetric[] {
  * grpc-web+proto into a Codex-shaped reset-credits scalar. Zero / expired
  * tokens stay off the metric list.
  */
-export function parseGrokRemainingResets(
+function parseGrokRemainingResetsResult(
   payload: unknown,
   now = Date.now()
-): AccountUsageMetric[] {
+): RemainingResetsParseResult {
   if (payload instanceof Uint8Array) {
     const fromBinary = parseGrpcWebBinary(payload, now);
-    if (fromBinary.length > 0) return fromBinary;
-    return parseGrokRemainingResets(new TextDecoder().decode(payload), now);
+    if (fromBinary) return fromBinary;
+    return parseGrokRemainingResetsResult(
+      new TextDecoder().decode(payload),
+      now
+    );
   }
   if (typeof payload === "string") {
     const trimmed = payload.trim();
     if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
       try {
-        return parseJsonResets(JSON.parse(trimmed), now);
+        return (
+          parseJsonResets(JSON.parse(trimmed), now) ?? invalidRemainingResets()
+        );
       } catch {
-        return [];
+        return invalidRemainingResets();
       }
     }
-    return parseGrpcWebText(trimmed, now);
+    return parseGrpcWebText(trimmed, now) ?? invalidRemainingResets();
   }
-  return parseJsonResets(payload, now);
+  return parseJsonResets(payload, now) ?? invalidRemainingResets();
 }
 
-export async function fetchGrokRemainingResetsSoft(options: {
-  fetchImpl: FetchImpl;
-  sessionKey: string;
-  signal: AbortSignal;
-  userId?: string | null;
-}): Promise<AccountUsageMetric[]> {
-  try {
-    const response = await options.fetchImpl(GROK_REMAINING_RESETS_URL, {
-      body: GROK_REMAINING_RESETS_REQUEST_BODY,
-      headers: {
-        Accept: "application/grpc-web+proto",
-        Authorization: `Bearer ${options.sessionKey}`,
-        "Content-Type": "application/grpc-web+proto",
-        "User-Agent": CLI_USER_AGENT,
-        "x-grpc-web": "1",
-        "x-grok-client-mode": "cli",
-        "x-xai-token-auth": "xai-grok-cli",
-        ...(options.userId ? { "x-userid": options.userId } : {}),
-      },
-      method: "POST",
-      signal: mergeAbortSignals([
-        options.signal,
-        createTimeoutSignal(REMAINING_RESETS_HOP_TIMEOUT_MS),
-      ]),
-    });
-    if (!response.ok || options.signal.aborted) return [];
-    if (typeof response.arrayBuffer === "function") {
-      const bytes = new Uint8Array(await response.arrayBuffer());
-      if (bytes.length > 0) {
-        return parseGrokRemainingResets(bytes);
-      }
-    }
-    return parseGrokRemainingResets(await response.text());
-  } catch {
-    return [];
+export function parseGrokRemainingResetsRpcResult(
+  payload: string | Uint8Array,
+  now = Date.now()
+): RemainingResetsParseResult {
+  if (payload instanceof Uint8Array) {
+    const fromBinary = parseGrpcWebBinary(payload, now);
+    if (fromBinary) return fromBinary;
+    return (
+      parseGrpcWebText(new TextDecoder().decode(payload), now) ??
+      invalidRemainingResets()
+    );
   }
+  return parseGrpcWebText(payload.trim(), now) ?? invalidRemainingResets();
+}
+
+export function parseGrokRemainingResets(
+  payload: unknown,
+  now = Date.now()
+): AccountUsageMetric[] {
+  return parseGrokRemainingResetsResult(payload, now).metrics;
 }

--- a/packages/plugin-grok/src/main/subscription-fetch.ts
+++ b/packages/plugin-grok/src/main/subscription-fetch.ts
@@ -1,5 +1,8 @@
-import type { FetchImpl } from "./grok-usage-types.ts";
-import { fetchGrokRemainingResetsSoft } from "./reset-credits.ts";
+import type {
+  FetchImpl,
+  RemainingResetsOriginFetch,
+} from "./grok-usage-types.ts";
+import { fetchGrokRemainingResetsSoft } from "./reset-credits-fetch.ts";
 import {
   type GrokSubscriptionInfo,
   parseGrokSubscriptionResult,
@@ -145,6 +148,7 @@ export async function withSoftSubscription(
     caller: AbortSignal;
     fetchImpl: FetchImpl;
     overall: AbortSignal | null;
+    remainingResetsOriginFetch?: RemainingResetsOriginFetch;
     sessionKey: string;
     userId?: string | null;
   }
@@ -192,6 +196,9 @@ export async function withSoftSubscription(
             sessionKey: options.sessionKey,
             signal: options.caller,
             ...(options.userId ? { userId: options.userId } : {}),
+            ...(options.remainingResetsOriginFetch
+              ? { originFetch: options.remainingResetsOriginFetch }
+              : {}),
           }),
         ])
       : Promise.resolve([[], []] as const);

--- a/src/main/app-core/external-plugin-context.ts
+++ b/src/main/app-core/external-plugin-context.ts
@@ -3,6 +3,7 @@ import type { LaunchWrapHandler } from "@pier/plugin-api/main";
 import { jsonValueSchema } from "@shared/contracts/plugin/settings.ts";
 import { createLogger } from "@shared/logger.ts";
 import { effectiveConfigurationValue } from "@shared/plugin-settings.ts";
+import { fetchFromDocumentOrigin } from "../plugins/document-origin-fetch.ts";
 import type { ExternalMainPluginContext } from "../plugins/external-main-runtime.ts";
 import { createExternalPluginProcessEnv } from "../plugins/external-plugin-process-env.ts";
 import type { PluginRpcBus } from "../plugins/rpc-bus.ts";
@@ -69,6 +70,9 @@ export function createExternalMainPluginContextFactory(deps: {
         deps.pluginRpcBus.emit(source.id, event, payload),
     },
     lifecycle: { onBeforeQuit: () => {} },
+    ...(source.id === "pier.grok"
+      ? { documentOriginFetch: fetchFromDocumentOrigin }
+      : {}),
     ...(source.id === "pier.codex"
       ? {
           legacyCodexAccounts: createCodexLegacyMigrationAdapter({

--- a/src/main/plugins/document-origin-fetch.ts
+++ b/src/main/plugins/document-origin-fetch.ts
@@ -1,0 +1,281 @@
+import type {
+  DocumentOriginFetchRequest,
+  DocumentOriginFetchResult,
+} from "@pier/plugin-api/main";
+import { BrowserWindow } from "electron";
+
+export type {
+  DocumentOriginFetchRequest,
+  DocumentOriginFetchResult,
+} from "@pier/plugin-api/main";
+
+const ORIGIN_FETCH_TIMEOUT_MS = 8000;
+const CF_WAIT_MS = 3000;
+const ISOLATED_WORLD_ID = 1000;
+const ALLOWED_DOCUMENT_ORIGINS = new Set(["https://grok.com"]);
+const ALLOWED_HEADER_NAMES = new Set([
+  "accept",
+  "authorization",
+  "content-type",
+  "x-grpc-web",
+  "x-grok-client-mode",
+  "x-userid",
+  "x-xai-token-auth",
+]);
+
+const windows = new Map<string, BrowserWindow>();
+const inflight = new Map<string, Promise<BrowserWindow>>();
+
+function abortError(): Error {
+  const error = new Error("document origin fetch aborted");
+  error.name = "AbortError";
+  return error;
+}
+
+export function assertDocumentOriginRequest(request: {
+  origin: string;
+  url: string;
+}): string {
+  let originUrl: URL;
+  let requestUrl: URL;
+  try {
+    originUrl = new URL(request.origin);
+    requestUrl = new URL(request.url);
+  } catch {
+    throw new Error("document origin fetch requires absolute https URLs");
+  }
+  if (originUrl.protocol !== "https:" || requestUrl.protocol !== "https:") {
+    throw new Error("document origin fetch requires https");
+  }
+  if (originUrl.username || originUrl.password) {
+    throw new Error("document origin must not include credentials");
+  }
+  if (!ALLOWED_DOCUMENT_ORIGINS.has(originUrl.origin)) {
+    throw new Error(`document origin is not allowed: ${originUrl.origin}`);
+  }
+  if (requestUrl.origin !== originUrl.origin) {
+    throw new Error(
+      `document origin fetch url must be same-origin: ${request.url}`
+    );
+  }
+  return originUrl.origin;
+}
+
+function sanitizedHeaders(
+  headers: Record<string, string>
+): Record<string, string> {
+  const next: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    if (ALLOWED_HEADER_NAMES.has(key.toLowerCase())) next[key] = value;
+  }
+  return next;
+}
+
+function isAllowedNavigation(origin: string, url: string): boolean {
+  if (url === "about:blank") return true;
+  try {
+    return new URL(url).origin === new URL(origin).origin;
+  } catch {
+    return false;
+  }
+}
+
+async function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  signal?: AbortSignal
+): Promise<T> {
+  if (signal?.aborted) throw abortError();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let abort: (() => void) | undefined;
+  try {
+    return await new Promise<T>((resolve, reject) => {
+      timer = setTimeout(() => {
+        reject(new Error("document origin fetch timed out"));
+      }, ms);
+      abort = (): void => reject(abortError());
+      signal?.addEventListener("abort", abort, { once: true });
+      promise.then(resolve, reject);
+    });
+  } finally {
+    if (abort) signal?.removeEventListener("abort", abort);
+    if (timer) clearTimeout(timer);
+  }
+}
+
+function bytesFromBase64(base64: string): Uint8Array {
+  return Uint8Array.from(Buffer.from(base64, "base64"));
+}
+
+function attachWindowGuards(win: BrowserWindow, origin: string): void {
+  win.webContents.setWindowOpenHandler(() => ({ action: "deny" }));
+  const denyForeign = (event: { preventDefault: () => void }, url: string) => {
+    if (!isAllowedNavigation(origin, url)) event.preventDefault();
+  };
+  win.webContents.on("will-navigate", denyForeign);
+  win.webContents.on("will-redirect", denyForeign);
+}
+
+function createOriginWindow(origin: string): BrowserWindow {
+  const win = new BrowserWindow({
+    focusable: false,
+    height: 600,
+    hiddenInMissionControl: true,
+    paintWhenInitiallyHidden: true,
+    show: false,
+    skipTaskbar: true,
+    width: 800,
+    webPreferences: {
+      backgroundThrottling: false,
+      contextIsolation: true,
+      nodeIntegration: false,
+      partition: "persist:pier-document-origin-fetch",
+      sandbox: true,
+    },
+  });
+  windows.set(origin, win);
+  win.on("closed", () => {
+    if (windows.get(origin) === win) windows.delete(origin);
+  });
+  attachWindowGuards(win, origin);
+  win.setOpacity(0);
+  win.setIgnoreMouseEvents(true);
+  win.showInactive();
+  return win;
+}
+
+function destroyOriginWindow(origin: string, win: BrowserWindow): void {
+  if (windows.get(origin) === win) windows.delete(origin);
+  if (!win.isDestroyed()) win.destroy();
+}
+
+async function createWindowForOrigin(origin: string): Promise<BrowserWindow> {
+  const win = createOriginWindow(origin);
+  try {
+    await withTimeout(win.loadURL(origin), ORIGIN_FETCH_TIMEOUT_MS);
+  } catch (error) {
+    destroyOriginWindow(origin, win);
+    throw error;
+  }
+  return win;
+}
+
+async function windowForOrigin(
+  origin: string,
+  signal?: AbortSignal
+): Promise<BrowserWindow> {
+  const existing = windows.get(origin);
+  if (existing && !existing.isDestroyed()) return existing;
+  let pending = inflight.get(origin);
+  if (!pending) {
+    pending = createWindowForOrigin(origin).finally(() => {
+      if (inflight.get(origin) === pending) inflight.delete(origin);
+    });
+    inflight.set(origin, pending);
+  }
+  return await withTimeout(pending, ORIGIN_FETCH_TIMEOUT_MS, signal);
+}
+
+function inPageFetchScript(request: {
+  bodyLiteral: string;
+  fetchTimeoutMs: number;
+  headers: Record<string, string>;
+  method: string;
+  url: string;
+  waitMs: number;
+}): string {
+  return `(async () => {
+      const deadline = Date.now() + ${request.waitMs};
+      while (Date.now() < deadline) {
+        const title = document.title || "";
+        if (
+          !/just a moment|attention required/i.test(title) &&
+          document.readyState === "complete"
+        ) {
+          break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 250));
+      }
+      const res = await fetch(${JSON.stringify(request.url)}, {
+        method: ${JSON.stringify(request.method)},
+        headers: ${JSON.stringify(request.headers)},
+        credentials: "include",
+        signal: AbortSignal.timeout(${request.fetchTimeoutMs}),
+        body: ${request.bodyLiteral},
+      });
+      const buf = new Uint8Array(await res.arrayBuffer());
+      let binary = "";
+      for (let i = 0; i < buf.length; i += 1) {
+        binary += String.fromCharCode(buf[i] ?? 0);
+      }
+      return { ok: res.ok, status: res.status, base64: btoa(binary) };
+    })()`;
+}
+
+function remainingMs(deadlineAt: number): number {
+  return Math.max(1, deadlineAt - Date.now());
+}
+
+/** Isolated-world fetch after loading `origin` so Cloudflare cookies apply. */
+export async function fetchFromDocumentOrigin(
+  request: DocumentOriginFetchRequest
+): Promise<DocumentOriginFetchResult> {
+  const origin = assertDocumentOriginRequest(request);
+  if (request.signal?.aborted) throw abortError();
+  const deadlineAt = Date.now() + ORIGIN_FETCH_TIMEOUT_MS;
+  const originUrl = `${origin}/`;
+  const win = await windowForOrigin(originUrl, request.signal);
+  if (request.signal?.aborted) throw abortError();
+  const method = request.method ?? "GET";
+  const headers = sanitizedHeaders(request.headers ?? {});
+  const bodyLiteral =
+    request.body === undefined
+      ? "undefined"
+      : `Uint8Array.from(${JSON.stringify([...request.body])})`;
+  const budget = remainingMs(deadlineAt);
+  const waitMs = Math.min(CF_WAIT_MS, Math.max(0, budget - 500));
+  try {
+    const result = (await withTimeout(
+      win.webContents.executeJavaScriptInIsolatedWorld(ISOLATED_WORLD_ID, [
+        {
+          code: inPageFetchScript({
+            bodyLiteral,
+            fetchTimeoutMs: budget,
+            headers,
+            method,
+            url: request.url,
+            waitMs,
+          }),
+        },
+      ]),
+      budget,
+      request.signal
+    )) as { base64?: unknown; ok?: unknown; status?: unknown };
+    if (request.signal?.aborted) throw abortError();
+    if (
+      typeof result?.base64 !== "string" ||
+      typeof result.ok !== "boolean" ||
+      typeof result.status !== "number"
+    ) {
+      throw new Error("document origin fetch returned an invalid result");
+    }
+    return {
+      body: bytesFromBase64(result.base64),
+      ok: result.ok,
+      status: result.status,
+    };
+  } catch (error) {
+    if (!(error instanceof Error && error.name === "AbortError")) {
+      destroyOriginWindow(originUrl, win);
+    }
+    throw error;
+  }
+}
+
+export function disposeDocumentOriginWindows(): void {
+  inflight.clear();
+  for (const win of windows.values()) {
+    if (!win.isDestroyed()) win.destroy();
+  }
+  windows.clear();
+}

--- a/src/main/plugins/external-main-runtime.ts
+++ b/src/main/plugins/external-main-runtime.ts
@@ -1,11 +1,13 @@
 import { pathToFileURL } from "node:url";
 import type {
   LaunchWrapHandler,
+  MainPluginContext,
   MainPluginUsageData,
   PluginConfigurationApi,
 } from "@pier/plugin-api/main";
 import { attachPluginLanguageServers } from "../services/lsp/host-bridge.ts";
 import type { ManagedPluginRuntimeSource } from "../services/managed-plugins/install-runtime.ts";
+import { disposeDocumentOriginWindows } from "./document-origin-fetch.ts";
 import type { PluginRpcBus } from "./rpc-bus.ts";
 
 /**
@@ -28,6 +30,7 @@ export interface ExternalMainPluginModule {
 
 export interface ExternalMainPluginContext {
   configuration: PluginConfigurationApi;
+  documentOriginFetch?: MainPluginContext["documentOriginFetch"];
   events: {
     emit(event: string, payload: unknown): void;
   };
@@ -297,8 +300,12 @@ export function createExternalMainPluginRuntime(options: {
     },
     dispose: (pluginId) => disposePlugin(pluginId),
     async disposeAll(): Promise<void> {
-      for (const id of Object.keys(disposers)) {
-        await disposePlugin(id);
+      try {
+        for (const id of Object.keys(disposers)) {
+          await disposePlugin(id);
+        }
+      } finally {
+        disposeDocumentOriginWindows();
       }
     },
     async flushAllBeforeQuit(): Promise<void> {
@@ -306,7 +313,11 @@ export function createExternalMainPluginRuntime(options: {
       for (const [pluginId, callbacks] of Object.entries(flushCallbacks)) {
         tasks.push(flushPluginCallbacks(pluginId, callbacks));
       }
-      await Promise.all(tasks);
+      try {
+        await Promise.all(tasks);
+      } finally {
+        disposeDocumentOriginWindows();
+      }
     },
     async reload(source): Promise<void> {
       await disposePlugin(source.id);

--- a/src/main/services/host-catalog/providers/agent-cli.ts
+++ b/src/main/services/host-catalog/providers/agent-cli.ts
@@ -43,6 +43,30 @@ function itemFromProbe(probe: AgentLifecycleProbe): CatalogItem {
   };
 }
 
+function detailsForMissing(
+  previous: CatalogItem | undefined
+): AgentLifecycleProbe | null {
+  const parsed = agentLifecycleProbeSchema.safeParse(previous?.details);
+  if (!parsed.success) {
+    return null;
+  }
+  return {
+    ...parsed.data,
+    canUninstall: false,
+    detected: false,
+    installedButBroken: false,
+    installs: [],
+    isConflict: false,
+    latestVersion: null,
+    uninstallMode: "none",
+    uninstallTargetPath: null,
+    uninstallTargetSource: null,
+    updateAvailable: false,
+    updateOffered: false,
+    version: null,
+  };
+}
+
 function itemFromDetection(
   agentId: AgentKind,
   detected: ReadonlySet<AgentKind>,
@@ -53,7 +77,7 @@ function itemFromDetection(
   const parsed = agentLifecycleProbeSchema.safeParse(previous?.details);
   const details = ((): unknown => {
     if (!present) {
-      return null;
+      return detailsForMissing(previous);
     }
     if (parsed.success) {
       return {

--- a/src/renderer/pages/settings/components/agent-lifecycle-format.ts
+++ b/src/renderer/pages/settings/components/agent-lifecycle-format.ts
@@ -208,8 +208,10 @@ export interface AgentRowStatusBadge {
 
 /**
  * Exception badges only (priority: broken > conflict > missing > disabled).
- * Healthy install and "update available" stay silent — version arrow + Update button carry that.
- * Missing beats disabled so stale prefs for uninstalled agents don't say "Disabled".
+ * Healthy install and "update available" stay silent — version arrow + Update
+ * button carry that. Missing stays on the row even when Install is shown.
+ * Missing beats disabled so stale prefs for uninstalled agents don't say
+ * "Disabled".
  */
 export function resolveAgentStatusBadge(
   t: TFunction,
@@ -245,4 +247,32 @@ export function resolveAgentStatusBadge(
     };
   }
   return null;
+}
+
+/**
+ * Offer one-click install as soon as PATH detect says missing.
+ * Do not wait for the lifecycle probe; hide when the host (or catalog) says
+ * this agent has no managed install.
+ */
+export function shouldOfferAgentInstall(state: {
+  canInstall?: boolean;
+  hasDetected: boolean;
+  installedButBroken?: boolean;
+  isBusy: boolean;
+  isDetected: boolean;
+  oneClickInstall: boolean;
+}): boolean {
+  if (!state.hasDetected || state.isDetected || state.isBusy) {
+    return false;
+  }
+  if (state.installedButBroken === true) {
+    return false;
+  }
+  if (state.canInstall === false) {
+    return false;
+  }
+  if (state.canInstall === true) {
+    return true;
+  }
+  return state.oneClickInstall;
 }

--- a/src/renderer/pages/settings/components/agent-row.tsx
+++ b/src/renderer/pages/settings/components/agent-row.tsx
@@ -14,6 +14,7 @@ import {
 } from "@pier/ui/item.tsx";
 import { AgentIcon } from "@plugins/api/components/agent-icons/index.tsx";
 import { getAgentCatalogEntry } from "@shared/agent-catalog.ts";
+import { agentOffersOneClickInstall } from "@shared/agent-lifecycle/one-click-install.ts";
 import type { AgentKind } from "@shared/contracts/agent.ts";
 import {
   ArrowUpCircle,
@@ -34,6 +35,7 @@ import {
   isLifecycleSoftFailure,
   lifecycleBusyStatusText,
   resolveAgentStatusBadge,
+  shouldOfferAgentInstall,
 } from "@/pages/settings/components/agent-lifecycle-format.ts";
 import { AgentExpandedDetails } from "@/pages/settings/components/agent-row-details.tsx";
 import { useAgentDetectStore } from "@/stores/agent-detect.store.ts";
@@ -50,6 +52,7 @@ export function AgentRow({ agentId }: { agentId: AgentKind }) {
   const [open, setOpen] = useState(false);
 
   const detectedIds = useAgentDetectStore((s) => s.detectedIds);
+  const hasDetected = useAgentDetectStore((s) => s.hasDetected);
   const disabledAgentIds = useAgentPreferencesStore((s) => s.disabledAgentIds);
   const defaultAgentId = useAgentPreferencesStore((s) => s.defaultAgentId);
   const setDisabledAgentIds = useAgentPreferencesStore(
@@ -79,7 +82,16 @@ export function AgentRow({ agentId }: { agentId: AgentKind }) {
   /** Cancel only while main is actually running this agent. */
   const canCancelBusy = job?.phase === "running";
   const lifecycleProgress = job?.progress;
-  const canInstall = probe?.canInstall === true;
+  const offerInstall = shouldOfferAgentInstall({
+    hasDetected,
+    isBusy: Boolean(job),
+    isDetected,
+    oneClickInstall: agentOffersOneClickInstall(agentId),
+    ...(typeof probe?.canInstall === "boolean"
+      ? { canInstall: probe.canInstall }
+      : {}),
+    ...(probe?.installedButBroken === true ? { installedButBroken: true } : {}),
+  });
   const canUpdate = isLifecycleUpdateCandidate(probe, { disabled: isDisabled });
   const canReinstall = isLifecycleReinstallCandidate(probe, {
     disabled: isDisabled,
@@ -323,9 +335,7 @@ export function AgentRow({ agentId }: { agentId: AgentKind }) {
               {busyStatusText}
             </Button>
           ) : null}
-          {!(isDetected || probe?.installedButBroken) &&
-          canInstall &&
-          !isBusy ? (
+          {offerInstall ? (
             <Button
               onClick={() => {
                 handleLifecycle("install").catch(() => undefined);

--- a/src/renderer/stores/agent-lifecycle.store.ts
+++ b/src/renderer/stores/agent-lifecycle.store.ts
@@ -117,14 +117,18 @@ function applyLifecycleSnapshot(snapshot: CatalogDomainSnapshot): void {
     if (!parsed.success) {
       continue;
     }
-    if (item.presence !== "present" && item.presence !== "broken") {
-      continue;
-    }
     const id = parsed.data;
     const incomingProbe = incomingById.get(id);
     if (incomingProbe) {
       next[id] = incomingProbe;
-    } else if (previous[id]) {
+      continue;
+    }
+    // Local detect may omit details. Keep the last probe only while still
+    // present/broken so a missing item cannot resurrect a stale install.
+    if (
+      (item.presence === "present" || item.presence === "broken") &&
+      previous[id]
+    ) {
       next[id] = previous[id];
     }
   }

--- a/src/shared/agent-lifecycle/one-click-install.ts
+++ b/src/shared/agent-lifecycle/one-click-install.ts
@@ -1,0 +1,18 @@
+import type { AgentKind } from "../contracts/agent.ts";
+
+/**
+ * Website-only / no Pier-managed install plan. Must stay in lockstep with
+ * lifecycle specs (`support !== "full"`).
+ */
+export const AGENT_NO_ONE_CLICK_INSTALL = [
+  "ante",
+  "openclaude",
+  "rovo",
+] as const satisfies readonly AgentKind[];
+
+const NO_ONE_CLICK = new Set<AgentKind>(AGENT_NO_ONE_CLICK_INSTALL);
+
+/** True when Settings can offer one-click install without waiting for probe. */
+export function agentOffersOneClickInstall(agentId: AgentKind): boolean {
+  return !NO_ONE_CLICK.has(agentId);
+}

--- a/tests/e2e/agents/settings.spec.ts
+++ b/tests/e2e/agents/settings.spec.ts
@@ -121,6 +121,9 @@ test.describe("Agents Settings e2e", () => {
           claudeRow.getByRole("button", { name: "详情" })
         ).toHaveCount(0);
         await expect(
+          claudeRow.getByRole("button", { name: "安装" })
+        ).toBeVisible();
+        await expect(
           claudeRow.getByRole("link", { name: "官网" })
         ).toHaveAttribute("href", "https://claude.com/claude-code");
         return;

--- a/tests/unit/app/dev-profile-electron-icon.test.ts
+++ b/tests/unit/app/dev-profile-electron-icon.test.ts
@@ -21,6 +21,17 @@ import {
 
 const onDarwin = process.platform === "darwin";
 
+function hasCommand(name: string): boolean {
+  try {
+    execFileSync("which", [name], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const hasRsvgConvert = hasCommand("rsvg-convert");
+
 const ROOT = process.cwd();
 const PIER_ICNS = readFileSync(join(ROOT, "build/icon.icns"));
 const STOCK_PLIST = `<?xml version="1.0" encoding="UTF-8"?>
@@ -136,7 +147,7 @@ describe("PierDev.app bundle icon", () => {
     }
   });
 
-  it.runIf(onDarwin)(
+  it.runIf(onDarwin && hasRsvgConvert)(
     "installs a plate-filled icns as electron.icns plus Tahoe AppIcon assets",
     { timeout: 15_000 },
     () => {

--- a/tests/unit/main/agents/codex/plugin-reset-credits.test.ts
+++ b/tests/unit/main/agents/codex/plugin-reset-credits.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import {
+  CODEX_RESET_CREDITS_METRIC_ID,
+  parseCodexResetCredits,
+} from "../../../../../packages/plugin-codex/src/main/codex-reset-credits.ts";
+
+describe("parseCodexResetCredits", () => {
+  it("reads available_count from the dedicated endpoint payload", () => {
+    expect(
+      parseCodexResetCredits({
+        available_count: 3,
+        credits: [
+          { status: "available", title: "Full reset (Weekly + 5 hr)" },
+          { status: "available" },
+          { status: "expired" },
+        ],
+      })
+    ).toEqual([
+      {
+        format: "count",
+        id: CODEX_RESET_CREDITS_METRIC_ID,
+        kind: "scalar",
+        value: 3,
+      },
+    ]);
+  });
+
+  it("counts available credits when available_count is omitted", () => {
+    expect(
+      parseCodexResetCredits({
+        credits: [
+          { status: "available" },
+          { status: "available" },
+          { status: "used" },
+        ],
+      })
+    ).toEqual([
+      {
+        format: "count",
+        id: CODEX_RESET_CREDITS_METRIC_ID,
+        kind: "scalar",
+        value: 2,
+      },
+    ]);
+  });
+
+  it("reads a nested usage payload without inventing a zero badge", () => {
+    expect(
+      parseCodexResetCredits({
+        rate_limit_reset_credits: { available_count: 0 },
+      })
+    ).toEqual([]);
+    expect(
+      parseCodexResetCredits({
+        rateLimitResetCredits: { availableCount: 1 },
+      })
+    ).toEqual([
+      {
+        format: "count",
+        id: CODEX_RESET_CREDITS_METRIC_ID,
+        kind: "scalar",
+        value: 1,
+      },
+    ]);
+  });
+});

--- a/tests/unit/main/agents/codex/plugin-usage-http.test.ts
+++ b/tests/unit/main/agents/codex/plugin-usage-http.test.ts
@@ -209,6 +209,13 @@ describe("fetchCodexUsageHttp", () => {
             }),
         };
       }
+      if (url.includes("/wham/rate-limit-reset-credits")) {
+        return {
+          ok: true,
+          status: 200,
+          text: async () => JSON.stringify({ available_count: 0 }),
+        };
+      }
       throw new Error(`unexpected URL: ${url}`);
     });
 
@@ -222,6 +229,117 @@ describe("fetchCodexUsageHttp", () => {
       status: "ok",
       subscriptionExpiresAt: Date.parse("2026-08-28T21:38:26+00:00"),
     });
+  });
+
+  it("fills reset credits from the dedicated wham endpoint", async () => {
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (url.includes("/wham/usage")) {
+        return {
+          ok: true,
+          status: 200,
+          text: async () =>
+            JSON.stringify({
+              plan_type: "pro",
+              rate_limit: {
+                primary_window: {
+                  limit_window_seconds: 604_800,
+                  used_percent: 0,
+                },
+              },
+            }),
+        };
+      }
+      if (url.includes("/wham/rate-limit-reset-credits")) {
+        return {
+          ok: true,
+          status: 200,
+          text: async () => JSON.stringify({ available_count: 3 }),
+        };
+      }
+      if (url.includes("/accounts/check/") || url.includes("/subscriptions")) {
+        return {
+          ok: false,
+          status: 404,
+          text: async () => "",
+        };
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const result = await fetchCodexUsageHttp(makeAuthJson(), {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      signal: new AbortController().signal,
+    });
+
+    expect(result.status).toBe("ok");
+    expect(result.metrics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          format: "count",
+          id: "codex:reset-credits",
+          kind: "scalar",
+          value: 3,
+        }),
+      ])
+    );
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits",
+      expect.objectContaining({
+        method: "GET",
+      })
+    );
+  });
+
+  it("keeps quota when the dedicated reset-credits request fails", async () => {
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (url.includes("/wham/usage")) {
+        return {
+          ok: true,
+          status: 200,
+          text: async () =>
+            JSON.stringify({
+              rate_limit: {
+                primary_window: {
+                  used_percent: 8,
+                  limit_window_seconds: 18_000,
+                },
+              },
+            }),
+        };
+      }
+      if (url.includes("/wham/rate-limit-reset-credits")) {
+        return {
+          ok: false,
+          status: 429,
+          text: async () =>
+            JSON.stringify({
+              detail: {
+                type: "connector_rate_limit",
+                message: "Connector rate limit exceeded",
+              },
+            }),
+        };
+      }
+      return {
+        ok: false,
+        status: 404,
+        text: async () => "",
+      };
+    });
+
+    const result = await fetchCodexUsageHttp(makeAuthJson(), {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      signal: new AbortController().signal,
+    });
+
+    expect(result.status).toBe("ok");
+    expect(result.metrics).toEqual([
+      expect.objectContaining({
+        id: "codex:primary",
+        kind: "quota",
+        usedPercent: 8,
+      }),
+    ]);
   });
 
   it("combines the caller signal with an independent request timeout", async () => {

--- a/tests/unit/main/agents/grok/plugin-reset-credits.test.ts
+++ b/tests/unit/main/agents/grok/plugin-reset-credits.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it, vi } from "vitest";
 import {
-  fetchGrokRemainingResetsSoft,
   GROK_REMAINING_RESETS_URL,
   GROK_RESET_CREDITS_METRIC_ID,
   parseGrokRemainingResets,
 } from "../../../../../packages/plugin-grok/src/main/reset-credits.ts";
+import {
+  createRemainingResetsOriginFetch,
+  fetchGrokRemainingResetsSoft,
+} from "../../../../../packages/plugin-grok/src/main/reset-credits-fetch.ts";
 import { withSoftSubscription } from "../../../../../packages/plugin-grok/src/main/subscription-fetch.ts";
 
 const NOW = Date.parse("2026-08-14T00:00:00Z");
@@ -92,20 +95,58 @@ describe("parseGrokRemainingResets", () => {
     ]);
   });
 
+  it("rejects grpc-web data without a success trailer", () => {
+    expect(
+      parseGrokRemainingResets(firstGrpcWebFrame(LIVE_GRPC_WEB_PROTO), NOW)
+    ).toEqual([]);
+  });
+
+  it("rejects a truncated grpc-web frame", () => {
+    expect(
+      parseGrokRemainingResets(LIVE_GRPC_WEB_PROTO.slice(0, 12), NOW)
+    ).toEqual([]);
+  });
+
+  it("rejects data after the grpc-web trailer", () => {
+    const data = firstGrpcWebFrame(LIVE_GRPC_WEB_PROTO);
+    expect(
+      parseGrokRemainingResets(concatBytes(data, grpcWebTrailer(0), data), NOW)
+    ).toEqual([]);
+  });
+
+  it("rejects a nonzero trailer even when followed by a success trailer", () => {
+    const data = firstGrpcWebFrame(LIVE_GRPC_WEB_PROTO);
+    expect(
+      parseGrokRemainingResets(
+        concatBytes(data, grpcWebTrailer(7), grpcWebTrailer(0)),
+        NOW
+      )
+    ).toEqual([]);
+  });
+
+  it("does not extract grpc-web text embedded in unrelated content", () => {
+    expect(
+      parseGrokRemainingResets(`<!--${LIVE_GRPC_WEB_TEXT}-->`, NOW)
+    ).toEqual([]);
+  });
+
   it("skips unknown protobuf tags instead of dropping the remaining-resets metric", () => {
-    const payload = encodeGrpcWebFrame([
-      ...encodeKey(2, 0),
-      ...encodeVarint(1),
-      ...encodeLengthDelimited(10, [
-        ...encodeKey(1, 0),
-        ...encodeVarint(7),
-        ...encodeLengthDelimited(10, textBytes("restok_extra")),
-        ...encodeLengthDelimited(30, [
+    const payload = concatBytes(
+      encodeGrpcWebFrame([
+        ...encodeKey(2, 0),
+        ...encodeVarint(1),
+        ...encodeLengthDelimited(10, [
           ...encodeKey(1, 0),
-          ...encodeVarint(Math.floor((NOW + 86_400_000) / 1000)),
+          ...encodeVarint(7),
+          ...encodeLengthDelimited(10, textBytes("restok_extra")),
+          ...encodeLengthDelimited(30, [
+            ...encodeKey(1, 0),
+            ...encodeVarint(Math.floor((NOW + 86_400_000) / 1000)),
+          ]),
         ]),
       ]),
-    ]);
+      grpcWebTrailer(0)
+    );
     expect(parseGrokRemainingResets(payload, NOW)).toEqual([
       {
         format: "count",
@@ -140,15 +181,228 @@ function encodeLengthDelimited(field: number, payload: number[]): number[] {
   return [...encodeKey(field, 2), ...encodeVarint(payload.length), ...payload];
 }
 
-function encodeGrpcWebFrame(payload: number[]): Uint8Array {
+function encodeGrpcWebFrame(payload: number[], flag = 0): Uint8Array {
   const bytes = new Uint8Array(5 + payload.length);
-  bytes[0] = 0;
+  bytes[0] = flag;
   new DataView(bytes.buffer).setUint32(1, payload.length);
   bytes.set(payload, 5);
   return bytes;
 }
 
+function concatBytes(...chunks: Uint8Array[]): Uint8Array {
+  const bytes = new Uint8Array(
+    chunks.reduce((total, chunk) => total + chunk.length, 0)
+  );
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return bytes;
+}
+
+function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  const copy = new Uint8Array(bytes.length);
+  copy.set(bytes);
+  return copy.buffer;
+}
+
+function grpcWebTrailer(status: number): Uint8Array {
+  return encodeGrpcWebFrame(
+    [...new TextEncoder().encode(`grpc-status:${status}\r\n`)],
+    128
+  );
+}
+
+function firstGrpcWebFrame(bytes: Uint8Array): Uint8Array {
+  const payloadLength = new DataView(
+    bytes.buffer,
+    bytes.byteOffset + 1,
+    4
+  ).getUint32(0);
+  return bytes.slice(0, 5 + payloadLength);
+}
+
 describe("fetchGrokRemainingResetsSoft", () => {
+  it("does not accept a successful JSON body without grpc-web framing", async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ availableCount: 1 }),
+    }));
+
+    const result = await fetchGrokRemainingResetsSoft({
+      fetchImpl,
+      sessionKey: "session-key",
+      signal: new AbortController().signal,
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it("falls back to grok.com origin fetch when Cloudflare blocks Node fetch", async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: false,
+      status: 403,
+      text: async () => "<html>Just a moment</html>",
+    }));
+    const originFetch = vi.fn(async () => [
+      {
+        format: "count" as const,
+        id: GROK_RESET_CREDITS_METRIC_ID,
+        kind: "scalar" as const,
+        value: 1,
+      },
+    ]);
+
+    const result = await fetchGrokRemainingResetsSoft({
+      fetchImpl,
+      originFetch,
+      sessionKey: "session-key",
+      signal: new AbortController().signal,
+    });
+
+    expect(result).toEqual([
+      {
+        format: "count",
+        id: GROK_RESET_CREDITS_METRIC_ID,
+        kind: "scalar",
+        value: 1,
+      },
+    ]);
+    expect(originFetch).toHaveBeenCalledOnce();
+  });
+
+  it("falls back to origin fetch when HTTP 200 is Cloudflare HTML", async () => {
+    const html = new TextEncoder().encode("<html>Just a moment</html>");
+    const fetchImpl = vi.fn(async () => ({
+      arrayBuffer: async () =>
+        html.buffer.slice(html.byteOffset, html.byteOffset + html.byteLength),
+      ok: true,
+      status: 200,
+      text: async () => "<html>Just a moment</html>",
+    }));
+    const originFetch = vi.fn(async () => [
+      {
+        format: "count" as const,
+        id: GROK_RESET_CREDITS_METRIC_ID,
+        kind: "scalar" as const,
+        value: 1,
+      },
+    ]);
+
+    const result = await fetchGrokRemainingResetsSoft({
+      fetchImpl,
+      originFetch,
+      sessionKey: "session-key",
+      signal: new AbortController().signal,
+    });
+
+    expect(result).toEqual([
+      {
+        format: "count",
+        id: GROK_RESET_CREDITS_METRIC_ID,
+        kind: "scalar",
+        value: 1,
+      },
+    ]);
+    expect(originFetch).toHaveBeenCalledOnce();
+  });
+
+  it("swallows origin-fetch failures so usage still succeeds", async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: false,
+      status: 403,
+      text: async () => "<html>Just a moment</html>",
+    }));
+    const originFetch = vi.fn(async () => {
+      throw new Error("hidden window failed");
+    });
+
+    const result = await fetchGrokRemainingResetsSoft({
+      fetchImpl,
+      originFetch,
+      sessionKey: "session-key",
+      signal: new AbortController().signal,
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it("does not origin-fetch after the caller aborts", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("network");
+    });
+    const originFetch = vi.fn(async () => []);
+    const controller = new AbortController();
+    controller.abort();
+
+    const result = await fetchGrokRemainingResetsSoft({
+      fetchImpl,
+      originFetch,
+      sessionKey: "session-key",
+      signal: controller.signal,
+    });
+
+    expect(result).toEqual([]);
+    expect(originFetch).not.toHaveBeenCalled();
+  });
+
+  it("returns no reset metric when the request is rejected", async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: false,
+      status: 403,
+      text: async () => "",
+    }));
+
+    const result = await fetchGrokRemainingResetsSoft({
+      fetchImpl,
+      sessionKey: "session-key",
+      signal: new AbortController().signal,
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it("returns no reset metric for a nonzero grpc-status trailer", async () => {
+    const body = concatBytes(
+      firstGrpcWebFrame(LIVE_GRPC_WEB_PROTO),
+      grpcWebTrailer(7)
+    );
+    const fetchImpl = vi.fn(async () => ({
+      arrayBuffer: async () => toArrayBuffer(body),
+      ok: true,
+      status: 200,
+      text: async () => "",
+    }));
+
+    const result = await fetchGrokRemainingResetsSoft({
+      fetchImpl,
+      sessionKey: "session-key",
+      signal: new AbortController().signal,
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it("returns no reset metric for malformed HTTP 200 content", async () => {
+    const body = new TextEncoder().encode("<html>challenge</html>");
+    const fetchImpl = vi.fn(async () => ({
+      arrayBuffer: async () => toArrayBuffer(body),
+      ok: true,
+      status: 200,
+      text: async () => "",
+    }));
+
+    const result = await fetchGrokRemainingResetsSoft({
+      fetchImpl,
+      sessionKey: "session-key",
+      signal: new AbortController().signal,
+    });
+
+    expect(result).toEqual([]);
+  });
+
   it("posts a raw empty protobuf frame and reads the binary grpc-web body", async () => {
     const fetchImpl = vi.fn(async (_url: string, init?: { body?: unknown }) => {
       const body = init?.body;
@@ -180,13 +434,13 @@ describe("fetchGrokRemainingResetsSoft", () => {
       };
     });
 
-    const metrics = await fetchGrokRemainingResetsSoft({
+    const result = await fetchGrokRemainingResetsSoft({
       fetchImpl,
       sessionKey: "session-key",
       signal: new AbortController().signal,
     });
 
-    expect(metrics).toEqual([
+    expect(result).toEqual([
       {
         format: "count",
         id: GROK_RESET_CREDITS_METRIC_ID,
@@ -205,9 +459,77 @@ describe("fetchGrokRemainingResetsSoft", () => {
       })
     );
   });
+
+  it("parses remaining resets from a host document-origin fetch", async () => {
+    const documentOriginFetch = vi.fn(async () => ({
+      body: LIVE_GRPC_WEB_PROTO,
+      ok: true,
+      status: 200,
+    }));
+    const originFetch = createRemainingResetsOriginFetch(documentOriginFetch);
+
+    await expect(
+      originFetch({
+        sessionKey: "session-key",
+        signal: new AbortController().signal,
+      })
+    ).resolves.toEqual([
+      {
+        format: "count",
+        id: GROK_RESET_CREDITS_METRIC_ID,
+        kind: "scalar",
+        value: 1,
+      },
+    ]);
+    expect(documentOriginFetch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "POST",
+        origin: "https://grok.com/",
+        signal: expect.any(AbortSignal),
+        url: GROK_REMAINING_RESETS_URL,
+      })
+    );
+  });
+
+  it("returns no metrics when the host document-origin fetch fails", async () => {
+    const originFetch = createRemainingResetsOriginFetch(async () => {
+      throw new Error("cf");
+    });
+    await expect(
+      originFetch({
+        sessionKey: "session-key",
+        signal: new AbortController().signal,
+      })
+    ).resolves.toEqual([]);
+  });
 });
 
 describe("withSoftSubscription remaining resets", () => {
+  it("omits reset metadata when the reset-count probe is rejected", async () => {
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (url === GROK_REMAINING_RESETS_URL) {
+        return { ok: false, status: 403, text: async () => "" };
+      }
+      return { ok: false, status: 404, text: async () => "" };
+    });
+
+    const result = await withSoftSubscription(
+      { metrics: [], status: "ok" },
+      {
+        caller: new AbortController().signal,
+        fetchImpl,
+        overall: null,
+        sessionKey: "session-key",
+      }
+    );
+
+    expect(result).toMatchObject({
+      metrics: [],
+      status: "ok",
+    });
+    expect(result).not.toHaveProperty("resetCreditsResolved");
+  });
+
   it("appends reset credits from the official remaining-resets RPC", async () => {
     const fetchImpl = vi.fn(async (url: string) => {
       if (url === GROK_REMAINING_RESETS_URL) {

--- a/tests/unit/main/agents/grok/plugin-usage-fetch.test.ts
+++ b/tests/unit/main/agents/grok/plugin-usage-fetch.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
-import { createUsageCacheEntry } from "../../../../../packages/plugin-grok/src/main/accounts-usage.ts";
+import {
+  createUsageCacheEntry,
+  toUsageSnapshot,
+} from "../../../../../packages/plugin-grok/src/main/accounts-usage.ts";
 import {
   ACCESS_DENIED_ERROR,
   API_KEY_QUOTA_ERROR,
@@ -1003,6 +1006,39 @@ describe("fetchGrokUsage subscription soft-attach", () => {
 });
 
 describe("createUsageCacheEntry subscription retention", () => {
+  it("hides a cached reset count after the latest usage refresh fails", () => {
+    const cached = createUsageCacheEntry(
+      {
+        metrics: [
+          {
+            groupId: "grok:period",
+            id: "grok:period",
+            kind: "quota",
+            usedPercent: 20,
+          },
+          {
+            format: "count",
+            id: GROK_RESET_CREDITS_METRIC_ID,
+            kind: "scalar",
+            value: 1,
+          },
+        ],
+        status: "ok",
+      },
+      undefined,
+      100
+    );
+    const failed = createUsageCacheEntry(
+      { error: "temporarily unavailable", metrics: [], status: "error" },
+      cached,
+      200
+    );
+
+    expect(toUsageSnapshot(failed).metrics).toEqual([
+      expect.objectContaining({ id: "grok:period", kind: "quota" }),
+    ]);
+  });
+
   it("retains previous membership when a successful quota fetch cannot resolve membership", () => {
     const cached = createUsageCacheEntry(
       {

--- a/tests/unit/main/agents/lifecycle/specs.test.ts
+++ b/tests/unit/main/agents/lifecycle/specs.test.ts
@@ -1,3 +1,7 @@
+import {
+  AGENT_NO_ONE_CLICK_INSTALL,
+  agentOffersOneClickInstall,
+} from "@shared/agent-lifecycle/one-click-install.ts";
 import { agentKindSchema } from "@shared/contracts/agent.ts";
 import { describe, expect, it } from "vitest";
 import { buildGuideCommands } from "../../../../../src/main/services/agents/lifecycle/plan.ts";
@@ -199,9 +203,14 @@ describe("agent lifecycle specs", () => {
     const websiteOnly = agentKindSchema.options.filter(
       (id) => getAgentLifecycleSpec(id).support !== "full"
     );
-    expect(websiteOnly.sort()).toEqual(["ante", "openclaude", "rovo"].sort());
+    expect(websiteOnly.sort()).toEqual([...AGENT_NO_ONE_CLICK_INSTALL].sort());
     for (const id of websiteOnly) {
       expect(getAgentLifecycleSpec(id).install).toEqual([]);
+    }
+    for (const id of agentKindSchema.options) {
+      expect(agentOffersOneClickInstall(id)).toBe(
+        getAgentLifecycleSpec(id).support === "full"
+      );
     }
   });
 });

--- a/tests/unit/main/host-catalog/agent-cli-provider.test.ts
+++ b/tests/unit/main/host-catalog/agent-cli-provider.test.ts
@@ -178,4 +178,53 @@ describe("createAgentCliCatalogProvider", () => {
       (cursor?.details as { updateOffered?: boolean } | null)?.updateOffered
     ).toBe(false);
   });
+
+  it("keeps install capability on missing items from previous probe details", async () => {
+    const previous = probe({
+      agentId: "codex",
+      canInstall: true,
+      detected: true,
+      version: "1.2.3",
+    });
+    const provider = createAgentCliCatalogProvider({
+      detect: async () => ({ detectedIds: [] }),
+      persist: {
+        flush: async () => undefined,
+        read: async () => ({
+          ...emptyDomainSnapshot("agent-cli"),
+          items: [
+            {
+              details: previous,
+              domain: "agent-cli",
+              id: "codex",
+              label: "Codex",
+              localVersion: previous.version,
+              presence: "present",
+              remoteVersion: null,
+              updateOffered: false,
+            },
+          ],
+        }),
+        write: async () => undefined,
+      },
+      probe: async () => [],
+    });
+
+    const snapshot = await provider.probeLocal({
+      env: { PATH: "/opt/bin" },
+      now: 20,
+    });
+    const codex = snapshot.items.find((item) => item.id === "codex");
+    expect(codex?.presence).toBe("missing");
+    expect(codex?.localVersion).toBeNull();
+    expect(codex?.details).toMatchObject({
+      agentId: "codex",
+      canInstall: true,
+      canUninstall: false,
+      detected: false,
+      installedButBroken: false,
+      installs: [],
+      version: null,
+    });
+  });
 });

--- a/tests/unit/main/plugins/document-origin-fetch.test.ts
+++ b/tests/unit/main/plugins/document-origin-fetch.test.ts
@@ -1,0 +1,237 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const loadURL = vi.fn(async () => undefined);
+const executeJavaScriptInIsolatedWorld = vi.fn();
+const destroy = vi.fn();
+const on = vi.fn();
+const webContentsOn = vi.fn();
+const isDestroyed = vi.fn(() => false);
+const setOpacity = vi.fn();
+const setIgnoreMouseEvents = vi.fn();
+const showInactive = vi.fn();
+const setWindowOpenHandler = vi.fn();
+const BrowserWindow = vi.fn(function MockBrowserWindow() {
+  return {
+    destroy,
+    isDestroyed,
+    loadURL,
+    on,
+    setIgnoreMouseEvents,
+    setOpacity,
+    showInactive,
+    webContents: {
+      executeJavaScriptInIsolatedWorld,
+      on: webContentsOn,
+      setWindowOpenHandler,
+    },
+  };
+});
+
+vi.mock("electron", () => ({
+  BrowserWindow,
+}));
+
+describe("fetchFromDocumentOrigin", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    loadURL.mockReset();
+    loadURL.mockResolvedValue(undefined);
+    executeJavaScriptInIsolatedWorld.mockReset();
+    destroy.mockClear();
+    on.mockClear();
+    webContentsOn.mockClear();
+    isDestroyed.mockReset();
+    isDestroyed.mockReturnValue(false);
+    setOpacity.mockClear();
+    setIgnoreMouseEvents.mockClear();
+    showInactive.mockClear();
+    setWindowOpenHandler.mockClear();
+    BrowserWindow.mockClear();
+  });
+
+  it("loads origin then returns isolated-world fetch body as base64 bytes", async () => {
+    const payload = Uint8Array.from([0, 0, 0, 0, 5, 1, 2, 3, 4, 5]);
+    executeJavaScriptInIsolatedWorld.mockResolvedValue({
+      base64: Buffer.from(payload).toString("base64"),
+      ok: true,
+      status: 200,
+    });
+    const { fetchFromDocumentOrigin } = await import(
+      "@main/plugins/document-origin-fetch.ts"
+    );
+
+    const result = await fetchFromDocumentOrigin({
+      body: new Uint8Array([0, 0, 0, 0, 0]),
+      headers: {
+        Accept: "application/grpc-web+proto",
+        Cookie: "steal-me",
+      },
+      method: "POST",
+      origin: "https://grok.com/",
+      url: "https://grok.com/rpc",
+    });
+
+    expect(loadURL).toHaveBeenCalledWith("https://grok.com/");
+    expect(showInactive).toHaveBeenCalledOnce();
+    expect(setWindowOpenHandler).toHaveBeenCalledOnce();
+    expect(setWindowOpenHandler.mock.calls[0]?.[0]?.()).toEqual({
+      action: "deny",
+    });
+    expect(webContentsOn).toHaveBeenCalledWith(
+      "will-navigate",
+      expect.any(Function)
+    );
+    expect(webContentsOn).toHaveBeenCalledWith(
+      "will-redirect",
+      expect.any(Function)
+    );
+    expect(executeJavaScriptInIsolatedWorld).toHaveBeenCalledOnce();
+    const worldId = executeJavaScriptInIsolatedWorld.mock.calls[0]?.[0];
+    const scripts = executeJavaScriptInIsolatedWorld.mock.calls[0]?.[1] as
+      | Array<{ code: string }>
+      | undefined;
+    expect(worldId).toBe(1000);
+    const script = scripts?.[0]?.code ?? "";
+    expect(script).toContain("https://grok.com/rpc");
+    expect(script).toContain("application/grpc-web+proto");
+    expect(script).not.toContain("steal-me");
+    expect(script).toContain("btoa");
+    expect(script).toContain('credentials: "include"');
+    expect(script).toContain("AbortSignal.timeout");
+    expect(BrowserWindow.mock.calls[0]?.[0]).toMatchObject({
+      hiddenInMissionControl: true,
+      show: false,
+      skipTaskbar: true,
+      webPreferences: expect.objectContaining({
+        contextIsolation: true,
+        partition: "persist:pier-document-origin-fetch",
+        sandbox: true,
+      }),
+    });
+    expect(result).toEqual({
+      body: payload,
+      ok: true,
+      status: 200,
+    });
+  });
+
+  it("reuses one window while a second caller is still loading origin", async () => {
+    let releaseLoad: (() => void) | undefined;
+    loadURL.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseLoad = resolve;
+        })
+    );
+    executeJavaScriptInIsolatedWorld.mockResolvedValue({
+      base64: Buffer.from("ok").toString("base64"),
+      ok: true,
+      status: 200,
+    });
+    const { fetchFromDocumentOrigin } = await import(
+      "@main/plugins/document-origin-fetch.ts"
+    );
+    const request = {
+      origin: "https://grok.com/",
+      url: "https://grok.com/rpc",
+    };
+    const first = fetchFromDocumentOrigin(request);
+    const second = fetchFromDocumentOrigin(request);
+    await vi.waitFor(() => {
+      expect(BrowserWindow).toHaveBeenCalledOnce();
+    });
+    releaseLoad?.();
+    await Promise.all([first, second]);
+    expect(BrowserWindow).toHaveBeenCalledOnce();
+    expect(executeJavaScriptInIsolatedWorld).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects origins outside the host allowlist", async () => {
+    const { fetchFromDocumentOrigin } = await import(
+      "@main/plugins/document-origin-fetch.ts"
+    );
+    await expect(
+      fetchFromDocumentOrigin({
+        origin: "https://chatgpt.com/",
+        url: "https://chatgpt.com/backend-api/x",
+      })
+    ).rejects.toThrow(/not allowed/);
+    expect(BrowserWindow).not.toHaveBeenCalled();
+  });
+
+  it("rejects a url that is not same-origin with origin", async () => {
+    const { fetchFromDocumentOrigin } = await import(
+      "@main/plugins/document-origin-fetch.ts"
+    );
+    await expect(
+      fetchFromDocumentOrigin({
+        origin: "https://grok.com/",
+        url: "https://cli-chat-proxy.grok.com/v1/billing",
+      })
+    ).rejects.toThrow(/same-origin/);
+    expect(BrowserWindow).not.toHaveBeenCalled();
+  });
+
+  it("rejects an already aborted signal before opening a window", async () => {
+    const { fetchFromDocumentOrigin } = await import(
+      "@main/plugins/document-origin-fetch.ts"
+    );
+    const controller = new AbortController();
+    controller.abort();
+    await expect(
+      fetchFromDocumentOrigin({
+        origin: "https://grok.com/",
+        signal: controller.signal,
+        url: "https://grok.com/rpc",
+      })
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(BrowserWindow).not.toHaveBeenCalled();
+  });
+
+  it("destroys the window when origin navigation fails", async () => {
+    loadURL.mockRejectedValueOnce(new Error("net::ERR_FAILED"));
+    const { fetchFromDocumentOrigin } = await import(
+      "@main/plugins/document-origin-fetch.ts"
+    );
+
+    await expect(
+      fetchFromDocumentOrigin({
+        origin: "https://grok.com/",
+        url: "https://grok.com/rpc",
+      })
+    ).rejects.toThrow("net::ERR_FAILED");
+    expect(destroy).toHaveBeenCalledOnce();
+  });
+
+  it("destroys the helper window when isolated-world fetch fails", async () => {
+    executeJavaScriptInIsolatedWorld.mockRejectedValueOnce(new Error("boom"));
+    const { fetchFromDocumentOrigin } = await import(
+      "@main/plugins/document-origin-fetch.ts"
+    );
+    await expect(
+      fetchFromDocumentOrigin({
+        origin: "https://grok.com/",
+        url: "https://grok.com/rpc",
+      })
+    ).rejects.toThrow("boom");
+    expect(destroy).toHaveBeenCalledOnce();
+  });
+
+  it("dispose destroys cached origin windows", async () => {
+    executeJavaScriptInIsolatedWorld.mockResolvedValue({
+      base64: Buffer.from("ok").toString("base64"),
+      ok: true,
+      status: 200,
+    });
+    const { disposeDocumentOriginWindows, fetchFromDocumentOrigin } =
+      await import("@main/plugins/document-origin-fetch.ts");
+
+    await fetchFromDocumentOrigin({
+      origin: "https://grok.com/",
+      url: "https://grok.com/rpc",
+    });
+    expect(destroy).not.toHaveBeenCalled();
+    disposeDocumentOriginWindows();
+    expect(destroy).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/unit/main/plugins/document-origin-fetch.test.ts
+++ b/tests/unit/main/plugins/document-origin-fetch.test.ts
@@ -98,16 +98,18 @@ describe("fetchFromDocumentOrigin", () => {
     expect(script).toContain("btoa");
     expect(script).toContain('credentials: "include"');
     expect(script).toContain("AbortSignal.timeout");
-    expect(BrowserWindow.mock.calls[0]?.[0]).toMatchObject({
-      hiddenInMissionControl: true,
-      show: false,
-      skipTaskbar: true,
-      webPreferences: expect.objectContaining({
-        contextIsolation: true,
-        partition: "persist:pier-document-origin-fetch",
-        sandbox: true,
-      }),
-    });
+    expect(BrowserWindow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hiddenInMissionControl: true,
+        show: false,
+        skipTaskbar: true,
+        webPreferences: expect.objectContaining({
+          contextIsolation: true,
+          partition: "persist:pier-document-origin-fetch",
+          sandbox: true,
+        }),
+      })
+    );
     expect(result).toEqual({
       body: payload,
       ok: true,
@@ -119,8 +121,8 @@ describe("fetchFromDocumentOrigin", () => {
     let releaseLoad: (() => void) | undefined;
     loadURL.mockImplementation(
       () =>
-        new Promise<void>((resolve) => {
-          releaseLoad = resolve;
+        new Promise<undefined>((resolve) => {
+          releaseLoad = () => resolve(undefined);
         })
     );
     executeJavaScriptInIsolatedWorld.mockResolvedValue({

--- a/tests/unit/main/plugins/external-main-runtime.test.ts
+++ b/tests/unit/main/plugins/external-main-runtime.test.ts
@@ -2,6 +2,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
+import { disposeDocumentOriginWindows } from "@main/plugins/document-origin-fetch.ts";
 import {
   createExternalMainPluginRuntime,
   type ExternalMainPluginContext,
@@ -9,6 +10,10 @@ import {
 import type { ManagedPluginRuntimeSource } from "@main/services/managed-plugins/install-runtime.ts";
 import type { PluginConfigurationApi } from "@pier/plugin-api/main";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@main/plugins/document-origin-fetch.ts", () => ({
+  disposeDocumentOriginWindows: vi.fn(),
+}));
 
 let dir = "";
 
@@ -181,6 +186,7 @@ describe("external main plugin runtime", () => {
     await runtime.flushAllBeforeQuit();
 
     expect(events).toEqual(["flush", "dispose"]);
+    expect(disposeDocumentOriginWindows).toHaveBeenCalled();
   });
 
   it("adds sourceRevision to the dynamic import URL", async () => {

--- a/tests/unit/main/plugins/managed-plugin-packaging-governance.test.ts
+++ b/tests/unit/main/plugins/managed-plugin-packaging-governance.test.ts
@@ -69,6 +69,27 @@ const committedOfficialIndex = JSON.parse(
   readFileSync(join(process.cwd(), "plugins/index.v1.json"), "utf8")
 ) as { signature?: { alg?: string } };
 
+function pluginSourceImportsElectron(source: string): boolean {
+  return (
+    /from\s+["']electron(?:\/[^"']*)?["']/.test(source) ||
+    /import\(\s*["']electron(?:\/[^"']*)?["']\s*\)/.test(source) ||
+    /require\(\s*["']electron(?:\/[^"']*)?["']\s*\)/.test(source)
+  );
+}
+
+function collectPluginSourceFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "node_modules" || entry.name === "dist") return [];
+      return collectPluginSourceFiles(path);
+    }
+    return entry.name.endsWith(".ts") || entry.name.endsWith(".tsx")
+      ? [path]
+      : [];
+  });
+}
+
 describe("managed plugin packaging governance", () => {
   it("builds every workspace plugin before starting the dev host", () => {
     expect(packageJson.scripts?.predev).toContain("pnpm plugins:pack");
@@ -181,5 +202,41 @@ describe("managed plugin packaging governance", () => {
     });
 
     expect(sizingPolicies).toEqual(APPROVED_BUNDLED_WIDGET_SIZE_POLICIES);
+  });
+
+  it("treats electron subpaths and require() as forbidden plugin imports", () => {
+    expect(pluginSourceImportsElectron('import { app } from "electron"')).toBe(
+      true
+    );
+    expect(
+      pluginSourceImportsElectron('import { app } from "electron/main"')
+    ).toBe(true);
+    expect(pluginSourceImportsElectron('const e = require("electron")')).toBe(
+      true
+    );
+    expect(pluginSourceImportsElectron('import fs from "node:fs"')).toBe(false);
+  });
+
+  it("does not import electron from official plugin sources", () => {
+    const pluginDirs = readdirSync(packagesRoot, {
+      withFileTypes: true,
+    }).filter(
+      (entry) =>
+        entry.isDirectory() &&
+        entry.name.startsWith("plugin-") &&
+        entry.name !== "plugin-api"
+    );
+    expect(pluginDirs.length).toBeGreaterThan(0);
+    for (const dir of pluginDirs) {
+      const root = join(packagesRoot, dir.name, "src");
+      if (!existsSync(root)) continue;
+      for (const file of collectPluginSourceFiles(root)) {
+        const source = readFileSync(file, "utf8");
+        expect(
+          pluginSourceImportsElectron(source),
+          relative(process.cwd(), file)
+        ).toBe(false);
+      }
+    }
   });
 });

--- a/tests/unit/renderer/accounts/grok-account-badges.test.tsx
+++ b/tests/unit/renderer/accounts/grok-account-badges.test.tsx
@@ -58,6 +58,34 @@ describe("Grok account badges", () => {
     expect(screen.getByText("Quota resets 2")).toBeInTheDocument();
   });
 
+  it("hides quota reset metadata when the count cannot be fetched", () => {
+    const legacyUnavailableUsage = {
+      attemptedAt: 1,
+      metrics: [],
+      resetCreditsResolved: false,
+      status: "ok" as const,
+      updatedAt: 1,
+    };
+    const { container } = render(
+      <AccountBadges
+        account={{
+          kind: "oidc",
+          usage: legacyUnavailableUsage,
+        }}
+        language="en"
+        t={t}
+      />
+    );
+
+    expect(screen.getByText("OIDC")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Quota resets temporarily unavailable")
+    ).not.toBeInTheDocument();
+    expect(
+      container.querySelector('[data-availability="unavailable"]')
+    ).toBeNull();
+  });
+
   it("does not override compact-mode metadata hiding", () => {
     render(
       <AccountBadges

--- a/tests/unit/renderer/accounts/grok-accounts-settings-page.test.tsx
+++ b/tests/unit/renderer/accounts/grok-accounts-settings-page.test.tsx
@@ -305,6 +305,46 @@ describe("Grok accounts settings page", () => {
     expect(screen.getByText("Quota resets 2")).toBeTruthy();
   });
 
+  it("hides quota reset metadata when the count is unavailable", async () => {
+    const now = Date.now();
+    const legacyUnavailableUsage = {
+      attemptedAt: now,
+      metrics: [],
+      resetCreditsResolved: false,
+      status: "ok" as const,
+      updatedAt: now,
+    };
+    const { context } = contextWithSnapshot({
+      accounts: [
+        {
+          email: "active@example.com",
+          error: null,
+          id: "acc-active",
+          kind: "oidc",
+          label: "active@example.com",
+          status: "active",
+          usage: legacyUnavailableUsage,
+        },
+      ],
+      activeAccountId: "acc-active",
+      login: null,
+      revision: 1,
+      schemaVersion: 1,
+    });
+
+    render(
+      <>
+        <AppContentDialogHost />
+        <AccountsSettingsPage context={context} />
+      </>
+    );
+
+    await screen.findByText("active@example.com");
+    expect(
+      screen.queryByText("Quota resets temporarily unavailable")
+    ).toBeNull();
+  });
+
   it("opens switch confirm dialog before selecting accounts", async () => {
     const { context, invokeCalls } = contextWithSnapshot(
       snapshotWithAccounts()

--- a/tests/unit/renderer/host-catalog/agent-mirror.test.ts
+++ b/tests/unit/renderer/host-catalog/agent-mirror.test.ts
@@ -23,6 +23,23 @@ const claudeProbe = agentLifecycleProbeSchema.parse({
   version: "1.2.3",
 });
 
+const missingCodexProbe = agentLifecycleProbeSchema.parse({
+  agentId: "codex",
+  canInstall: true,
+  canUninstall: false,
+  detected: false,
+  installedButBroken: false,
+  installs: [],
+  isConflict: false,
+  latestVersion: null,
+  support: "full",
+  uninstallMode: "none",
+  updateAvailable: false,
+  updateMode: "versioned",
+  updateOffered: false,
+  version: null,
+});
+
 describe("agent catalog views", () => {
   beforeEach(() => {
     useHostCatalogStore.getState().reset();
@@ -155,5 +172,32 @@ describe("agent catalog views", () => {
 
     expect(useAgentDetectStore.getState().detectedIds).toEqual([]);
     expect(useAgentLifecycleStore.getState().probesById.claude).toBeUndefined();
+  });
+
+  it("keeps canInstall probe for a missing catalog item", () => {
+    useHostCatalogStore.getState().applyDomain({
+      ...emptyDomainSnapshot("agent-cli"),
+      items: [
+        {
+          details: missingCodexProbe,
+          domain: "agent-cli",
+          id: "codex",
+          label: "Codex",
+          localVersion: null,
+          presence: "missing",
+          remoteVersion: null,
+          updateOffered: false,
+        },
+      ],
+      localProbedAt: 100,
+      revision: 4,
+    });
+
+    expect(useAgentDetectStore.getState().detectedIds).toEqual([]);
+    expect(useAgentLifecycleStore.getState().probesById.codex).toMatchObject({
+      agentId: "codex",
+      canInstall: true,
+      detected: false,
+    });
   });
 });

--- a/tests/unit/renderer/settings/agent-lifecycle-format.test.ts
+++ b/tests/unit/renderer/settings/agent-lifecycle-format.test.ts
@@ -5,6 +5,7 @@ import {
   isLifecycleSoftFailure,
   lifecycleBusyStatusText,
   resolveAgentStatusBadge,
+  shouldOfferAgentInstall,
 } from "../../../../src/renderer/pages/settings/components/agent-lifecycle-format.ts";
 
 const t = ((key: string, opts?: Record<string, unknown>) => {
@@ -72,6 +73,75 @@ describe("resolveAgentStatusBadge", () => {
       detected: false,
     });
     expect(badge?.label).toBe("settings.agents.status.missing");
+  });
+});
+
+describe("shouldOfferAgentInstall", () => {
+  it("offers install for a one-click agent before the lifecycle probe returns", () => {
+    expect(
+      shouldOfferAgentInstall({
+        hasDetected: true,
+        installedButBroken: false,
+        isBusy: false,
+        isDetected: false,
+        oneClickInstall: true,
+      })
+    ).toBe(true);
+  });
+
+  it("does not offer install for website-only agents before probe", () => {
+    expect(
+      shouldOfferAgentInstall({
+        hasDetected: true,
+        isBusy: false,
+        isDetected: false,
+        oneClickInstall: false,
+      })
+    ).toBe(false);
+  });
+
+  it("hides install until PATH detection has a snapshot", () => {
+    expect(
+      shouldOfferAgentInstall({
+        hasDetected: false,
+        isBusy: false,
+        isDetected: false,
+        oneClickInstall: true,
+      })
+    ).toBe(false);
+  });
+
+  it("hides install when the host says this agent cannot be installed", () => {
+    expect(
+      shouldOfferAgentInstall({
+        canInstall: false,
+        hasDetected: true,
+        isBusy: false,
+        isDetected: false,
+        oneClickInstall: true,
+      })
+    ).toBe(false);
+  });
+
+  it("hides install for detected or busy rows", () => {
+    expect(
+      shouldOfferAgentInstall({
+        canInstall: true,
+        hasDetected: true,
+        isBusy: false,
+        isDetected: true,
+        oneClickInstall: true,
+      })
+    ).toBe(false);
+    expect(
+      shouldOfferAgentInstall({
+        canInstall: true,
+        hasDetected: true,
+        isBusy: true,
+        isDetected: false,
+        oneClickInstall: true,
+      })
+    ).toBe(false);
   });
 });
 

--- a/tests/unit/renderer/settings/agents-section.test.tsx
+++ b/tests/unit/renderer/settings/agents-section.test.tsx
@@ -288,15 +288,63 @@ describe("AgentsSection", () => {
     expect(claudeRow.textContent).not.toContain("Update available");
   });
 
-  it("shows missing badge for agents not on PATH", async () => {
+  it("shows missing badge and Install together before a lifecycle probe", async () => {
     Object.defineProperty(window, "pier", {
       configurable: true,
       value: makePierMock([]),
     });
-    useAgentDetectStore.setState({ detectedIds: [] });
+    useAgentDetectStore.setState({ detectedIds: [], hasDetected: true });
     render(<AgentsSection />);
     const codexRow = await screen.findByTestId("agent-row-codex");
-    expect(codexRow.textContent).toContain("Not installed");
+    expect(within(codexRow).getByText("Not installed")).toBeInTheDocument();
+    expect(
+      within(codexRow).getByRole("button", { name: "Install" })
+    ).toBeInTheDocument();
+  });
+
+  it("does not offer Install for website-only missing agents", async () => {
+    Object.defineProperty(window, "pier", {
+      configurable: true,
+      value: makePierMock([]),
+    });
+    useAgentDetectStore.setState({ detectedIds: [], hasDetected: true });
+    render(<AgentsSection />);
+    const rovoRow = await screen.findByTestId("agent-row-rovo");
+    expect(within(rovoRow).getByText("Not installed")).toBeInTheDocument();
+    expect(
+      within(rovoRow).queryByRole("button", { name: "Install" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows Install for a missing full-support agent with canInstall probe", async () => {
+    Object.defineProperty(window, "pier", {
+      configurable: true,
+      value: makePierMock([], {
+        probe: async () => [
+          {
+            agentId: "codex",
+            canInstall: true,
+            canUninstall: false,
+            detected: false,
+            installedButBroken: false,
+            installs: [],
+            isConflict: false,
+            latestVersion: null,
+            support: "full",
+            uninstallMode: "none",
+            updateAvailable: false,
+            updateMode: "versioned",
+            updateOffered: false,
+            version: null,
+          },
+        ],
+      }),
+    });
+    render(<AgentsSection />);
+    const codexRow = await screen.findByTestId("agent-row-codex");
+    expect(
+      within(codexRow).getByRole("button", { name: "Install" })
+    ).toBeInTheDocument();
   });
 
   it("expanding agent-row-claude shows launchCmd", async () => {
@@ -383,6 +431,7 @@ describe("AgentsSection", () => {
     const codexRow = screen.getByTestId("agent-row-codex");
     const codex = within(codexRow);
     expect(codex.getByText("Not installed")).toBeInTheDocument();
+    expect(codex.getByRole("button", { name: "Install" })).toBeInTheDocument();
     expect(codex.queryByText("Default")).not.toBeInTheDocument();
     expect(
       codex.queryByRole("button", { name: "Details" })


### PR DESCRIPTION
## Summary

设置页恢复未安装智能体的一键安装（PATH 探测完成后即显示徽章 + 安装按钮），并在 Codex / Grok 账号行展示剩余额度重置次数。

- 未安装徽章与安装按钮同时出现；网站-only 智能体（rovo / openclaude / ante）不提供一键安装。
- Codex 从 `/wham/rate-limit-reset-credits` 读取剩余次数。
- Grok 的 `GetRemainingResets` 会被 Cloudflare 拦截 Node 请求：宿主提供 `documentOriginFetch`（hidden BrowserWindow、isolated world、仅 grok.com），插件解析 grpc-web。官方插件不得 import Electron。

## Test plan

- [x] `pnpm preflight:ci` 本地绿
- [ ] CI 绿后 squash 合入 main
- [ ] 设置页：未安装智能体同时显示徽章与安装按钮
- [ ] Codex / Grok 账号行：有正数剩余重置时显示次数