### PR TITLE
chore(plugins): patch bump codex 1.4.13、grok 1.1.14

### DIFF
--- a/packages/plugin-codex/package.json
+++ b/packages/plugin-codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pier/plugin-codex",
-  "version": "1.4.12",
+  "version": "1.4.13",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/plugin-codex/plugin.json
+++ b/packages/plugin-codex/plugin.json
@@ -455,5 +455,5 @@
     }
   ],
   "terminalStatusItems": [],
-  "version": "1.4.12"
+  "version": "1.4.13"
 }

--- a/packages/plugin-grok/package.json
+++ b/packages/plugin-grok/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pier/plugin-grok",
-  "version": "1.1.13",
+  "version": "1.1.14",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/plugin-grok/plugin.json
+++ b/packages/plugin-grok/plugin.json
@@ -568,5 +568,5 @@
     }
   ],
   "terminalStatusItems": [],
-  "version": "1.1.13"
+  "version": "1.1.14"
 }


### PR DESCRIPTION
## Summary

官方插件 patch bump，相对上次 tag 有账号重置次数源码变更：

- `pier.codex` 1.4.12 → **1.4.13**
- `pier.grok` 1.1.13 → **1.1.14**

claude / ssh 相对最新 tag 无插件源码 diff，跳过。合入 main 后由 Release Plugin 打 `plugin-codex-v1.4.13` / `plugin-grok-v1.1.14` prerelease。

## Test plan

- [ ] Quality Gate 绿
- [ ] 合入后确认 Release Plugin 产出 tgz + 更新 `plugins/index.v1.json`