### PR TITLE
fix(ci): restore macOS release signing

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -91,6 +91,29 @@ jobs:
       - name: Verify package.json version matches tag
         run: node ./scripts/verify-app-release-version.mjs "${{ steps.version.outputs.version }}"
 
+      # electron-builder 26.15.3 passes the p12 password to set-key-partition-list
+      # instead of its generated keychain password (rejected by macOS 26.6).
+      # Import once with separate passwords; the action also cleans up the keychain.
+      - name: Materialize Developer ID certificate
+        env:
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+        run: |
+          set -euo pipefail
+          umask 077
+          CERT_PATH="${RUNNER_TEMP}/pier-signing.p12"
+          case "$CSC_LINK" in
+            https://*) curl --fail --silent --show-error --location "$CSC_LINK" --output "$CERT_PATH" ;;
+            *) printf '%s' "$CSC_LINK" | base64 --decode > "$CERT_PATH" ;;
+          esac
+          test -s "$CERT_PATH"
+
+      - name: Import Developer ID certificate
+        uses: apple-actions/import-codesign-certs@5142e029c445c10ffc7149d172e540235a065466 # v7
+        with:
+          keychain: signing_temp
+          p12-filepath: ${{ runner.temp }}/pier-signing.p12
+          p12-password: ${{ secrets.CSC_KEY_PASSWORD }}
+
       # GhosttyKit is not in git; build:dist requires the xcframework (same as Quality Gate native).
       - id: ghostty-kit-cache
         uses: actions/cache@v4
@@ -127,8 +150,7 @@ jobs:
       - name: Build, sign, notarize, and publish
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CSC_LINK: ${{ secrets.CSC_LINK }}
-          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          CSC_KEYCHAIN: signing_temp.keychain
           CSC_NAME: ${{ secrets.CSC_NAME }}
           # APPLE_API_KEY path is set by the previous step via GITHUB_ENV when present.
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
@@ -137,8 +159,6 @@ jobs:
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           APPLE_KEYCHAIN_PROFILE: ${{ secrets.APPLE_KEYCHAIN_PROFILE }}
-          # build-dist.sh blocks CSC_LINK publish unless explicitly allowed.
-          PIER_DIST_ALLOW_CSC_LINK_PUBLISH: "1"
           CHANNEL: ${{ steps.version.outputs.channel }}
         run: |
           set -euo pipefail
@@ -192,6 +212,10 @@ jobs:
           # This candidate tag must itself be prerelease.
           node ./scripts/verify-github-latest-isolation.mjs \
             --candidate-tag "${{ steps.version.outputs.tag }}"
+
+      - name: Remove temporary signing credentials
+        if: always()
+        run: rm -f "${RUNNER_TEMP}/pier-signing.p12" "${RUNNER_TEMP}/AuthKey.p8"
 
   publish-blog:
     needs: release

--- a/docs/app-release.md
+++ b/docs/app-release.md
@@ -19,7 +19,7 @@
   - `Pier-<ver>-arm64.dmg` / `Pier-<ver>.dmg`
 - `publish-mac-release-artifacts.mjs` 会强制 `EP_GH_IGNORE_TIME=true`（覆盖 >2h 旧 release 的静默 skip），并在上传后再查 GitHub 远端资产；缺 arm64 dmg 等会硬失败
 - `electron-builder.yml`：`publish.releaseType: release`（正式默认；候选由 publish 脚本覆盖为 `prerelease`；禁止 draft，否则无 Latest）
-- 使用 `CSC_LINK` 时 workflow 设置 `PIER_DIST_ALLOW_CSC_LINK_PUBLISH=1`（`build-dist.sh` 默认禁 CSC_LINK publish）
+- CI 先用 `apple-actions/import-codesign-certs` 把 `CSC_LINK`（base64 p12 或 HTTPS 下载地址）导入临时钥匙串，构建只传 `CSC_KEYCHAIN`；任务结束清理钥匙串和临时凭据文件。不要向构建步骤再传 `CSC_LINK` / `CSC_KEY_PASSWORD`：electron-builder 26.15.3 会把 p12 密码误当作钥匙串密码，在 macOS 26.6 的 `set-key-partition-list` 阶段失败。
 - 发布后门禁：
   - 本地：`verify-mac-release-artifacts.mjs --dir dist-builder --version <ver>`
   - 上传后远端：publish wrapper 内嵌 dual-arch 校验
@@ -41,6 +41,8 @@
 | 或 `APPLE_ID` + `APPLE_APP_SPECIFIC_PASSWORD` + `APPLE_TEAM_ID` | 公证 |
 | 或 `APPLE_KEYCHAIN_PROFILE` + `APPLE_TEAM_ID` | 本机 keychain profile |
 | `GITHUB_TOKEN` | workflow 自带，用于 publish |
+
+若失败发生在发布资产上传前，且仅需修复 workflow，可将修复合入 `main` 后手动运行 **Release App**（workflow 分支选 `main`，`tag` 填原 tag）。构建仍 checkout 原 tag，不移动 tag，也不改变应用源码；已有发布内容不得通过这种方式改写。
 
 官网博客（CI 仓库 Secrets，不进 `electron-builder.env`）：
 

