### PR TITLE
chore(plugins): patch bump codex 1.4.15

### DIFF
--- a/packages/plugin-codex/package.json
+++ b/packages/plugin-codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pier/plugin-codex",
-  "version": "1.4.14",
+  "version": "1.4.15",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/plugin-codex/plugin.json
+++ b/packages/plugin-codex/plugin.json
@@ -411,5 +411,5 @@
     }
   ],
   "terminalStatusItems": [],
-  "version": "1.4.14"
+  "version": "1.4.15"
 }


### PR DESCRIPTION
## Summary

- Codex `package.json` / `plugin.json` → **1.4.15**
- 覆盖 20260904 合入的会员位与续期对账（相对 `plugin-codex-v1.4.14` 的源码变更）
- 合入后由 Release Plugin 打 `plugin-codex-v1.4.15` prerelease，不占 Latest

## Test plan

- [x] 本地 `pnpm plugin:codex:pack` 产出 `pier.codex-1.4.15.tgz`
- [ ] GitHub CI 一次绿
- [ ] Release Plugin 绿；tag 为 prerelease；`plugins/index.v1.json` 回写 main


Made with [Cursor](https://cursor.com)