### PR TITLE
chore(release): bump host to 0.1.36

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## [Unreleased]
 
+## [0.1.36] - 2026-09-02
+
 ### Added
 
 - **任务跟踪面板。** 官方插件把 GitHub、Linear、Jira 的事项放到项目面板和画布上。Linear / Jira 按工作流分列并可记住拖放顺序；GitHub 仍按指派归列。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pier",
-  "version": "0.1.35",
+  "version": "0.1.36",
   "description": "Pier — 本地 AI 开发工作台（dockview panel 布局 + 终端 + 代码变更预览 + 多 agent 状态可见性）",
   "type": "module",
   "main": "out/main/index.js",


### PR DESCRIPTION
Host 0.1.36: move Unreleased into a dated changelog entry and bump package.json.

Direct stable release (skip candidate). Do not tag until this lands on main. Tag `v0.1.36` after merge to trigger Release App.

Made with [Cursor](https://cursor.com)