--- a/tests/unit/main/app-core/release-workflow.test.ts
+++ b/tests/unit/main/app-core/release-workflow.test.ts
@@ -1,6 +1,7 @@
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
 
 describe("app release workflow", () => {
   it("publishes mac app updates to GitHub Latest on stable version tags", async () => {
@@ -17,7 +18,6 @@ describe("app release workflow", () => {
     expect(source).toContain("contents: write");
     expect(source).toContain("latest-mac.yml");
     expect(source).toContain("verify-mac-release-artifacts.mjs");
-    expect(source).toContain("PIER_DIST_ALLOW_CSC_LINK_PUBLISH");
     expect(source).toContain("runs-on: macos-26");
     expect(source).toContain("/Applications/Xcode_26.6.app/Contents/Developer");
     expect(source).toContain("Xcode 26.6");
@@ -31,6 +31,44 @@ describe("app release workflow", () => {
     expect(source).toMatch(
       /outputs:\s*\n\s+tag:\s*\$\{\{\s*steps\.version\.outputs\.tag\s*\}\}/
     );
+  });
+
+  it("imports the signing certificate before building without forwarding its password to electron-builder", async () => {
+    const source = await readFile(
+      join(process.cwd(), ".github/workflows/release-app.yml"),
+      "utf8"
+    );
+    const workflow = parse(source) as {
+      jobs: {
+        release: {
+          steps: {
+            uses?: string;
+            env?: Record<string, string>;
+            with?: Record<string, string>;
+            run?: string;
+          }[];
+        };
+      };
+    };
+    const steps = workflow.jobs.release.steps;
+    const buildIndex = steps.findIndex((step) =>
+      step.run?.includes("pnpm build:dist")
+    );
+    const build = steps[buildIndex];
+    expect(build?.env?.CSC_LINK).toBeUndefined();
+    expect(build?.env?.CSC_KEY_PASSWORD).toBeUndefined();
+    expect(build?.env?.CSC_KEYCHAIN).toBe("signing_temp.keychain");
+    const certificateIndex = steps.findIndex((step) =>
+      step.uses?.startsWith("apple-actions/import-codesign-certs@")
+    );
+    expect(certificateIndex).toBeGreaterThanOrEqual(0);
+    expect(certificateIndex).toBeLessThan(buildIndex);
+    expect(steps[certificateIndex]?.with).toMatchObject({
+      keychain: "signing_temp",
+      "p12-password": expect.stringMatching(
+        /^\$\{\{\s*secrets\.CSC_KEY_PASSWORD\s*\}\}$/
+      ),
+    });
   });
 
   it("routes host rc tags through candidate channel off Latest", async () => {

--- a/tests/unit/main/live-modules/graph.test.ts
+++ b/tests/unit/main/live-modules/graph.test.ts
@@ -81,7 +81,8 @@ describe("createLiveModuleGraphTracker", () => {
     const dir = await mkdtemp(join(tmpdir(), "pier-graph-data-"));
     const canvas = join(dir, "notes.canvas.tsx");
     await writeFile(canvas, "export default function K() { return null; }\n");
-    const tracker = createLiveModuleGraphTracker();
+    const fake = createFakeDirWatch();
+    const tracker = createLiveModuleGraphTracker({ watch: fake.watch });
     const events: Array<{ moduleId: string; rootId: string }> = [];
     stops.push(
       tracker.watch((batch) => {
@@ -89,10 +90,11 @@ describe("createLiveModuleGraphTracker", () => {
       })
     );
     tracker.setModuleGraph("root", "notes.canvas.tsx", [canvas]);
-    await wait(LIVE_MODULE_WATCH_DEBOUNCE_MS + 150);
-    events.length = 0;
     await writeFile(join(dir, "board.json"), '{"cards":[]}\n');
-    await wait(LIVE_MODULE_WATCH_DEBOUNCE_MS + 200);
+    // Deliver only the data write: macOS can otherwise report the earlier
+    // canvas creation after the fixed settling delay under coverage load.
+    fake.emit("board.json");
+    await wait(LIVE_MODULE_WATCH_DEBOUNCE_MS + 50);
     expect(events).toEqual([]);
   });
 


### PR DESCRIPTION
Release App v0.1.40 failed on macOS 26.6 while authorizing the signing private key: electron-builder 26.15.3 passed the p12 password to `security set-key-partition-list` instead of the generated keychain password.

Import the certificate before the build using a pinned `apple-actions/import-codesign-certs` revision, then pass only `CSC_KEYCHAIN` to electron-builder. Keep signing and notarization enabled, remove temporary credential files on failure or success, and let the import action clean up its keychain. The workflow still checks out the requested release tag, allowing recovery of the unpublished v0.1.40 from the fixed main workflow without moving the tag or changing application code.

The Canvas data-write unit test now delivers an explicit JSON watch event, avoiding late macOS notifications for the initial canvas creation under coverage load. The adjacent real filesystem watcher test is retained.

Validation: static checks and application build passed; 13,482 unit tests and 623 component tests passed; all 51 indexed plugin assets verified; release workflow regression tests (5 passed); native macOS 26.6.2 reproduction confirms the p12 password fails keychain authorization and the separate keychain password succeeds. Workflow shell syntax, certificate decoding, file permissions and empty-certificate rejection checked. Full coverage verification passed with unchanged coverage floors and a 15-second local test timeout for git I/O (75.97% statements, 67.18% branches, 75.92% functions, 76.55% lines). Independent review found no blocking issues.
