### PR TITLE
chore(plugins): patch bump claude/codex/grok/ssh/agent-splits

### DIFF
--- a/packages/plugin-agent-splits/package.json
+++ b/packages/plugin-agent-splits/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pier/plugin-agent-splits",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/plugin-agent-splits/plugin.json
+++ b/packages/plugin-agent-splits/plugin.json
@@ -150,7 +150,7 @@
     }
   ],
   "terminalStatusItems": [],
-  "version": "1.5.1",
+  "version": "1.5.2",
   "configuration": {
     "properties": {
       "pier.agent-splits.adapter.enabled": {

--- a/packages/plugin-claude/package.json
+++ b/packages/plugin-claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pier/plugin-claude",
-  "version": "1.3.10",
+  "version": "1.3.11",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/plugin-claude/plugin.json
+++ b/packages/plugin-claude/plugin.json
@@ -480,5 +480,5 @@
     }
   ],
   "terminalStatusItems": [],
-  "version": "1.3.10"
+  "version": "1.3.11"
 }

--- a/packages/plugin-codex/package.json
+++ b/packages/plugin-codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pier/plugin-codex",
-  "version": "1.4.13",
+  "version": "1.4.14",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/plugin-codex/plugin.json
+++ b/packages/plugin-codex/plugin.json
@@ -411,5 +411,5 @@
     }
   ],
   "terminalStatusItems": [],
-  "version": "1.4.13"
+  "version": "1.4.14"
 }

--- a/packages/plugin-grok/package.json
+++ b/packages/plugin-grok/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pier/plugin-grok",
-  "version": "1.1.14",
+  "version": "1.1.15",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/plugin-grok/plugin.json
+++ b/packages/plugin-grok/plugin.json
@@ -524,5 +524,5 @@
     }
   ],
   "terminalStatusItems": [],
-  "version": "1.1.14"
+  "version": "1.1.15"
 }

--- a/packages/plugin-ssh/package.json
+++ b/packages/plugin-ssh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pier/plugin-ssh",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/plugin-ssh/plugin.json
+++ b/packages/plugin-ssh/plugin.json
@@ -251,5 +251,5 @@
     }
   ],
   "terminalStatusItems": [],
-  "version": "1.0.8"
+  "version": "1.0.9"
 }


### PR DESCRIPTION
Patch bump official plugins after the 20260826 merge train.

- pier.claude 1.3.10 → 1.3.11
- pier.codex 1.4.13 → 1.4.14
- pier.grok 1.1.14 → 1.1.15
- pier.ssh 1.0.8 → 1.0.9
- pier.agent-splits 1.5.1 → 1.5.2

Account plugins: remove workbenchWidgets, add projection RPC. ssh / agent-splits: manifest cleanup only.